### PR TITLE
revert aws batch compute environment changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [0.8.15]
-### Added
-- Added r5d.2xlarge as an available instance size when launching EC2 instances
-
 ## [0.8.14]
 ### Added
 - Jobs now include a `logs` key containing a list of log file download urls

--- a/apps/compute-cf.yml
+++ b/apps/compute-cf.yml
@@ -55,12 +55,11 @@ Resources:
       Type: MANAGED
       ComputeResources:
         Type: SPOT
-        AllocationStrategy: BEST_FIT_PROGRESSIVE
+        AllocationStrategy: SPOT_CAPACITY_OPTIMIZED
         MinvCpus: 0
         MaxvCpus: 1600
         InstanceTypes:
           - r5d.xlarge
-          - r5d.2xlarge
         ImageId: !Ref AmiId
         Subnets: !Ref SubnetIds
         InstanceRole: !Ref InstanceProfile


### PR DESCRIPTION
Resource contention dramatically reduces performance when running multiple RTC_GAMMA jobs on a single `r5d.2xlarge` instance.

RTC for `S1B_IW_SLC__1SDV_20210217T033834_20210217T033907_025641_030E5F_E5F9` consistently takes 27-29 minutes on an `r5d.xlarge`, but takes 34-90+ minutes when running alongside another job on an `r5d.2xlarge`.