### PR TITLE
make sure cfn-lint runs during static analysis

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: scottbrenner/cfn-lint-action@v2
         with:
-          args: "--ignore-checks W3002 --template **/*cf.yml"
+          command: cfn-lint --info --ignore-checks W3002 --template **/*cf.yml
 
   openapi-spec-validator:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Previous runs were installing cfn-lint, but not actually running it. This also adds `--info` so the output will print a list of the templates being evaluated.