### PR TITLE
increase INSAR_GAMMA timeout to 3 hours

### DIFF
--- a/job_types.yml
+++ b/job_types.yml
@@ -110,7 +110,7 @@ InsarGamma:
     - Ref::granules
   validators:
     - check_dem_coverage
-  timeout: 5400
+  timeout: 10800
 
 Autorift:
   image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-autorift


### PR DESCRIPTION
Golden test with 10x2 looks has timed out repeatedly the last three times I've run it.

Golden insar timeout is still 2 hours, planning to leave that as-is unless I see jobs running longer than that.
https://github.com/ASFHyP3/hyp3-testing/blob/develop/tests/test_tifs.py#L70