### PR TITLE
fix AmiId parameter type in compute-cf.yml

### DIFF
--- a/apps/compute-cf.yml
+++ b/apps/compute-cf.yml
@@ -9,7 +9,7 @@ Parameters:
     Type: List<AWS::EC2::Subnet::Id>
 
   AmiId:
-    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Type: AWS::EC2::Image::Id
 
   ContentBucket:
     Type: String


### PR DESCRIPTION
Fixes `Unable to fetch parameters [ami-0971980bcf180eb0c] from parameter store for this account.` error when deploying