### PR TITLE
Add optional PermissionsBoundaryPolicyArn stack parameter

### DIFF
--- a/apps/api/api-cf.yml
+++ b/apps/api/api-cf.yml
@@ -27,6 +27,13 @@ Parameters:
   SystemAvailable:
     Type: String
 
+  PermissionsBoundaryPolicyArn:
+    Type: String
+    Default: ""
+
+Conditions:
+  UsePermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryPolicyArn, "" ] ]
+
 Outputs:
 
   Url:
@@ -84,6 +91,7 @@ Resources:
           Principal:
             Service: apigateway.amazonaws.com
           Effect: Allow
+      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
       Policies:
         - PolicyName: policy
           PolicyDocument:
@@ -109,6 +117,7 @@ Resources:
           Principal:
             Service: lambda.amazonaws.com
           Effect: Allow
+      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
       Policies:
         - PolicyName: policy
           PolicyDocument:

--- a/apps/compute-cf.yml
+++ b/apps/compute-cf.yml
@@ -15,6 +15,13 @@ Parameters:
   ContentBucket:
     Type: String
 
+  PermissionsBoundaryPolicyArn:
+    Type: String
+    Default: ""
+
+Conditions:
+  UsePermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryPolicyArn, "" ] ]
+
 Outputs:
 
   JobQueueArn:
@@ -89,6 +96,7 @@ Resources:
           Principal:
             Service: ecs-tasks.amazonaws.com
           Effect: Allow
+      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
       Policies:
@@ -113,6 +121,7 @@ Resources:
           Principal:
             Service: batch.amazonaws.com
           Effect: Allow
+      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole
 

--- a/apps/get-files/get-files-cf.yml
+++ b/apps/get-files/get-files-cf.yml
@@ -5,6 +5,13 @@ Parameters:
   Bucket:
     Type: String
 
+  PermissionsBoundaryPolicyArn:
+    Type: String
+    Default: ""
+
+Conditions:
+  UsePermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryPolicyArn, "" ] ]
+
 Outputs:
 
   LambdaArn:
@@ -28,6 +35,7 @@ Resources:
           Principal:
             Service: lambda.amazonaws.com
           Effect: Allow
+      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
       Policies:
         - PolicyName: policy
           PolicyDocument:

--- a/apps/main-cf.yml
+++ b/apps/main-cf.yml
@@ -66,6 +66,10 @@ Parameters:
       - ITS_LIVE_OD
       - ITS_LIVE_PROD
 
+  PermissionsBoundaryPolicyArn:
+    Type: String
+    Default: ""
+
 Outputs:
 
   ApiUrl:
@@ -86,6 +90,7 @@ Resources:
         CertificateArn: !Ref CertificateArn
         MonthlyJobQuotaPerUser: !Ref MonthlyJobQuotaPerUser
         SystemAvailable: !Ref SystemAvailable
+        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
       TemplateURL: api/api-cf.yml
 
   Cluster:
@@ -95,6 +100,7 @@ Resources:
         VpcId: !Ref VpcId
         SubnetIds: !Join [',', !Ref SubnetIds]
         ContentBucket: !Ref ContentBucket
+        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
       TemplateURL: compute-cf.yml
 
   ProcessNewGranules:
@@ -105,8 +111,8 @@ Resources:
         UsersTable: !Ref UsersTable
         SubscriptionsTable: !Ref SubscriptionsTable
         MonthlyJobQuotaPerUser: !Ref MonthlyJobQuotaPerUser
+        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
       TemplateURL: process-new-granules/process-new-granules-cf.yml
-
 
   StepFunction:
     Type: AWS::CloudFormation::Stack
@@ -120,6 +126,7 @@ Resources:
         Bucket: !Ref ContentBucket
         ImageTag: !Ref ImageTag
         AutoriftNamingScheme: !Ref AutoriftNamingScheme
+        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
       TemplateURL: workflow-cf.yml
 
   Monitoring:

--- a/apps/process-new-granules/process-new-granules-cf.yml
+++ b/apps/process-new-granules/process-new-granules-cf.yml
@@ -9,6 +9,12 @@ Parameters:
     Type: String
   MonthlyJobQuotaPerUser:
     Type: Number
