### PR TITLE
Revert "remove unneeded fetch-depth: 0 from deploy workflow"

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
           token: ${{ secrets.TOOLS_BOT_PAK }}
 
       - if: endsWith(github.ref, '/develop')

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,6 +28,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           token: ${{ secrets.TOOLS_BOT_PAK }}
 
       - if: endsWith(github.ref, '/develop')


### PR DESCRIPTION
This reverts commit fd3c534fa39e180e59437d9268a38f7f81779803.

fetch-depth: 0 is needed for production deployments to figure out the version tag for the new release.