### PR TITLE
update path to static files now that ui is hosted at ui/ instead of ui

### DIFF
--- a/apps/api/src/hyp3_api/__init__.py
+++ b/apps/api/src/hyp3_api/__init__.py
@@ -1,7 +1,7 @@
 import boto3
 from flask import Flask
 
-app = Flask(__name__, template_folder='ui/swagger/', static_folder='ui/swagger/', static_url_path='/')
+app = Flask(__name__, template_folder='ui/swagger/', static_folder='ui/swagger/', static_url_path='/ui/')
 DYNAMODB_RESOURCE = boto3.resource('dynamodb')
 CMR_URL = 'https://cmr.earthdata.nasa.gov/search/granules.json'
 


### PR DESCRIPTION
`index.html` loads other static files (css, images, etc.) via relative links such as `./swagger-ui.css`. When the ui was hosted at `/ui`, that resovled to `/swagger-ui.css`. Now that the ui is hosted at `/ui/`, it resolves to `/ui/swagger-ui.css`.