### PR TITLE
move retry strategy for containers to Batch from Step Functions

### DIFF
--- a/apps/step-function.json.j2
+++ b/apps/step-function.json.j2
@@ -85,7 +85,10 @@
         "JobName.$": "$.job_id",
         "JobQueue": "${JobQueueArn}",
         "Parameters.$": "$.job_parameters",
-        "ContainerOverrides.$": "$.container_overrides"
+        "ContainerOverrides.$": "$.container_overrides",
+        "RetryStrategy": {
+          "Attempts": 2
+        }
       },
       "ResultPath": "$.results.processing_results",
       "Next": "UPLOAD_LOG",
@@ -94,7 +97,7 @@
           "ErrorEquals": [
             "States.ALL"
           ],
-          "MaxAttempts": 2
+          "MaxAttempts": 0
         }
       ],
       "Catch": [

--- a/apps/step-function.json.j2
+++ b/apps/step-function.json.j2
@@ -87,7 +87,7 @@
         "Parameters.$": "$.job_parameters",
         "ContainerOverrides.$": "$.container_overrides",
         "RetryStrategy": {
-          "Attempts": 2
+          "Attempts": 3
         }
       },
       "ResultPath": "$.results.processing_results",


### PR DESCRIPTION
Step Function retry documentation: https://states-language.net/spec.html#errors

Batch submit-job retry documentation: https://docs.aws.amazon.com/batch/latest/APIReference/API_SubmitJob.html#Batch-SubmitJob-request-retryStrategy

~I'm not sure if the RetryAttempts should be 2 or 3, will verify after deployment.~

I prefer overriding the retry strategy in the step function, rather than setting the retry strategy in the job definition itself, so that the default behavior is still a single attempt and so that retry configurations for all components are still all in the step function definition.

Does this deserve a changelog entry?

We could get fancy with the retry handling, but I'd prefer to start simple and see how it goes. I can see situations (such as a timeout when the step function calls the SubmitJob api) where a single transient failure would cause the entire job to fail, since no retry is set at the step function level.