### PR TITLE
increase default memory reservation to 63 GB to support 10m jobs

### DIFF
--- a/apps/workflow-cf.yml.j2
+++ b/apps/workflow-cf.yml.j2
@@ -41,7 +41,7 @@ Resources:
       ContainerProperties:
         Image: !Sub "{{ job_spec['image'] }}:${ImageTag}"
         Vcpus: 1
-        Memory: 30000
+        Memory: 63000
         JobRoleArn: !Ref TaskRoleArn
         Command:
           {% for command in job_spec['command'] %}


### PR DESCRIPTION
`r5d.2xlarge` has up to `63591` MB available for tasks