### PR TITLE
Pin version number for 1.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [1.1.1]
+## [1.1.1]
+### Changed
+- Granules for INSAR_GAMMA jobs are now validated against Copernicus GLO-30 Public DEM coverage
+
 ### Fixed
 - resolved `handlers.get_names_for_user` error when `dynamo.query_jobs` requires paging.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-## [Unreleased]
-
-### Changed
-- Granules for INSAR_GAMMA jobs are now validated against Copernicus GLO-30 Public DEM coverage
-
 # [1.1.1]
 ### Fixed
 - resolved `handlers.get_names_for_user` error when `dynamo.query_jobs` requires paging.

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -78,7 +78,7 @@ def check_granules_exist(granules, granule_metadata):
 
 
 def check_dem_coverage(job, granule_metadata):
-    legacy = job['job_type'] == 'RTC_GAMMA' and job['job_parameters'].get('dem_name') != 'copernicus'
+    legacy = job['job_parameters'].get('dem_name', 'legacy') == 'legacy'
     bad_granules = [g['name'] for g in granule_metadata if not has_sufficient_coverage(g['polygon'], legacy=legacy)]
     if bad_granules:
         raise GranuleValidationError(f'Some requested scenes do not have DEM coverage: {", ".join(bad_granules)}')

--- a/tests/api/test_validation.py
+++ b/tests/api/test_validation.py
@@ -102,7 +102,7 @@ def test_check_dem_coverage():
     copernicus_only = {'name': 'copernicus_only', 'polygon': rectangle(-62, -90, 180, -180)}
     neither = {'name': 'neither', 'polygon': rectangle(-20, -30, 70, 100)}
 
-    job = {'job_type': 'RTC_GAMMA', 'job_parameters': {'dem_name': 'copernicus'}}
+    job = {'job_parameters': {'dem_name': 'copernicus'}}
     validation.check_dem_coverage(job, [])
     validation.check_dem_coverage(job, [both])
     validation.check_dem_coverage(job, [copernicus_only])
@@ -116,7 +116,8 @@ def test_check_dem_coverage():
     assert 'neither' in str(e)
     assert 'copernicus_only' not in str(e)
 
-    job = {'job_type': 'RTC_GAMMA', 'job_parameters': {'dem_name': 'legacy'}}
+    job = {'job_parameters': {'dem_name': 'legacy'}}
+    validation.check_dem_coverage(job, [])
     validation.check_dem_coverage(job, [both])
 
     with raises(validation.GranuleValidationError):
@@ -125,7 +126,11 @@ def test_check_dem_coverage():
     with raises(validation.GranuleValidationError):
         validation.check_dem_coverage(job, [neither])
 
-    job = {'job_type': 'RTC_GAMMA', 'job_parameters': {}}
+    with raises(validation.GranuleValidationError):
+        validation.check_dem_coverage(job, [both, copernicus_only])
+
+    job = {'job_parameters': {}}
+    validation.check_dem_coverage(job, [])
     validation.check_dem_coverage(job, [both])
 
     with raises(validation.GranuleValidationError):
@@ -134,12 +139,8 @@ def test_check_dem_coverage():
     with raises(validation.GranuleValidationError):
         validation.check_dem_coverage(job, [neither])
 
-    job = {'job_type': 'INSAR_GAMMA', 'job_parameters': {}}
-    validation.check_dem_coverage(job, [both])
-    validation.check_dem_coverage(job, [copernicus_only])
-
     with raises(validation.GranuleValidationError):
-        validation.check_dem_coverage(job, [neither])
+        validation.check_dem_coverage(job, [both, copernicus_only])
 
 
 def test_check_granules_exist():
@@ -214,7 +215,7 @@ def test_validate_jobs():
         {
             'job_type': 'INSAR_GAMMA',
             'job_parameters': {
-                'granules': [granule_with_dem_coverage, granule_without_legacy_dem_coverage],
+                'granules': [granule_with_dem_coverage],
             }
         },
         {
@@ -239,7 +240,7 @@ def test_validate_jobs():
 
     jobs = [
         {
-            'job_type': 'RTC_GAMMA',
+            'job_type': 'INSAR_GAMMA',
             'job_parameters': {
                 'granules': [granule_without_legacy_dem_coverage],
             }


### PR DESCRIPTION
The hotfix for `handlers.get_names_for_user` is already in production, but the 1.1.1 header was h1 instead of h2 so the github release was never created.  This will publish 1.1.1 and including both the hotfix and the the Copernicus DEM change for InSAR.