### PR TITLE
upgrade to serverless_wsgi 1.7.8 to remove need to pin Werkzeug version

### DIFF
--- a/apps/api/requirements-api.txt
+++ b/apps/api/requirements-api.txt
@@ -5,7 +5,6 @@ openapi-core
 prance
 PyJWT
 requests
-serverless_wsgi
+serverless_wsgi>=1.7.8
 shapely
 strict-rfc3339
-Werkzeug>=1.0.1,<2.*


### PR DESCRIPTION
Resolves #417 

If/when serverless_wsgi supports flask/werkzeug>=2.0.0 we should upgrade automatically.