### PR TITLE
expose AmiId as a top level stack parameter and freeze version in env…

### DIFF
--- a/.github/actions/deploy-hyp3/action.yml
+++ b/.github/actions/deploy-hyp3/action.yml
@@ -47,6 +47,9 @@ inputs:
   BANNED_CIDR_BLOCKS:
     description: "Comma separated list of IP CIDR blocks that will receive HTTP 403 FORBIDDEN responses from the API"
     required: true
+  AMI_ID:
+    description: "Amazon Linux 2 ECS-optimized AMI id to use when running AWS Batch jobs"
+    required: true
 
 runs:
   using: "composite"
@@ -85,4 +88,5 @@ runs:
                 AutoriftImage='${{ inputs.AUTORIFT_IMAGE }}' \
                 AutoriftNamingScheme='${{ inputs.AUTORIFT_NAMING_SCHEME }}' \
                 AutoriftParameterFile='${{ inputs.AUTORIFT_PARAMETER_FILE }}' \
-                BannedCidrBlocks='${{ inputs.BANNED_CIDR_BLOCKS }}'
+                BannedCidrBlocks='${{ inputs.BANNED_CIDR_BLOCKS }}' \
+                AmiId='${{ inputs.AMI_ID }}'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
             autorift_image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-autorift
             autorift_naming_scheme: ITS_LIVE_OD
             autorift_parameter_file: '/vsicurl/http://its-live-data.jpl.nasa.gov.s3.amazonaws.com/autorift_parameters/v001/autorift_landice_0120m.shp'
+            ami_id: 'ami-0971980bcf180eb0c'
 
           - environment: hyp3-test
             domain: hyp3-test-api.asf.alaska.edu
@@ -31,6 +32,7 @@ jobs:
             autorift_image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-autorift
             autorift_naming_scheme: ITS_LIVE_OD
             autorift_parameter_file: '/vsicurl/http://its-live-data.jpl.nasa.gov.s3.amazonaws.com/autorift_parameters/v001/autorift_landice_0120m.shp'
+            ami_id: 'ami-0971980bcf180eb0c'
 
           - environment: hyp3-autorift
             domain: hyp3-autorift.asf.alaska.edu
@@ -41,6 +43,7 @@ jobs:
             autorift_image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-autorift
             autorift_naming_scheme: ITS_LIVE_PROD
             autorift_parameter_file: '/vsicurl/http://its-live-data.jpl.nasa.gov.s3.amazonaws.com/autorift_parameters/v001/autorift_landice_0120m.shp'
+            ami_id: 'ami-0971980bcf180eb0c'
 
           - environment: hyp3-autorift-eu
             domain: hyp3-autorift-eu.asf.alaska.edu
@@ -51,6 +54,7 @@ jobs:
             autorift_image: 230742024655.dkr.ecr.eu-central-1.amazonaws.com/hyp3-autorift
             autorift_naming_scheme: ITS_LIVE_PROD
             autorift_parameter_file: '/vsicurl/http://its-live-data-eu.jpl.nasa.gov.s3.amazonaws.com/autorift_parameters/v001/autorift_landice_0120m.shp'
+            ami_id: 'ami-06a0b593202c1590d'
 
     environment:
       name: ${{ matrix.environment }}
@@ -87,6 +91,7 @@ jobs:
           AUTORIFT_NAMING_SCHEME: ${{ matrix.autorift_naming_scheme }}
           AUTORIFT_PARAMETER_FILE: ${{ matrix.autorift_parameter_file }}
           BANNED_CIDR_BLOCKS: ${{ secrets.BANNED_CIDR_BLOCKS }}
+          AMI_ID: ${{ matrix.ami_id }}
 
   tag:
     runs-on: ubuntu-latest

--- a/apps/compute-cf.yml
+++ b/apps/compute-cf.yml
@@ -10,7 +10,6 @@ Parameters:
 
   AmiId:
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-    Default: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
 
   ContentBucket:
     Type: String

--- a/apps/main-cf.yml
+++ b/apps/main-cf.yml
@@ -90,6 +90,9 @@ Parameters:
       - false
       - true
 
+  AmiId:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+
 Conditions:
 
   LambdasInVpc: !Equals [!Ref DeployLambdasInVpc, "true"]
@@ -126,6 +129,7 @@ Resources:
       Parameters:
         VpcId: !Ref VpcId
         SubnetIds: !Join [',', !Ref SubnetIds]
+        AmiId: !Ref AmiId
         ContentBucket: !Ref ContentBucket
         PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
       TemplateURL: compute-cf.yml


### PR DESCRIPTION
Changelog pending.

The specific AMI id to use is different from region to region: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html

I think as-written, when it comes time to update the ami id, we'd update it for all of the environments and merge to develop (which will deploy it for hyp3-test), then merge it to main (which will deploy it for hyp3/autorift/autorift-eu). Would be nice if the us-west-2 id weren't duplicated three times in `deploy.yml`