### PR TITLE
Fix back-merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.TOOLS_BOT_PAK }}
+
       - name: Release
         uses: docker://antonyurchenko/git-release:v3.5.0
         env:


### PR DESCRIPTION
To push it will need to use the tools-bot keys (write permission)
Fetching only a single commit doesn't include history so initial checkout looks totally unrelated to main