### PR TITLE
use http.HTTPStatus instead of flask_api.status in API testing

### DIFF
--- a/apps/api/requirements-api.txt
+++ b/apps/api/requirements-api.txt
@@ -1,7 +1,6 @@
 connexion[swagger-ui]
 cryptography
 flask
-flask_api
 Flask-Cors
 prance
 PyJWT
@@ -9,3 +8,4 @@ requests
 serverless_wsgi
 shapely
 strict-rfc3339
+Werkzeug>=1.0.1,<2.*

--- a/tests/api/test_get_job_by_id.py
+++ b/tests/api/test_get_job_by_id.py
@@ -1,5 +1,6 @@
+from http import HTTPStatus
+
 from api.conftest import JOBS_URI, login, make_db_record
-from flask_api import status
 
 
 def test_get_job_by_id(client, tables):
@@ -10,14 +11,14 @@ def test_get_job_by_id(client, tables):
 
     login(client)
     response = client.get(f'{JOBS_URI}/{job_id}')
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
     assert response.json == record
 
     job_id = '0ddaeb98-7636-494d-9496-03ea4a7df200'
     response = client.get(f'{JOBS_URI}/{job_id}')
-    assert response.status_code == status.HTTP_404_NOT_FOUND
+    assert response.status_code == HTTPStatus.NOT_FOUND
     assert job_id in response.json['detail']
 
     job_id = 'boogers'
     response = client.get(f'{JOBS_URI}/{job_id}')
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == HTTPStatus.BAD_REQUEST

--- a/tests/api/test_get_user.py
+++ b/tests/api/test_get_user.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
+from http import HTTPStatus
 
 from api.conftest import USER_URI, login, make_db_record
-from flask_api import status
 
 from hyp3_api.util import format_time
 
@@ -21,7 +21,7 @@ def test_get_user(client, tables, monkeypatch):
 
     login(client, 'user_with_jobs')
     response = client.get(USER_URI)
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
     assert response.json == {
         'user_id': 'user_with_jobs',
         'quota': {
@@ -45,17 +45,17 @@ def test_user_at_quota(client, tables, monkeypatch):
 
     login(client)
     response = client.get(USER_URI)
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
     assert response.json['quota']['remaining'] == 1
 
     tables['jobs_table'].put_item(Item=make_db_record('anotherJob', request_time=request_time))
     response = client.get(USER_URI)
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
     assert response.json['quota']['remaining'] == 0
 
     tables['jobs_table'].put_item(Item=make_db_record('yetAnotherJob', request_time=request_time))
     response = client.get(USER_URI)
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
     assert response.json['quota']['remaining'] == 0
 
 
@@ -65,7 +65,7 @@ def test_get_user_custom_quota(client, tables):
     tables['users_table'].put_item(Item={'user_id': username, 'max_jobs_per_month': 50})
 
     response = client.get(USER_URI)
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
     assert response.json == {
         'user_id': username,
         'quota': {

--- a/tests/api/test_lambda_handler.py
+++ b/tests/api/test_lambda_handler.py
@@ -1,4 +1,4 @@
-from flask_api import status
+from http import HTTPStatus
 
 from hyp3_api import lambda_handler
 
@@ -15,7 +15,7 @@ def test_404_response():
         },
     }
     response = lambda_handler.handler(event, None)
-    assert response['statusCode'] == status.HTTP_404_NOT_FOUND
+    assert response['statusCode'] == HTTPStatus.NOT_FOUND
     assert response['headers']['Content-Type'] == 'application/problem+json'
     assert response['isBase64Encoded'] is False
 
@@ -32,6 +32,6 @@ def test_401_response():
         },
     }
     response = lambda_handler.handler(event, None)
-    assert response['statusCode'] == status.HTTP_401_UNAUTHORIZED
+    assert response['statusCode'] == HTTPStatus.UNAUTHORIZED
     assert response['headers']['Content-Type'] == 'application/problem+json'
     assert response['isBase64Encoded'] is False

--- a/tests/api/test_list_jobs.py
+++ b/tests/api/test_list_jobs.py
@@ -1,8 +1,8 @@
+from http import HTTPStatus
 from unittest import mock
 from urllib.parse import unquote
 
 from api.conftest import JOBS_URI, list_have_same_elements, login, make_db_record
-from flask_api import status
 
 
 def test_list_jobs(client, tables):
@@ -38,13 +38,13 @@ def test_list_jobs(client, tables):
 
     login(client, 'user_with_jobs')
     response = client.get(JOBS_URI)
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
     assert 'jobs' in response.json
     assert list_have_same_elements(response.json['jobs'], items)
 
     login(client, 'user_without_jobs')
     response = client.get(JOBS_URI)
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
     assert response.json == {'jobs': []}
 
 
@@ -58,11 +58,11 @@ def test_list_jobs_by_name(client, tables):
 
     login(client)
     response = client.get(JOBS_URI, query_string={'name': 'item1'})
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
     assert response.json == {'jobs': [items[0]]}
 
     response = client.get(JOBS_URI, query_string={'name': 'item does not exist'})
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
     assert response.json == {'jobs': []}
 
 
