### PR TITLE
remove optional description field for jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Removed
+- Removed optional `description` field for jobs
 
 ## [0.3.9]
 ### Added

--- a/api/src/hyp3_api/openapi-spec.yml
+++ b/api/src/hyp3_api/openapi-spec.yml
@@ -141,8 +141,6 @@ components:
           $ref: "#/components/schemas/job_type"
         job_parameters:
           $ref: "#/components/schemas/job_parameters"
-        description:
-          $ref: "#/components/schemas/description"
         name:
           $ref: "#/components/schemas/name"
 
@@ -175,8 +173,6 @@ components:
           $ref: "#/components/schemas/datetime"
         status_code:
           $ref: "#/components/schemas/status_code"
-        description:
-          $ref: "#/components/schemas/description"
         name:
           $ref: "#/components/schemas/name"
         files:
@@ -306,12 +302,6 @@ components:
         - SUCCEEDED
         - FAILED
       example: SUCCEEDED
-
-    description:
-      description: User provided text to describe the job
-      type: string
-      minLength: 1
-      example: a description of the job
 
     name:
       description: User provided text to name the job

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -46,7 +46,6 @@ def get_table_properties_from_template():
 
 
 def make_job(granule='S1B_IW_SLC__1SDV_20200604T082207_20200604T082234_021881_029874_5E38',
-             description='someDescription',
              name='someName',
              job_type='RTC_GAMMA'):
     job = {
@@ -55,8 +54,6 @@ def make_job(granule='S1B_IW_SLC__1SDV_20200604T082207_20200604T082234_021881_02
             'granule': granule
         }
     }
-    if description is not None:
-        job['description'] = description
     if name is not None:
         job['name'] = name
 

--- a/api/tests/test_submit_job.py
+++ b/api/tests/test_submit_job.py
@@ -63,27 +63,6 @@ def test_submit_without_jobs(client):
     assert response.status_code == status.HTTP_400_BAD_REQUEST
 
 
-def test_submit_job_without_description(client, table):
-    login(client)
-    batch = [
-        make_job(description=None)
-    ]
-    setup_requests_mock(batch)
-
-    response = submit_batch(client, batch)
-    assert response.status_code == status.HTTP_200_OK
-
-
-def test_submit_job_with_empty_description(client):
-    login(client)
-    batch = [
-        make_job(description='')
-    ]
-    setup_requests_mock(batch)
-    response = submit_batch(client, batch)
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
-
-
 def test_submit_job_without_name(client, table):
     login(client)
     batch = [


### PR DESCRIPTION
I've removed the `description` field from all existing jobs in the hyp3-test database.  We'll need to do the same when we release to production; `GET /jobs` requests that include a description won't pass connexion's schema validation.