### PR TITLE
remove resource-level override made obsolete by cfn-lint 0.36.0

### DIFF
--- a/step-function/cloudformation.yml
+++ b/step-function/cloudformation.yml
@@ -24,11 +24,6 @@ Resources:
 
   StepFunction:
     Type: AWS::StepFunctions::StateMachine
-    Metadata:
-      cfn-lint:
-        config:
-          ignore_checks:
-            - E3002
     Properties:
       RoleArn: !GetAtt StepFunctionRole.Arn
       DefinitionS3Location: step-function.json


### PR DESCRIPTION
https://github.com/aws-cloudformation/cfn-python-lint/releases/tag/v0.36.0