### PR TITLE
remove user_id index from subscriptions table

### DIFF
--- a/apps/main-cf.yml
+++ b/apps/main-cf.yml
@@ -252,12 +252,6 @@ Resources:
         - AttributeName: subscription_id
           KeyType: HASH
       GlobalSecondaryIndexes:
-        - IndexName: user_id
-          KeySchema:
-            - AttributeName: user_id
-              KeyType: HASH
-          Projection:
-            ProjectionType: ALL
         - IndexName: user_id_by_creation_date
           KeySchema:
             - AttributeName: user_id


### PR DESCRIPTION
Shuffling the index parameter in order to add RANGE key, will follow up with a deployment creating a new index