@@ -77,15 +77,15 @@ def test_list_jobs_by_type(client, tables):
 
     login(client)
     response = client.get(JOBS_URI, query_string={'job_type': 'RTC_GAMMA'})
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
     assert list_have_same_elements(response.json['jobs'], items[:2])
 
     response = client.get(JOBS_URI, query_string={'job_type': 'INSAR_GAMMA'})
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
     assert response.json == {'jobs': [items[2]]}
 
     response = client.get(JOBS_URI, query_string={'job_type': 'FOOBAR'})
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == HTTPStatus.BAD_REQUEST
 
 
 def test_list_jobs_by_status(client, tables):
@@ -98,11 +98,11 @@ def test_list_jobs_by_status(client, tables):
 
     login(client)
     response = client.get(JOBS_URI, query_string={'status_code': 'RUNNING'})
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
     assert response.json == {'jobs': [items[0]]}
 
     response = client.get(JOBS_URI, query_string={'status_code': 'FAILED'})
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
     assert response.json == {'jobs': []}
 
 
@@ -110,10 +110,10 @@ def test_list_jobs_bad_status(client):
     login(client)
 
     response = client.get(JOBS_URI, query_string={'status_code': 'BAD'})
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == HTTPStatus.BAD_REQUEST
 
     response = client.get(JOBS_URI, query_string={'status_code': ''})
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == HTTPStatus.BAD_REQUEST
 
 
 def test_list_jobs_date_start_and_end(client, tables):
@@ -138,15 +138,15 @@ def test_list_jobs_date_start_and_end(client, tables):
     login(client)
     for date in dates:
         response = client.get(JOBS_URI, query_string={'start': date})
-        assert response.status_code == status.HTTP_200_OK
+        assert response.status_code == HTTPStatus.OK
         assert list_have_same_elements(response.json['jobs'], items[1:])
 
         response = client.get(JOBS_URI, query_string={'end': date})
-        assert response.status_code == status.HTTP_200_OK
+        assert response.status_code == HTTPStatus.OK
         assert list_have_same_elements(response.json['jobs'], items[:2])
 
         response = client.get(JOBS_URI, query_string={'start': date, 'end': date})
-        assert response.status_code == status.HTTP_200_OK
+        assert response.status_code == HTTPStatus.OK
         assert response.json == {'jobs': [items[1]]}
 
 
@@ -169,7 +169,7 @@ def test_bad_date_formats(client):
     for datetime_parameter in datetime_parameters:
         for bad_date in bad_dates:
             response = client.get(JOBS_URI, query_string={datetime_parameter: bad_date})
-            assert response.status_code == status.HTTP_400_BAD_REQUEST
+            assert response.status_code == HTTPStatus.BAD_REQUEST
 
 
 def test_list_paging(client):

--- a/tests/api/test_submit_job.py
+++ b/tests/api/test_submit_job.py
@@ -1,7 +1,7 @@
+from http import HTTPStatus
 from datetime import datetime, timedelta, timezone
 
 from api.conftest import DEFAULT_USERNAME, login, make_db_record, make_job, setup_requests_mock, submit_batch
-from flask_api import status
 
 from hyp3_api.util import format_time
 
@@ -9,7 +9,7 @@ from hyp3_api.util import format_time
 def test_submit_one_job(client, tables):
     login(client)
     response = submit_batch(client)
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
     jobs = response.json['jobs']
     assert len(jobs) == 1
     assert jobs[0]['status_code'] == 'PENDING'
@@ -29,7 +29,7 @@ def test_submit_insar_gamma(client, tables):
         job_type='INSAR_GAMMA',
     )
     response = submit_batch(client, batch=[job])
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
 
     job = make_job(
         granules=granules,
@@ -42,7 +42,7 @@ def test_submit_insar_gamma(client, tables):
         },
     )
     response = submit_batch(client, batch=[job])
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
 
 
 def test_submit_autorift(client, tables):
@@ -55,7 +55,7 @@ def test_submit_autorift(client, tables):
         job_type='AUTORIFT'
     )
     response = submit_batch(client, batch=[job])
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
 
 
 def test_submit_multiple_job_types(client, tables):
@@ -76,7 +76,7 @@ def test_submit_multiple_job_types(client, tables):
         job_type='AUTORIFT'
     )
     response = submit_batch(client, batch=[rtc_gamma_job, insar_gamma_job, autorift_job])
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
 
 
 def test_submit_many_jobs(client, tables):
@@ -87,7 +87,7 @@ def test_submit_many_jobs(client, tables):
     setup_requests_mock(batch)
 
     response = submit_batch(client, batch)
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
     jobs = response.json['jobs']
     distinct_request_times = {job['request_time'] for job in jobs}
     assert len(jobs) == max_jobs
@@ -95,7 +95,7 @@ def test_submit_many_jobs(client, tables):
 
     batch.append(make_job())
     response = submit_batch(client, batch)
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == HTTPStatus.BAD_REQUEST
 
 
 def test_submit_exceeds_quota(client, tables, monkeypatch):
