### PR TITLE
upgrade to v2 http api gateway

### DIFF
--- a/api/cloudformation.yml
+++ b/api/cloudformation.yml
@@ -24,92 +24,48 @@ Parameters:
 Outputs:
 
   Url:
-    Value: !Sub "https://${DomainName}/ui"
+    Value: !Sub "https://${CustomDomainName}/ui"
 
 Resources:
 
-  RestApi:
-    Type: AWS::ApiGateway::RestApi
+  Api:
+    Type: AWS::ApiGatewayV2::Api
     Properties:
       Name: !Ref AWS::StackName
-      EndpointConfiguration:
-        Types:
-          - REGIONAL
+      ProtocolType: HTTP
+      Target: !GetAtt Lambda.Arn
+      CredentialsArn: !GetAtt ApiRole.Arn
 
-  Resource:
-    Type: AWS::ApiGateway::Resource
+  ApiOverrides:
+    Type: AWS::ApiGatewayV2::ApiGatewayManagedOverrides
     Properties:
-      RestApiId: !Ref RestApi
-      ParentId: !GetAtt RestApi.RootResourceId
-      PathPart: "{proxy+}"
-
-  RootMethod:
-    Type: AWS::ApiGateway::Method
-    Properties:
-      RestApiId: !Ref RestApi
-      ResourceId: !GetAtt RestApi.RootResourceId
-      HttpMethod: ANY
-      AuthorizationType: NONE
+      ApiId: !Ref Api
       Integration:
-        Type: AWS_PROXY
-        Uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${Lambda.Arn}/invocations"
-        IntegrationHttpMethod: POST
-        Credentials: !GetAtt ApiRole.Arn
-        PassthroughBehavior: NEVER
-
-  ResourceMethod:
-    Type: AWS::ApiGateway::Method
-    Properties:
-      RestApiId: !Ref RestApi
-      ResourceId: !Ref Resource
-      HttpMethod: ANY
-      AuthorizationType: NONE
-      Integration:
-        Type: AWS_PROXY
-        Uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${Lambda.Arn}/invocations"
-        IntegrationHttpMethod: POST
-        Credentials: !GetAtt ApiRole.Arn
-        PassthroughBehavior: NEVER
+        PayloadFormatVersion: "1.0"
+      Stage:
+        AccessLogSettings:
+          DestinationArn: !GetAtt ApiLogGroup.Arn
+          Format: $context.identity.sourceIp - - [$context.requestTime] "$context.httpMethod $context.path $context.protocol" $context.status $context.responseLength $context.requestId
 
   ApiLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       RetentionInDays: 180
 
-  Deployment:
-    Type: AWS::ApiGateway::Deployment
-    DependsOn:
-      - RootMethod
-      - ResourceMethod
-    Properties:
-      RestApiId: !Ref RestApi
-
-  Stage:
-    Type: AWS::ApiGateway::Stage
-    Properties:
-      StageName: api
-      RestApiId: !Ref RestApi
-      DeploymentId: !Ref Deployment
-      AccessLogSetting:
-        DestinationArn: !GetAtt ApiLogGroup.Arn
-        Format: $context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime] "$context.httpMethod $context.path $context.protocol" $context.status $context.responseLength $context.requestId
-
   CustomDomainName:
-    Type: AWS::ApiGateway::DomainName
+    Type: AWS::ApiGatewayV2::DomainName
     Properties:
       DomainName: !Ref DomainName
-      EndpointConfiguration:
-        Types:
-          - REGIONAL
-      RegionalCertificateArn: !Ref CertificateArn
-      SecurityPolicy: TLS_1_2
+      DomainNameConfigurations:
+        - CertificateArn: !Ref CertificateArn
+          EndpointType: REGIONAL
 
-  BasePathMapping:
-    Type: AWS::ApiGateway::BasePathMapping
+  ApiMapping:
+    Type: AWS::ApiGatewayV2::ApiMapping
     Properties:
+      ApiId: !Ref Api
       DomainName: !Ref CustomDomainName
-      RestApiId: !Ref RestApi
-      Stage: !Ref Stage
+      Stage: $default
 
   ApiRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
https://aws.amazon.com/blogs/compute/announcing-http-apis-for-amazon-api-gateway/
https://aws.amazon.com/blogs/compute/building-better-apis-http-apis-now-generally-available/
https://blog.thundra.io/api-gateway-gets-a-second-version

v2 HTTP solves many of our pain points with v1 REST.  Features we're not using are stripped away for lower latency and fewer cloudformation resources.  It also autodeploys to the `$default` stage with each stack update, which solves my biggest headache with v1.

I don't *think* our `cloudformation-deployment-role` needs any permission updates; looks like v1 and v2 both fall under `apigateway:*` actions.

The `serverless-wsgi` package we're using to translate between Api Gateway and WSGI only speaks [Payload Format Version](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html) 1.0, not 2.0, hence the override in the new `ApiGatewayManagedOverrides` resource.

v2 comes with simple CORs configuration as well.  We could consider moving CORs from python to cloudformation; it would be less code and we should only need it in a "real world" deployment.  I haven't pulled the trigger on that here, though.