### PR TITLE
revise cloudwatch logs retry strategy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,13 +28,13 @@ jobs:
             deploy_ref: refs/heads/develop
             autorift_naming_scheme: ITS_LIVE_OD
 
-#          - environment: hyp3-autorift
-#            domain: hyp3-autorift.asf.alaska.edu
-#            template_bucket: cf-templates-igavixdzdy7k-us-west-2
-#            image_tag: latest
-#            quota: 0
-#            deploy_ref: refs/heads/main
-#            autorift_naming_scheme: ITS_LIVE_PROD
+          - environment: hyp3-autorift
+            domain: hyp3-autorift.asf.alaska.edu
+            template_bucket: cf-templates-igavixdzdy7k-us-west-2
+            image_tag: latest
+            quota: 0
+            deploy_ref: refs/heads/main
+            autorift_naming_scheme: ITS_LIVE_PROD
 
     environment:
       name: ${{ matrix.environment }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1](https://github.com/ASFHyP3/hyp3/compare/v2.1.0...v2.1.1)
+### Changed
+- Modified retry strategies for Batch jobs and UploadLog lambda to address scaling errors
+
 ## [2.1.0](https://github.com/ASFHyP3/hyp3/compare/v2.0.4...v2.1.0)
 ### Added
 - `lib/dynamo` library to allow sharing common code among different apps.

--- a/apps/upload-log/src/upload_log.py
+++ b/apps/upload-log/src/upload_log.py
@@ -2,8 +2,10 @@ import json
 from os import environ
 
 import boto3
+from botocore.config import Config
 
-CLOUDWATCH = boto3.client('logs')
+config = Config(retries={'max_attempts': 2, 'mode': 'standard'})
+CLOUDWATCH = boto3.client('logs', config=config)
 S3 = boto3.client('s3')
 
 


### PR DESCRIPTION
Addresses service limit quota on GetLogEvents requests:

> GetLogEvents - 10 requests per second per account per Region. This quota can't be changed.We recommend subscriptions if you are continuously processing new data. If you need historical data, we recommend exporting your data to Amazon S3.

https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/cloudwatch_limits_cwl.html