### PR TITLE
set cpu ulimit for aws batch job definitions

### DIFF
--- a/apps/workflow-cf.yml.j2
+++ b/apps/workflow-cf.yml.j2
@@ -42,6 +42,10 @@ Resources:
         Image: !Sub "{{ job_spec['image'] }}:${ImageTag}"
         Vcpus: 4
         Memory: 30000
+        Ulimits:
+          - Name: cpu
+            SoftLimit: 3
+            HardLimit: 3
         JobRoleArn: !Ref TaskRoleArn
         Command:
           {% for command in job_spec['command'] %}


### PR DESCRIPTION
limiting to 3 cpus isn't a fantastic solution, but I at least want to see if it works as expected