### PR TITLE
Revert water mask option to RTC jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [1.1.3]
-- INSAR GAMMA jobs now expose `apply_water_mask` parameter that allows users to apply a water mask to the DEM used in processing.
 - AUTORIFT jobs now accept Landsat 8 scenes with a sensor mode of ORI-only (`LO08`)
 
 ## [1.1.2]

--- a/apps/api/src/hyp3_api/api-spec/job_parameters.yml.j2
+++ b/apps/api/src/hyp3_api/api-spec/job_parameters.yml.j2
@@ -143,12 +143,6 @@ components:
       default: false
       type: boolean
 
-    apply_water_mask:
-      # TODO: revisit description
-      description: Apply a water mask to the DEM used in processing
-      default: false
-      type: boolean
-
     include_rgb:
       description: Include a false-color RGB decomposition in the product package for dual-pol granules (ignored for single-pol granules)
       default: false

--- a/job_types.yml
+++ b/job_types.yml
@@ -93,9 +93,6 @@ InsarGamma:
     include_inc_map:
       default: false
       api_schema_location: "#/components/schemas/include_inc_map"
-    apply_water_mask:
-      default: false
-      api_schema_location: "#/components/schemas/apply_water_mask"
     looks:
       default:  20x4
       api_schema_location: "#/components/schemas/looks"
@@ -120,8 +117,6 @@ InsarGamma:
     - Ref::include_inc_map
     - --looks
     - Ref::looks
-    - --apply-water-mask
-    - Ref::apply_water_mask
     - Ref::granules
   validators:
     - check_dem_coverage

--- a/tests/api/test_submit_job.py
+++ b/tests/api/test_submit_job.py
@@ -39,7 +39,6 @@ def test_submit_insar_gamma(client, tables):
             'include_inc_map': True,
             'include_look_vectors': True,
             'include_los_displacement': True,
-            'apply_water_mask': True,
         },
     )
     response = submit_batch(client, batch=[job])


### PR DESCRIPTION
Water masking still needs some work, so this unblocks autoRIFT validation (#409  and #411 ) and potentially #412 from being shipped. We can revert-revert this once those ship and water mapping is ready for another round of testing.