### PR TITLE
fix merge conflict in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,7 @@ export PYTHONPATH="${PYTHONPATH}:`pwd`/apps/api/src:`pwd`/apps/get-files/src:`pw
 
 - Set environment variables needed by the API module
 ```sh
-
-pip install -r apps/api/requirements-api.txt
-
 export $(cat tests/api/cfg.env | xargs)
-
 ```
 
 - Render CloudFormation templates needed by the API module


### PR DESCRIPTION
Jiang had caught that our old instructions referenced the wrong requirements file and included a fix in https://github.com/ASFHyP3/hyp3/pull/421

But that had already prompted me to update the testing section to run all of the tests (not just the API) in https://github.com/ASFHyP3/hyp3/pull/420 , which moved the pip install to it's own step.