### PR TITLE
Specify product lifecycles for all deployments

### DIFF
--- a/.github/actions/deploy-hyp3/action.yml
+++ b/.github/actions/deploy-hyp3/action.yml
@@ -17,6 +17,9 @@ inputs:
   IMAGE_TAG:
     description: "HyP3 plugin docker image tag to pull"
     required: true
+  PRODUCT_LIFETIME:
+    description: "Number of days to keep output files before deleting them"
+    required: true
   VPC_ID:
     description: "Default VPC ID"
     required: true
@@ -73,6 +76,7 @@ runs:
                 EDLUsername='${{ inputs.EDL_USERNAME }}' \
                 EDLPassword='${{ inputs.EDL_PASSWORD }}' \
                 ImageTag='${{ inputs.IMAGE_TAG }}' \
+                ProductLifetimeInDays='${{ inputs.PRODUCT_LIFETIME }}'\
                 DomainName='${{ inputs.DOMAIN_NAME }}' \
                 CertificateArn='${{ inputs.CERTIFICATE_ARN }}' \
                 MonthlyJobQuotaPerUser='${{ inputs.MONTHLY_JOB_QUOTA_PER_USER }}' \

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
             domain: hyp3-api.asf.alaska.edu
             template_bucket: cf-templates-aubvn3i9olmk-us-west-2
             image_tag: latest
+            product_lifetime_in_days: 14
             quota: 250
             deploy_ref: refs/heads/main
             job_files: job_spec/AUTORIFT.yml job_spec/INSAR_GAMMA.yml job_spec/RTC_GAMMA.yml
@@ -25,6 +26,7 @@ jobs:
             domain: hyp3-test-api.asf.alaska.edu
             template_bucket: cf-templates-aubvn3i9olmk-us-west-2
             image_tag: test
+            product_lifetime_in_days: 14
             quota: 250
             deploy_ref: refs/heads/develop
             job_files: job_spec/AUTORIFT.yml job_spec/INSAR_GAMMA.yml job_spec/RTC_GAMMA.yml
@@ -33,6 +35,7 @@ jobs:
             domain: hyp3-autorift.asf.alaska.edu
             template_bucket: cf-templates-igavixdzdy7k-us-west-2
             image_tag: latest
+            product_lifetime_in_days: 180
             quota: 0
             deploy_ref: refs/heads/main
             job_files: job_spec/AUTORIFT_ITS_LIVE.yml
@@ -41,6 +44,7 @@ jobs:
             domain: hyp3-autorift-eu.asf.alaska.edu
             template_bucket: cf-templates-autorift-eu-central-1
             image_tag: latest
+            product_lifetime_in_days: 180
             quota: 0
             deploy_ref: refs/heads/main
             job_files: job_spec/AUTORIFT_ITS_LIVE_EU.yml
@@ -70,6 +74,7 @@ jobs:
           DOMAIN_NAME: ${{ matrix.domain }}
           CERTIFICATE_ARN:  ${{ secrets.CERTIFICATE_ARN }}
           IMAGE_TAG: ${{ matrix.image_tag }}
+          PRODUCT_LIFETIME: ${{ matrix.product_lifetime_in_days }}
           VPC_ID: ${{ secrets.VPC_ID }}
           SUBNET_IDS: ${{ secrets.SUBNET_IDS }}
           EDL_USERNAME: ${{ secrets.EDL_USERNAME }}


### PR DESCRIPTION
`hyp3-autorfit` was deployed with a 180 lifecylce, but `hyp3-autorift-eu` was deployed with the default 14 days, causing some products to be lost before they were ingested. This brings the lifecycle front-and-center so we remember to customize it for science depolyments. 