### PR TITLE
Switch autoRIFT job to Github Container Registry

### DIFF
--- a/job_spec/AUTORIFT.yml
+++ b/job_spec/AUTORIFT.yml
@@ -1,5 +1,5 @@
 AUTORIFT:
-  image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-autorift
+  image: ghcr.io/asfhyp3/hyp3-autorift
   required_parameters:
     - granules
   parameters:

--- a/job_spec/AUTORIFT_ITS_LIVE.yml
+++ b/job_spec/AUTORIFT_ITS_LIVE.yml
@@ -1,5 +1,5 @@
 AUTORIFT:
-  image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-autorift
+  image: ghcr.io/asfhyp3/hyp3-autorift
   required_parameters:
     - granules
   parameters:

--- a/job_spec/AUTORIFT_ITS_LIVE_EU.yml
+++ b/job_spec/AUTORIFT_ITS_LIVE_EU.yml
@@ -1,5 +1,5 @@
 AUTORIFT:
-  image: 230742024655.dkr.ecr.eu-central-1.amazonaws.com/hyp3-autorift
+  image: ghcr.io/asfhyp3/hyp3-autorift
   required_parameters:
     - granules
   parameters:


### PR DESCRIPTION
`hyp3-autorift` is now primarily publishing to the Github Container Registry ( ASFHyP3/hyp3-autorift#133 ). This switches the default autoRIFT job to use the container registry. 

~~I *have not* modified `AUTORIFT_ITS_LIVE.yml` or `AUTORIFT_ITS_LIVE_EU.yml` as we likely don't want the extra runtime of pulling from ghcr.io instead of ECR, especially for optical processing.~~

*Note: I don't think this is an issue for prod HyP3 as those are generally S1 jobs that take a long time and there aren't many of them being run, so this change shouldn't be appreciable.*
