### PR TITLE
avoid job table query for project names when submitting new jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [0.8.12]
+### Changed
+- Improved response latency when submitting new jobs via `POST /jobs`
+
 ## [0.8.11]
 ### Added
 - `GET /jobs` responses now include `s3.bucket` and `s3.key` entries for each file to facilitate interacting with
   products using s3-aware tools.
-  
+
 ### Fixed
 - AUTORIFT jobs now correctly accept Sentinel-2 granules using Earth Search IDs of 23 characters.
 

--- a/apps/api/src/hyp3_api/handlers.py
+++ b/apps/api/src/hyp3_api/handlers.py
@@ -56,10 +56,10 @@ def redirect_to_ui():
 def post_jobs(body, user):
     print(body)
 
-    quota = get_user(user)['quota']
-    if quota['remaining'] - len(body['jobs']) < 0:
-        max_jobs = quota['max_jobs_per_month']
-        message = f'Your monthly quota is {max_jobs} jobs. You have {quota["remaining"]} jobs remaining.'
+    monthly_quota = get_max_jobs_per_month(user)
+    remaining_jobs = get_remaining_jobs_for_user(user, monthly_quota)
+    if remaining_jobs - len(body['jobs']) < 0:
+        message = f'Your monthly quota is {monthly_quota} jobs. You have {remaining_jobs} jobs remaining.'
         return problem(400, 'Bad Request', message)
 
     try:


### PR DESCRIPTION
The `handlers.get_user()` function queries *all* job records for a user to find all past project names.  `handlers.post_jobs()` only needs to know the quota information, not the project name list.  This PR updates `post_jobs()` to compute the quota numbers directly, without relying on `get_user()`.