### PR TITLE
fix bug in test_check_dem_coverage

### DIFF
--- a/tests/api/test_validation.py
+++ b/tests/api/test_validation.py
@@ -112,9 +112,9 @@ def test_check_dem_coverage():
     assert 'neither' in str(e)
 
     with raises(validation.GranuleValidationError) as e:
-        validation.check_dem_coverage(job, [both, neither])
+        validation.check_dem_coverage(job, [copernicus_only, neither])
     assert 'neither' in str(e)
-    assert 'both' not in str(e)
+    assert 'copernicus_only' not in str(e)
 
     job = {'job_parameters': {'dem_name': 'legacy'}}
     validation.check_dem_coverage(job, [])
@@ -129,8 +129,8 @@ def test_check_dem_coverage():
     assert 'neither' in str(e)
 
     with raises(validation.GranuleValidationError) as e:
-        validation.check_dem_coverage(job, [both, neither])
-    assert 'neither' in str(e)
+        validation.check_dem_coverage(job, [both, copernicus_only])
+    assert 'copernicus_only' in str(e)
     assert 'both' not in str(e)
 
 

--- a/tests/api/test_validation.py
+++ b/tests/api/test_validation.py
@@ -98,57 +98,40 @@ def test_format_points():
 
 
 def test_check_dem_coverage():
+    both = {'name': 'both', 'polygon': rectangle(45, 41, -104, -111)}
+    copernicus_only = {'name': 'copernicus_only', 'polygon': rectangle(-62, -90, 180, -180)}
+    neither = {'name': 'neither', 'polygon': rectangle(-20, -30, 70, 100)}
+
     job = {'job_parameters': {'dem_name': 'copernicus'}}
-    good = {
-        'name': 'good',
-        'polygon': rectangle(45, 41, -104, -111),
-    }
-
-    bad = {
-        'name': 'bad',
-        'polygon': rectangle(-20, -30, 70, 100),
-    }
-
     validation.check_dem_coverage(job, [])
-
-    validation.check_dem_coverage(job, [good])
-
-    with raises(validation.GranuleValidationError) as e:
-        validation.check_dem_coverage(job, [bad])
-    assert 'bad' in str(e)
+    validation.check_dem_coverage(job, [both])
+    validation.check_dem_coverage(job, [copernicus_only])
 
     with raises(validation.GranuleValidationError) as e:
-        validation.check_dem_coverage(job, [good, bad])
-    assert 'bad' in str(e)
-    assert 'good' not in str(e)
+        validation.check_dem_coverage(job, [neither])
+    assert 'neither' in str(e)
 
+    with raises(validation.GranuleValidationError) as e:
+        validation.check_dem_coverage(job, [both, neither])
+    assert 'neither' in str(e)
+    assert 'both' not in str(e)
 
-def test_check_dem_coverage_legacy():
     job = {'job_parameters': {'dem_name': 'legacy'}}
-    good = {
-        'name': 'good',
-        'polygon': rectangle(45, 41, -104, -111),
-    }
-
-    bad = {
-        'name': 'bad',
-        'polygon': rectangle(-62, -90, 180, -180),
-    }
-
     validation.check_dem_coverage(job, [])
-
-    validation.check_dem_coverage(job, [good])
-
-    with raises(validation.GranuleValidationError) as e:
-        validation.check_dem_coverage(job, [bad])
-    assert 'bad' in str(e)
+    validation.check_dem_coverage(job, [both])
 
     with raises(validation.GranuleValidationError) as e:
-        validation.check_dem_coverage(job, [good, bad])
-    assert 'bad' in str(e)
-    assert 'good' not in str(e)
+        validation.check_dem_coverage(job, [copernicus_only])
+    assert 'copernicus_only' in str(e)
 
-    assert 'bad' in str(e)
+    with raises(validation.GranuleValidationError) as e:
+        validation.check_dem_coverage(job, [neither])
+    assert 'neither' in str(e)
+
+    with raises(validation.GranuleValidationError) as e:
+        validation.check_dem_coverage(job, [both, neither])
+    assert 'neither' in str(e)
+    assert 'both' not in str(e)
 
 
 def test_check_granules_exist():


### PR DESCRIPTION
The issue was `test_check_dem_coverage` was testing using a polygon covered by *both* copernicus and legacy, so we didn't catch that the function was using the incorrect, tighter coverage map.