### PR TITLE
add expiration time based on product not browse.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.7]
+### Fixed 
+- `get-files` get expiration only from product
+
 ## [0.3.6]
 ### Fixed
 - `get-files` step functions AMI roles for tags

--- a/step-function/get-files/src/main.py
+++ b/step-function/get-files/src/main.py
@@ -34,6 +34,7 @@ def lambda_handler(event, context):
     files = []
     browse_images = []
     thumbnail_images = []
+    expiration = None
 
     for item in response['Contents']:
         download_url = get_download_url(bucket, item['Key'])
@@ -49,9 +50,10 @@ def lambda_handler(event, context):
                 'filename': basename(item['Key']),
             }
             files.append(file)
+            expiration = get_expiration_time(bucket, item['Key'])
 
     return {
-        'expiration_time': get_expiration_time(bucket, response['Contents'][0]['Key']),
+        'expiration_time': expiration,
         'files': files,
         'browse_images': browse_images,
         'thumbnail_images': thumbnail_images,


### PR DESCRIPTION
fixes bug 
```
[ERROR] KeyError: 'Expiration'
Traceback (most recent call last):
  File "/var/task/main.py", line 54, in lambda_handler
    'expiration_time': get_expiration_time(bucket, response['Contents'][0]['Key']),
  File "/var/task/main.py", line 17, in get_expiration_time
    expiration_string = s3_object['Expiration'].split('"')[1]
```