### PR TITLE
Update autorift paramter file URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.6.5](https://github.com/ASFHyP3/hyp3/compare/v2.6.4...v2.6.5)
 ### Changed
+- Default autoRIFT parameter file was updated to point at the new `its-live-data` AWS S3 bucket
+  instead of `its-live-data.jpl.nasa.gov`, except for the custom `autorift-eu` deployment which uses a copy in `eu-central-1`.
 - Job specification YAMLs can now specify a container `image_tag`, which will override the deployment default
   image tag
 - Provided example granule pairs for INSAR_GAMMA and AUTORIFT jobs in the OpenApi schema 

--- a/job_spec/AUTORIFT.yml
+++ b/job_spec/AUTORIFT.yml
@@ -50,7 +50,7 @@ AUTORIFT:
     - --bucket-prefix
     - Ref::bucket_prefix
     - --parameter-file
-    - '/vsicurl/http://its-live-data.jpl.nasa.gov.s3.amazonaws.com/autorift_parameters/v001/autorift_landice_0120m.shp'
+    - '/vsicurl/http://its-live-data.s3.amazonaws.com/autorift_parameters/v001/autorift_landice_0120m.shp'
     - --naming-scheme
     - ITS_LIVE_OD
     - Ref::granules

--- a/job_spec/AUTORIFT_ITS_LIVE.yml
+++ b/job_spec/AUTORIFT_ITS_LIVE.yml
@@ -50,7 +50,7 @@ AUTORIFT:
     - --bucket-prefix
     - Ref::bucket_prefix
     - --parameter-file
-    - '/vsicurl/http://its-live-data.jpl.nasa.gov.s3.amazonaws.com/autorift_parameters/v001/autorift_landice_0120m.shp'
+    - '/vsicurl/http://its-live-data.s3.amazonaws.com/autorift_parameters/v001/autorift_landice_0120m.shp'
     - --naming-scheme
     - ITS_LIVE_PROD
     - Ref::granules


### PR DESCRIPTION
Addresses (on our end) nasa-jpl/itslive#7 so that the new canonical source of the parameter file is used, except for the custom autorift-eu deployment copy. 