@@ -110,10 +110,10 @@ def test_submit_exceeds_quota(client, tables, monkeypatch):
     setup_requests_mock(batch)
 
     response = submit_batch(client, batch)
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
 
     response = submit_batch(client)
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == HTTPStatus.BAD_REQUEST
     assert '25 jobs' in response.json['detail']
     assert '0 jobs' in response.json['detail']
 
@@ -122,7 +122,7 @@ def test_submit_without_jobs(client):
     login(client)
     batch = []
     response = submit_batch(client, batch)
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == HTTPStatus.BAD_REQUEST
 
 
 def test_submit_job_without_name(client, tables):
@@ -133,7 +133,7 @@ def test_submit_job_without_name(client, tables):
     setup_requests_mock(batch)
 
     response = submit_batch(client, batch)
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
 
 
 def test_submit_job_with_empty_name(client):
@@ -143,7 +143,7 @@ def test_submit_job_with_empty_name(client):
     ]
     setup_requests_mock(batch)
     response = submit_batch(client, batch)
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == HTTPStatus.BAD_REQUEST
 
 
 def test_submit_job_with_long_name(client):
@@ -153,7 +153,7 @@ def test_submit_job_with_long_name(client):
     ]
     setup_requests_mock(batch)
     response = submit_batch(client, batch)
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == HTTPStatus.BAD_REQUEST
 
 
 def test_submit_job_granule_does_not_exist(client, tables):
@@ -166,7 +166,7 @@ def test_submit_job_granule_does_not_exist(client, tables):
 
     login(client)
     response = submit_batch(client, batch)
-    assert response.status_code == status.HTTP_400_BAD_REQUEST
+    assert response.status_code == HTTPStatus.BAD_REQUEST
     assert response.json['title'] == 'Bad Request'
     assert response.json['detail'] == 'Some requested scenes could not be found: ' \
                                       'S1A_IW_SLC__1SDV_20200610T173646_20200610T173704_032958_03D14C_5F2A'
@@ -186,7 +186,7 @@ def test_submit_good_rtc_granule_names(client, tables):
         ]
         setup_requests_mock(batch)
         response = submit_batch(client, batch)
-        assert response.status_code == status.HTTP_200_OK
+        assert response.status_code == HTTPStatus.OK
 
 
 def test_submit_bad_rtc_granule_names(client):
@@ -218,7 +218,7 @@ def test_submit_bad_rtc_granule_names(client):
         ]
         setup_requests_mock(batch)
         response = submit_batch(client, batch)
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.status_code == HTTPStatus.BAD_REQUEST
 
 
 def test_submit_good_autorift_granule_names(client, tables):
@@ -238,7 +238,7 @@ def test_submit_good_autorift_granule_names(client, tables):
         ]
         setup_requests_mock(batch)
         response = submit_batch(client, batch)
-        assert response.status_code == status.HTTP_200_OK
+        assert response.status_code == HTTPStatus.OK
 
 
 def test_submit_bad_autorift_granule_names(client):
@@ -270,19 +270,19 @@ def test_submit_bad_autorift_granule_names(client):
         ]
         setup_requests_mock(batch)
         response = submit_batch(client, batch)
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert response.status_code == HTTPStatus.BAD_REQUEST
 
 
 def test_float_input(client, tables):
     login(client)
     job = make_job(parameters={'resolution': 30.0})
     response = submit_batch(client, batch=[job])
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
     assert isinstance(response.json['jobs'][0]['job_parameters']['resolution'], float)
 
     job = make_job(parameters={'resolution': 30})
     response = submit_batch(client, batch=[job])
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
     assert isinstance(response.json['jobs'][0]['job_parameters']['resolution'], int)
 
 
@@ -290,16 +290,16 @@ def test_submit_validate_only(client, tables):
     login(client)
 
     response = submit_batch(client, validate_only=True)
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
     jobs = tables['jobs_table'].scan()['Items']
     assert len(jobs) == 0
 
     response = submit_batch(client, validate_only=False)
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
     jobs = tables['jobs_table'].scan()['Items']
     assert len(jobs) == 1
 
     response = submit_batch(client, validate_only=None)
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == HTTPStatus.OK
     jobs = tables['jobs_table'].scan()['Items']
     assert len(jobs) == 2

--- a/tests/api/test_submit_job.py
+++ b/tests/api/test_submit_job.py
@@ -1,5 +1,5 @@
-from http import HTTPStatus
 from datetime import datetime, timedelta, timezone
+from http import HTTPStatus
 
 from api.conftest import DEFAULT_USERNAME, login, make_db_record, make_job, setup_requests_mock, submit_batch
 


### PR DESCRIPTION
[flask_api](https://pypi.org/project/Flask-API/) hasn't had a PyPI release in 18 months and the homepage linked from PyPI doesn't exist.

This change was prompted by the Flask 2.0.0 release; `flask_api` imports `flask._compat` which was removed in the 2.0.0 release.