### PR TITLE
enable request metrics for content bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [unreleased]
-###
+### Added
 - A new `include_scattering_area` paramter has been added for `RTC_GAMMA` jobs, which includes a GeoTIFF of scattering area in the product package. This supports creation of composites of RTC images using Local Resolution Weighting per Small (2012) https://doi.org/10.1109/IGARSS.2012.6350465.
+- Cloudwatch request metrics are now enabled for the S3 content bucket
 
 ## [0.8.5]
 ### Changed

--- a/apps/main-cf.yml
+++ b/apps/main-cf.yml
@@ -126,7 +126,7 @@ Resources:
         DestinationBucketName: !Ref LogBucket
         LogFilePrefix: s3-access-logs/content-bucket/
       MetricsConfigurations:
-        Id: EntireBucket
+        - Id: EntireBucket
       PublicAccessBlockConfiguration:
         BlockPublicAcls: True
         IgnorePublicAcls: True

--- a/apps/main-cf.yml
+++ b/apps/main-cf.yml
@@ -125,6 +125,8 @@ Resources:
       LoggingConfiguration:
         DestinationBucketName: !Ref LogBucket
         LogFilePrefix: s3-access-logs/content-bucket/
+      MetricsConfigurations:
+        Id: EntireBucket
       PublicAccessBlockConfiguration:
         BlockPublicAcls: True
         IgnorePublicAcls: True


### PR DESCRIPTION
In particular, this will let us review bytes downloaded from our individual public buckets.

https://docs.aws.amazon.com/AmazonS3/latest/dev/cloudwatch-monitoring.html