+  PermissionsBoundaryPolicyArn:
+    Type: String
+    Default: ""
+
+Conditions:
+  UsePermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryPolicyArn, "" ] ]
 
 Outputs:
   LambdaArn:
@@ -31,6 +37,7 @@ Resources:
           Principal:
             Service: lambda.amazonaws.com
           Effect: Allow
+      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
       Policies:
         - PolicyName: policy
           PolicyDocument:

--- a/apps/start-execution/start-execution-cf.yml
+++ b/apps/start-execution/start-execution-cf.yml
@@ -8,6 +8,13 @@ Parameters:
   StepFunctionArn:
     Type: String
 
+  PermissionsBoundaryPolicyArn:
+    Type: String
+    Default: ""
+
+Conditions:
+  UsePermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryPolicyArn, "" ] ]
+
 Resources:
 
   LogGroup:
@@ -26,6 +33,7 @@ Resources:
           Principal:
             Service: lambda.amazonaws.com
           Effect: Allow
+      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
       Policies:
         - PolicyName: policy
           PolicyDocument:

--- a/apps/update-db/update-db-cf.yml
+++ b/apps/update-db/update-db-cf.yml
@@ -5,6 +5,13 @@ Parameters:
   JobsTable:
     Type: String
 
+  PermissionsBoundaryPolicyArn:
+    Type: String
+    Default: ""
+
+Conditions:
+  UsePermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryPolicyArn, "" ] ]
+
 Outputs:
 
   LambdaArn:
@@ -28,6 +35,7 @@ Resources:
           Principal:
             Service: lambda.amazonaws.com
           Effect: Allow
+      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
       Policies:
         - PolicyName: policy
           PolicyDocument:

--- a/apps/upload-log/upload-log-cf.yml
+++ b/apps/upload-log/upload-log-cf.yml
@@ -5,6 +5,13 @@ Parameters:
   Bucket:
     Type: String
 
+  PermissionsBoundaryPolicyArn:
+    Type: String
+    Default: ""
+
+Conditions:
+  UsePermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryPolicyArn, "" ] ]
+
 Outputs:
 
   LambdaArn:
@@ -28,6 +35,7 @@ Resources:
           Principal:
             Service: lambda.amazonaws.com
           Effect: Allow
+      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
       Policies:
         - PolicyName: policy
           PolicyDocument:

--- a/apps/workflow-cf.yml.j2
+++ b/apps/workflow-cf.yml.j2
@@ -31,6 +31,13 @@ Parameters:
       - ITS_LIVE_OD
       - ITS_LIVE_PROD
 
+  PermissionsBoundaryPolicyArn:
+    Type: String
+    Default: ""
+
+Conditions:
+  UsePermissionsBoundary: !Not [ !Equals [ !Ref PermissionsBoundaryPolicyArn, "" ] ]
+
 Outputs:
   StepFunctionArn:
     Value: !Ref StepFunction

--- a/apps/workflow-cf.yml.j2
+++ b/apps/workflow-cf.yml.j2
@@ -92,6 +92,7 @@ Resources:
           Principal:
             Service: states.amazonaws.com
           Effect: Allow
+      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
       Policies:
         - PolicyName: policy
           PolicyDocument:


### PR DESCRIPTION
Earthdata Cloud requirement from the [EDC Run Rules](https://wiki.earthdata.nasa.gov/download/attachments/151617812/Earthdata%20Cloud%20Tenant%20Run%20Rules%20Release%201.pdf?version=1&modificationDate=1601569460493&api=v2:)
> IAM roles created by Platform Users must include the permissions boundary provided and managed by NGAP, which restricts the permissions the created role can have to only those that are permitted (by NGAP) to application developers.

More about permissions boundaries: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html

Details on conditions, `If`, and `AWS::NoValue`: https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-conditions.html#associating-a-condition

Working example from TEA: https://github.com/asfadmin/thin-egress-app/blob/master/cloudformation/thin-egress-app.yaml#L250