### PR TITLE
Add GetObjectTagging to get-files role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+### Fixed
+- `get-files` step functions AMI roles for tags
 
 ## [0.3.5]
 ### Added

--- a/step-function/get-files/cloudformation.yml
+++ b/step-function/get-files/cloudformation.yml
@@ -41,6 +41,9 @@ Resources:
               - Effect: Allow
                 Action: s3:ListBucket
                 Resource: !Sub "arn:aws:s3:::${Bucket}"
+              - Effect: Allow
+                Action: s3:GetObjectTagging
+                Resource: !Sub "arn:aws:s3:::${Bucket}/*"
 
   Lambda:
     Type: AWS::Lambda::Function


### PR DESCRIPTION
Fixes GET_FILES step function error:

```
2020-08-07T12:04:24.717-08:00 | 


[ERROR] ClientError: An error occurred (AccessDenied) when calling the GetObjectTagging operation: Access Denied
Traceback (most recent call last):
  File "/var/task/main.py", line 40, in lambda_handler
    file_type = get_object_file_type(bucket, item['Key'])
  File "/var/task/main.py", line 23, in get_object_file_type
    response = S3_CLIENT.get_object_tagging(Bucket=bucket, Key=key)
  File "/var/runtime/botocore/client.py", line 316, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/var/runtime/botocore/client.py", line 635, in _make_api_call
    raise error_class(parsed_response, operation_name)
```

I *think* this is all we need