### PR TITLE
Fix prod env name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - environment: hyp3-prod
+          - environment: hyp3
             domain: hyp3-api.asf.alaska.edu
             template_bucket: cf-templates-aubvn3i9olmk-us-west-2
             image_tag: latest


### PR DESCRIPTION
witll deploy the right `hyp3` stack instead of `hyp3-prod`

After this is successful we should delete the `hyp3-prod` environment on GitHub