### PR TITLE
Add python setup and dependencies to tag job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -76,6 +76,15 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.TOOLS_BOT_PAK }}
 
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: install python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install bump2version
+
       - name: Get associated PR
         uses: helaili/github-graphql-action@2.0.1
         env:


### PR DESCRIPTION
Prod deployment didn't tag the next version because bump2version wasn't installed. 
