### PR TITLE
add missing s3:GetObject permissions for get-files lambda

### DIFF
--- a/apps/get-files/get-files-cf.yml
+++ b/apps/get-files/get-files-cf.yml
@@ -61,7 +61,9 @@ Resources:
                 Action: s3:ListBucket
                 Resource: !Sub "arn:aws:s3:::${Bucket}"
               - Effect: Allow
-                Action: s3:GetObjectTagging
+                Action:
+                  - s3:GetObject
+                  - s3:GetObjectTagging
                 Resource: !Sub "arn:aws:s3:::${Bucket}/*"
 
   Lambda:


### PR DESCRIPTION
Things worked anyway since the content bucket grants public s3:GetObject access, but get-files failed with a permissions issue when we deployed to an Earthdata Cloud account with the public bucket policy.