### PR TITLE
must specify VCPU in job definition ResourceRequirements in addition …

### DIFF
--- a/apps/workflow-cf.yml.j2
+++ b/apps/workflow-cf.yml.j2
@@ -49,6 +49,8 @@ Resources:
         Image: !Sub "{{ job_spec['image'] }}:${ImageTag}"
         JobRoleArn: !Ref TaskRoleArn
         ResourceRequirements:
+          - Type: VCPU
+            Value: "1"
           - Type: MEMORY
             Value: "31672"
         Command:


### PR DESCRIPTION
…to MEMORY

Deploy failed to create the Job Definitions with `An error occurred (ClientException) when calling the RegisterJobDefinition operation: Error executing request, Exception : vCPU is not provided., RequestId: 19ed0c04-a434-4c4d-a4b3-ffc0105e9022`