### PR TITLE
L8 max Memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.3](https://github.com/ASFHyP3/hyp3/compare/v2.4.2...v2.4.3)
+### Changed
+- REVERT ME: Upped the Landsat-8 Memory to `31000` to re-run the seemingly memory-limited failures
+
 ## [2.4.2](https://github.com/ASFHyP3/hyp3/compare/v2.4.1...v2.4.2)
 ### Added
 - `POST /subscriptions` requests may now include a `validate_only` key which when set to `true` will not add the subscription

--- a/apps/step-function.json.j2
+++ b/apps/step-function.json.j2
@@ -52,7 +52,7 @@
     "USE_LANDSAT_MEMORY": {
       "Type": "Pass",
       "Result": {
-        "Memory": 10500
+        "Memory": 31000
       },
       "ResultPath": "$.container_overrides",
       "Next": "INSPECT_JOB_TYPE"


### PR DESCRIPTION
~ 1K pairs failed in what looks to be hitting the memory limit. This ups the memory limit for Landsat-8 so I can test a random subset.

I think whether they work or don't we'll want to revert this out before releasing to production