### PR TITLE
update example secondary granule for isce jobs

### DIFF
--- a/job_spec/INSAR_ISCE.yml
+++ b/job_spec/INSAR_ISCE.yml
@@ -27,7 +27,7 @@ INSAR_ISCE:
           pattern: "^S1[AB]_IW_SLC__1S[SD][VH]"
           minLength: 67
           maxLength: 67
-          example: S1B_IW_SLC__1SDV_20210711T014922_20210711T014949_027740_034F80_859D
+          example: S1B_IW_SLC__1SDV_20210711T014947_20210711T015013_027740_034F80_D404
     bucket_prefix:
       default:  '""'
   command:

--- a/job_spec/INSAR_ISCE_TEST.yml
+++ b/job_spec/INSAR_ISCE_TEST.yml
@@ -28,7 +28,7 @@ INSAR_ISCE_TEST:
           pattern: "^S1[AB]_IW_SLC__1S[SD][VH]"
           minLength: 67
           maxLength: 67
-          example: S1B_IW_SLC__1SDV_20210711T014922_20210711T014949_027740_034F80_859D
+          example: S1B_IW_SLC__1SDV_20210711T014947_20210711T015013_027740_034F80_D404
     bucket_prefix:
       default:  '""'
   command:


### PR DESCRIPTION
uses the middle secondary from the DockerizedTopsApp readme, which is the one that overlaps the reference scene

https://github.com/ACCESS-cloud-based-InSAR/DockerizedTopsApp#run-locally