### PR TITLE
up max jobs per POST /jobs request to 1000

### DIFF
--- a/apps/api/src/hyp3_api/api-spec/openapi-spec.yml
+++ b/apps/api/src/hyp3_api/api-spec/openapi-spec.yml
@@ -154,7 +154,7 @@ components:
       description: Contains a list of new job objects.
       type: array
       minItems: 1
-      maxItems: 200
+      maxItems: 1000
       items:
         $ref: "#/components/schemas/new_job"
 


### PR DESCRIPTION
I think this is the most expedient way to move forward in the short term.  We should work with the Vertex team on a better long term strategy.