### PR TITLE
Use ResourceRequirements to override container memory

### DIFF
--- a/apps/step-function.json.j2
+++ b/apps/step-function.json.j2
@@ -43,30 +43,34 @@
     },
     "USE_SENTINEL2_MEMORY": {
       "Type": "Pass",
-      "Result": [
-        {
-          "type": "MEMORY",
-          "value": 7900
-        }
-      ],
-      "ResultPath": "$.resource_requirements",
+      "Result": {
+        "ResourceRequirements": [
+          {
+            "type": "MEMORY",
+            "value": 7900
+          }
+        ]
+      },
+      "ResultPath": "$.container_overrides",
       "Next": "INSPECT_JOB_TYPE"
     },
     "USE_LANDSAT_MEMORY": {
       "Type": "Pass",
-      "Result": [
-        {
-          "type": "MEMORY",
-          "value": 10500
-        }
-      ],
-      "ResultPath": "$.resource_requirements",
+      "Result": {
+        "ResourceRequirements": [
+          {
+            "type": "MEMORY",
+            "value": 10500
+          }
+        ]
+      },
+      "ResultPath": "$.container_overrides",
       "Next": "INSPECT_JOB_TYPE"
     },
     "USE_DEFAULT_MEMORY": {
       "Type": "Pass",
-      "Result": [],
-      "ResultPath": "$.resource_requirements",
+      "Result": {},
+      "ResultPath": "$.container_overrides",
       "Next": "INSPECT_JOB_TYPE"
     },
     "INSPECT_JOB_TYPE": {
@@ -91,7 +95,7 @@
         "JobName.$": "$.job_id",
         "JobQueue": "${JobQueueArn}",
         "Parameters.$": "$.job_parameters",
-        "ResourceRequirements.$": "$.resource_requirements",
+        "ContainerOverrides.$": "$.container_overrides",
         "RetryStrategy": {
           "Attempts": 3
         }

--- a/apps/step-function.json.j2
+++ b/apps/step-function.json.j2
@@ -43,24 +43,30 @@
     },
     "USE_SENTINEL2_MEMORY": {
       "Type": "Pass",
-      "Result": {
-        "Memory": 7900
-      },
-      "ResultPath": "$.container_overrides",
+      "Result": [
+        {
+          "type": "MEMORY",
+          "value": 7900
+        }
+      ],
+      "ResultPath": "$.resource_requirements",
       "Next": "INSPECT_JOB_TYPE"
     },
     "USE_LANDSAT_MEMORY": {
       "Type": "Pass",
-      "Result": {
-        "Memory": 10500
-      },
-      "ResultPath": "$.container_overrides",
+      "Result": [
+        {
+          "type": "MEMORY",
+          "value": 10500
+        }
+      ],
+      "ResultPath": "$.resource_requirements",
       "Next": "INSPECT_JOB_TYPE"
     },
     "USE_DEFAULT_MEMORY": {
       "Type": "Pass",
-      "Result": {},
-      "ResultPath": "$.container_overrides",
+      "Result": [],
+      "ResultPath": "$.resource_requirements",
       "Next": "INSPECT_JOB_TYPE"
     },
     "INSPECT_JOB_TYPE": {
@@ -85,7 +91,7 @@
         "JobName.$": "$.job_id",
         "JobQueue": "${JobQueueArn}",
         "Parameters.$": "$.job_parameters",
-        "ContainerOverrides.$": "$.container_overrides",
+        "ResourceRequirements.$": "$.resource_requirements",
         "RetryStrategy": {
           "Attempts": 3
         }

--- a/apps/step-function.json.j2
+++ b/apps/step-function.json.j2
@@ -46,8 +46,8 @@
       "Result": {
         "ResourceRequirements": [
           {
-            "type": "MEMORY",
-            "value": 7900
+            "Type": "MEMORY",
+            "Value": "7900"
           }
         ]
       },
@@ -59,8 +59,8 @@
       "Result": {
         "ResourceRequirements": [
           {
-            "type": "MEMORY",
-            "value": 10500
+            "Type": "MEMORY",
+            "Value": "10500"
           }
         ]
       },

--- a/apps/workflow-cf.yml.j2
+++ b/apps/workflow-cf.yml.j2
@@ -47,9 +47,10 @@ Resources:
         {% endfor %}
       ContainerProperties:
         Image: !Sub "{{ job_spec['image'] }}:${ImageTag}"
-        Vcpus: 1
-        Memory: 30000
         JobRoleArn: !Ref TaskRoleArn
+        ResourceRequirements:
+          - Type: MEMORY
+            Value: "30000"
         Command:
           {% for command in job_spec['command'] %}
           - {{ command }}

--- a/apps/workflow-cf.yml.j2
+++ b/apps/workflow-cf.yml.j2
@@ -50,7 +50,7 @@ Resources:
         JobRoleArn: !Ref TaskRoleArn
         ResourceRequirements:
           - Type: MEMORY
-            Value: "30000"
+            Value: "31672"
         Command:
           {% for command in job_spec['command'] %}
           - {{ command }}


### PR DESCRIPTION
not yet tested

The `Memory` field we were using previously works, but is deprecated. See the documentation for the memory/vcpus/resourceRequirements fields at https://docs.aws.amazon.com/batch/latest/APIReference/API_ContainerOverrides.html

This PR also increases the default memory reservation to 31,672 MB, the maximum available on an `r5d.xlarge` instance. AWS Batch will still reserve 32 MB for the ECS agent and system processes. For more information, see https://docs.aws.amazon.com/batch/latest/userguide/memory-management.html . This will hopefully reduce the impact of https://github.com/ASFHyP3/hyp3-gamma/issues/316

![Screenshot from 2021-09-22 09-10-00](https://user-images.githubusercontent.com/17994518/134391499-61a9d76b-97bb-44e8-8278-1876b79e7c46.png)