### PR TITLE
support landsat 8 'ORI-only' scenes for autorift jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.1.3]
 - INSAR GAMMA jobs now expose `apply_water_mask` parameter that allows users to apply a water mask to the DEM used in processing.
+- AUTORIFT jobs now accept Landsat 8 scenes with a sensor mode of ORI-only (`LO08`)
 
 ## [1.1.2]
 ### Added

--- a/apps/api/src/hyp3_api/api-spec/job_parameters.yml.j2
+++ b/apps/api/src/hyp3_api/api-spec/job_parameters.yml.j2
@@ -86,7 +86,7 @@ components:
     granule_lc08:
       description: The name of the Landsat 8 Collection 2 granule to process
       type: string
-      pattern: "^LC08_"
+      pattern: "^L[CO]08_"
       minLength: 40
       maxLength: 40
       example: LC08_L1GT_118112_20210107_20210107_02_RT

--- a/tests/api/test_submit_job.py
+++ b/tests/api/test_submit_job.py
@@ -231,6 +231,7 @@ def test_submit_good_autorift_granule_names(client, tables):
         'S2A_1UCR_20210124_0_L1C',
         'S2B_22WEB_20200612_0_L1C',
         'LC08_L1TP_009011_20200820_20200905_02_T1',
+        'LO08_L1GT_043001_20201106_20201110_02_T2',
     ]
     for granule in good_granule_names:
         batch = [
@@ -261,6 +262,8 @@ def test_submit_bad_autorift_granule_names(client):
         'S1A_IW_GRDM_1SDH_20190624T101121_20190624T101221_027820_0323FF_79E4',
         'S1A_IW_GRDH_1SDV_20200604T190627_20200604T190652_032871_03CEB7_56F3',
         'S1A_IW_GRDH_1SSH_20171122T184459_20171122T184524_019381_020DD8_B825',
+        # bad L8 sensor mode
+        'LT08_L1GT_041001_20200125_20200925_02_T2',
     ]
     for granule in bad_granule_names:
         batch = [


### PR DESCRIPTION
I expect we'll need this change to go to production before the water masking option will be ready, but I'll defer how to handle that until after the landsat change is merged/validated in test.