### PR TITLE
Make custom domain name and ssl certificate optional stack parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.7.1](https://github.com/ASFHyP3/hyp3/compare/v2.7.0...v2.7.1)
+### Changed
+- The `DomainName` and `CertificateArn` stack parameters are now optional, allowing HyP3 to be deployed without
+  a custom domain name for the API.
+
 ## [2.7.0](https://github.com/ASFHyP3/hyp3/compare/v2.6.6...v2.7.0)
 ### Added
 - Support for automatic toggling between two `maxvCpus` values for the Batch compute environment, based on monthly

--- a/apps/api/api-cf.yml
+++ b/apps/api/api-cf.yml
@@ -45,7 +45,7 @@ Conditions:
 
   LambdasInVpc: !Not [!Equals [!Ref SecurityGroupId, ""]]
 
-  UseCustomDomainName: !Not [!Equals [!Ref DomainNames, ""]]
+  UseCustomDomainName: !Not [!Equals [!Ref DomainName, ""]]
 
 Outputs:
 

--- a/apps/api/api-cf.yml
+++ b/apps/api/api-cf.yml
@@ -45,10 +45,12 @@ Conditions:
 
   LambdasInVpc: !Not [!Equals [!Ref SecurityGroupId, ""]]
 
+  UseCustomDomainName: !Not [!Equals [!Ref DomainNames, ""]]
+
 Outputs:
 
   Url:
-    Value: !Sub "https://${CustomDomainName}/ui"
+    Value: !If [UseCustomDomainName, !Sub "https://${CustomDomainName}/ui", !Sub "${Api.ApiEndpoint}/ui"]
 
   ApiId:
     Value: !Ref Api
@@ -79,6 +81,7 @@ Resources:
 
   CustomDomainName:
     Type: AWS::ApiGatewayV2::DomainName
+    Condition: UseCustomDomainName
     Properties:
       DomainName: !Ref DomainName
       DomainNameConfigurations:
@@ -87,6 +90,7 @@ Resources:
 
   ApiMapping:
     Type: AWS::ApiGatewayV2::ApiMapping
+    Condition: UseCustomDomainName
     Properties:
       ApiId: !Ref Api
       DomainName: !Ref CustomDomainName

--- a/apps/main-cf.yml
+++ b/apps/main-cf.yml
@@ -40,10 +40,12 @@ Parameters:
   DomainName:
     Description: DNS domain name that will be used to invoke this api.
     Type: String
+    Default: ""
 
   CertificateArn:
     Description: ARN of Certificate in AWS Certificate Manager setup previously for this domain name.
     Type: String
+    Default: ""
 
   MonthlyJobQuotaPerUser:
     Description: Number of jobs each user is allowed per month.


### PR DESCRIPTION
This prepares for deployment into AWS environments (JPL, Earthdata Cloud) where deploying custom domain names and SSL certificates will require coordination with an external platform security team.

API authentication is still dependent on cookies, which will continue to present a challenge when accessing the API at a domain name outside the `*.asf.alaska.edu` umbrella.

I'm considering whether we should [disable the default endpoint](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-apigatewayv2-api.html#cfn-apigatewayv2-api-disableexecuteapiendpoint) (e.g. https://abc123.execute-api.us-west-2.amazonaws.com)  when a custom domain name is provided. Any thoughts?