### PR TITLE
Allow get object tagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.8.15]
 ### Changed
-- S3 content bucket now allows public `s3:ListBucket`
+- S3 content bucket now allows public `s3:ListBucket` and `s3:GetObjectTagging`
 
 ## [0.8.14]
 ### Added

--- a/apps/main-cf.yml
+++ b/apps/main-cf.yml
@@ -157,7 +157,9 @@ Resources:
         Statement:
           - Effect: Allow
             Principal: "*"
-            Action: s3:GetObject
+            Action:
+              - s3:GetObject
+              - s3:GetObjectTagging
             Resource: !Sub "${ContentBucket.Arn}/*"
           - Effect: Allow
             Principal: "*"


### PR DESCRIPTION
Using the AWS CLI, users cannot copy out of our current buckets because it tries to also copy the tags. 

This was reported by a user at JPL and I confirmed it using our HyP3v1 account:
```
$ aws s3 cp s3://hyp3-test-contentbucket-1517400zl5hi8/cd472e70-d030-43ed-838c-7c760b358184/S1A_IW_20150621T120220_SVP_RTC30_G_gpuned_6B20.zip s3://hyp3-product-joe/
copy failed: s3://hyp3-test-contentbucket-1517400zl5hi8/cd472e70-d030-43ed-838c-7c760b358184/S1A_IW_20150621T120220_SVP_RTC30_G_gpuned_6B20.zip to s3://hyp3-product-joe/S1A_IW_20150621T120220_SVP_RTC30_G_gpuned_6B20.zip An error occurred (AccessDenied) when calling the GetObjectTagging operation: Access Denied
```

I could not find a convenient CLI switch to turn this off, so I think we should allow it. 