### PR TITLE
increase watermap timeout to 24 hours

### DIFF
--- a/job_types.yml
+++ b/job_types.yml
@@ -216,4 +216,4 @@ WaterMap:
     - Ref::granules
   validators:
     - check_dem_coverage
-  timeout: 21600
+  timeout: 86400


### PR DESCRIPTION
First ten 10m watermap jobs for random S1 granules all timed out after six hours.  The corresponding RTC jobs took between 45 minutes and 2 hours.