### PR TITLE
Allow job spec YAMLs to specify an image tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.6.5](https://github.com/ASFHyP3/hyp3/compare/v2.6.4...v2.6.5)
+### Changed
+- Job specification YAMLs can now specify a container `image_tag`, which will override the deployment default
+  image tag
+
 ## [2.6.4](https://github.com/ASFHyP3/hyp3/compare/v2.6.3...v2.6.4)
 ### Fixed
 - `POST /jobs` no longer allows users to submit a job of one `job_type` with the parameters of another

--- a/apps/workflow-cf.yml.j2
+++ b/apps/workflow-cf.yml.j2
@@ -53,7 +53,11 @@ Resources:
         {{ k }}: {{ v.get('default') or v['api_schema'].get('default') }}
         {% endfor %}
       ContainerProperties:
-        Image: !Sub "{{ job_spec['image'] }}:{{ job_spec['image_tag'] if 'image_tag' in job_spec else '${ImageTag}' }}"
+        {% if  'image_tag' in job_spec %}
+        Image: "{{ job_spec['image'] }}:{{ job_spec['image_tag'] }}"
+        {% else %}
+        Image: !Sub "{{ job_spec['image'] }}:${ImageTag}"
+        {% endif %}
         JobRoleArn: !Ref TaskRoleArn
         ResourceRequirements:
           - Type: VCPU

--- a/apps/workflow-cf.yml.j2
+++ b/apps/workflow-cf.yml.j2
@@ -53,7 +53,7 @@ Resources:
         {{ k }}: {{ v.get('default') or v['api_schema'].get('default') }}
         {% endfor %}
       ContainerProperties:
-        Image: !Sub "{{ job_spec['image'] }}:${ImageTag}"
+        Image: !Sub "{{ job_spec['image'] }}:{{ job_spec['image_tag'] if 'image_tag' in job_spec else '${ImageTag}' }}"
         JobRoleArn: !Ref TaskRoleArn
         ResourceRequirements:
           - Type: VCPU


### PR DESCRIPTION
This PR allows job specification YAML's to override the default deployment image tag (`ImageTag` cloudformation deployment parameter) by including `image_tag` in the YAML like:
```yaml
INSAR_GAMMA:
  image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma
  image_tag: '4.9.0'
  required_parameters:
    - granules
   ...
 ```
 
 We'veneeded this for the watermapping deployment to freeze the gamma plugin version, and would allow us to put both a prod and test job in a custom deployment for prototyping work