### PR TITLE
modify ec2 instance type, add 10.0 as resolution option for RTC_GAMMA…

### DIFF
--- a/apps/api/src/hyp3_api/api-spec/job_parameters.yml.j2
+++ b/apps/api/src/hyp3_api/api-spec/job_parameters.yml.j2
@@ -96,6 +96,7 @@ components:
       type: number
       enum:
         - 30.0
+        - 10.0
 
     dem_name:
       description: Name of the DEM to use for processing. `copernicus` will use the Copernicus GLO-30 Public DEM, while `legacy` will use the DEM with the best coverage from ASF's legacy SRTM/NED datasets.

--- a/apps/compute-cf.yml
+++ b/apps/compute-cf.yml
@@ -59,7 +59,7 @@ Resources:
         MinvCpus: 0
         MaxvCpus: 1600
         InstanceTypes:
-          - r5d.xlarge
+          - r5d.2xlarge
         ImageId: !Ref AmiId
         Subnets: !Ref SubnetIds
         InstanceRole: !Ref InstanceProfile

--- a/job_types.yml
+++ b/job_types.yml
@@ -73,7 +73,7 @@ RtcGamma:
     - Ref::granules
   validators:
     - check_dem_coverage
-  timeout: 5400
+  timeout: 10800
 
 InsarGamma:
   image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma


### PR DESCRIPTION
…, WATER_MAP jobs

Job timeouts in job_types.yml may need to be adjusted based on running a batch of sample 10m jobs.  Currently RTC_GAMMA has a timeout of 3 hours and WATER_MAP has a timeout of 6 hours.