### PR TITLE
set job priority based on jobs already submitted month-to-date for user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.7.2](https://github.com/ASFHyP3/hyp3/compare/v2.7.1...v2.7.2)
+### Changed
+- Jobs are now assigned a `priority` attribute when submitted. `priority` is calculated based on jobs already
+  submitted month-to-date by the same user. Jobs with a higher `priority` value will run before jobs with a lower value.
+
 ## [2.7.1](https://github.com/ASFHyP3/hyp3/compare/v2.7.0...v2.7.1)
 ### Changed
 - The `DomainName` and `CertificateArn` stack parameters are now optional, allowing HyP3 to be deployed without

--- a/apps/api/src/hyp3_api/api-spec/openapi-spec.yml
+++ b/apps/api/src/hyp3_api/api-spec/openapi-spec.yml
@@ -426,6 +426,8 @@ components:
           $ref: "#/components/schemas/list_of_urls"
         expiration_time:
           $ref: "#/components/schemas/datetime"
+        priority:
+          $ref: "#/components/schemas/priority"
 
     validate_only:
       type: boolean
@@ -515,6 +517,11 @@ components:
       type: array
       items:
         type: string
+
+    priority:
+      type: integer
+      minimum: 0
+      maximum: 9999
 
   securitySchemes:
     EarthDataLogin:

--- a/apps/api/src/hyp3_api/handlers.py
+++ b/apps/api/src/hyp3_api/handlers.py
@@ -1,5 +1,4 @@
 from http.client import responses
-from os import environ
 from uuid import UUID
 
 import requests
@@ -81,23 +80,14 @@ def get_names_for_user(user):
     return sorted(list(names))
 
 
-def get_max_jobs_per_month(user):
-    user = dynamo.user.get_user(user)
-    if user:
-        max_jobs_per_month = user['max_jobs_per_month']
-    else:
-        max_jobs_per_month = int(environ['MONTHLY_JOB_QUOTA_PER_USER'])
-    return max_jobs_per_month
-
-
 def get_user(user):
-    max_jobs = get_max_jobs_per_month(user)
+    max_jobs, _, remaining_jobs = dynamo.jobs.get_quota_staus(user)
 
     return {
         'user_id': user,
         'quota': {
             'max_jobs_per_month': max_jobs,
-            'remaining': util.get_remaining_jobs_for_user(user, max_jobs),
+            'remaining': remaining_jobs,
         },
         'job_names': get_names_for_user(user)
     }

--- a/apps/api/src/hyp3_api/handlers.py
+++ b/apps/api/src/hyp3_api/handlers.py
@@ -81,7 +81,7 @@ def get_names_for_user(user):
 
 
 def get_user(user):
-    max_jobs, _, remaining_jobs = dynamo.jobs.get_quota_staus(user)
+    max_jobs, _, remaining_jobs = dynamo.jobs.get_quota_status(user)
 
     return {
         'user_id': user,

--- a/apps/compute-cf.yml
+++ b/apps/compute-cf.yml
@@ -88,7 +88,7 @@ Resources:
           Name: !Ref AWS::StackName
 
   SchedulingPolicy:
-    Type: AWS::Batch::ScedulingPolicy
+    Type: AWS::Batch::SchedulingPolicy
 
   JobQueue:
     Type: AWS::Batch::JobQueue

--- a/apps/compute-cf.yml
+++ b/apps/compute-cf.yml
@@ -87,6 +87,9 @@ Resources:
         Tags:
           Name: !Ref AWS::StackName
 
+  SchedulingPolicy:
+    Type: AWS::Batch::ScedulingPolicy
+
   JobQueue:
     Type: AWS::Batch::JobQueue
     Properties:
@@ -94,6 +97,7 @@ Resources:
       ComputeEnvironmentOrder:
         - ComputeEnvironment: !Ref ComputeEnvironment
           Order: 1
+      SchedulingPolicyArn: !Ref SchedulingPolicy
 
   TaskRole:
     Type: AWS::IAM::Role

--- a/apps/step-function.json.j2
+++ b/apps/step-function.json.j2
@@ -94,6 +94,8 @@
         "JobDefinition": "{{ '${'+ snake_to_pascal_case(job_type) + '}' }}",
         "JobName.$": "$.job_id",
         "JobQueue": "${JobQueueArn}",
+        "ShareIdentifier": "default",
+        "SchedulingPriorityOverride": $.priority,
         "Parameters.$": "$.job_parameters",
         "ContainerOverrides.$": "$.container_overrides",
         "RetryStrategy": {

--- a/apps/step-function.json.j2
+++ b/apps/step-function.json.j2
@@ -95,7 +95,7 @@
         "JobName.$": "$.job_id",
         "JobQueue": "${JobQueueArn}",
         "ShareIdentifier": "default",
-        "SchedulingPriorityOverride": $.priority,
+        "SchedulingPriorityOverride": "$.priority",
         "Parameters.$": "$.job_parameters",
         "ContainerOverrides.$": "$.container_overrides",
         "RetryStrategy": {

--- a/lib/dynamo/dynamo/jobs.py
+++ b/lib/dynamo/dynamo/jobs.py
@@ -20,7 +20,7 @@ def _get_job_count_for_month(user) -> int:
     return job_count_for_month
 
 
-def get_quota_status(user) -> Tuple[int]:
+def get_quota_status(user) -> Tuple[int, int, int]:
     max_jobs = get_max_jobs_per_month(user)
     previous_jobs = _get_job_count_for_month(user)
     remaining_jobs = max(max_jobs - previous_jobs, 0)

--- a/lib/dynamo/dynamo/jobs.py
+++ b/lib/dynamo/dynamo/jobs.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 from os import environ
-from typing import List
+from typing import List, Tuple
 from uuid import uuid4
 
 from boto3.dynamodb.conditions import Attr, Key
@@ -13,29 +13,28 @@ class QuotaError(Exception):
     """Raised when trying to submit more jobs that user has remaining"""
 
 
-def _get_job_count_for_month(user):
+def _get_job_count_for_month(user) -> int:
     now = datetime.now(timezone.utc)
     start_of_month = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
     job_count_for_month = count_jobs(user, format_time(start_of_month))
     return job_count_for_month
 
 
-def get_remaining_jobs_for_user(user, limit):
+def get_quota_status(user) -> Tuple[int]:
+    max_jobs = get_max_jobs_per_month(user)
     previous_jobs = _get_job_count_for_month(user)
-    remaining_jobs = limit - previous_jobs
-    return max(remaining_jobs, 0)
+    remaining_jobs = max(max_jobs - previous_jobs, 0)
+    return max_jobs, previous_jobs, remaining_jobs
 
 
 def put_jobs(user_id: str, jobs: List[dict], fail_when_over_quota=True) -> List[dict]:
     table = DYNAMODB_RESOURCE.Table(environ['JOBS_TABLE_NAME'])
     request_time = format_time(datetime.now(timezone.utc))
 
-    job_limit = get_max_jobs_per_month(user_id)
-    number_of_jobs = len(jobs)
-    remaining_jobs = get_remaining_jobs_for_user(user_id, job_limit)
-    if number_of_jobs > remaining_jobs:
+    max_jobs, previous_jobs, remaining_jobs = get_quota_status(user_id)
+    if len(jobs) > remaining_jobs:
         if fail_when_over_quota:
-            raise QuotaError(f'Your monthly quota is {job_limit} jobs. You have {remaining_jobs} jobs remaining.')
+            raise QuotaError(f'Your monthly quota is {max_jobs} jobs. You have {remaining_jobs} jobs remaining.')
         jobs = jobs[:remaining_jobs]
 
     prepared_jobs = [
@@ -44,8 +43,9 @@ def put_jobs(user_id: str, jobs: List[dict], fail_when_over_quota=True) -> List[
             'user_id': user_id,
             'status_code': 'PENDING',
             'request_time': request_time,
+            'priority': max(9999 - previous_jobs - index, 0),
             **job,
-        } for job in jobs
+        } for index, job in enumerate(jobs)
     ]
 
     for prepared_job in prepared_jobs:

--- a/lib/dynamo/dynamo/user.py
+++ b/lib/dynamo/dynamo/user.py
@@ -9,7 +9,7 @@ def get_user(user):
     return response.get('Item')
 
 
-def get_max_jobs_per_month(user):
+def get_max_jobs_per_month(user) -> int:
     user = get_user(user)
     if user:
         max_jobs_per_month = int(user['max_jobs_per_month'])

--- a/tests/test_dynamo/test_jobs.py
+++ b/tests/test_dynamo/test_jobs.py
@@ -317,13 +317,20 @@ def test_put_jobs(tables):
     jobs = dynamo.jobs.put_jobs('user1', payload)
     assert len(jobs) == 3
     for job in jobs:
-        assert set(job.keys()) == {'name', 'job_id', 'user_id', 'status_code', 'request_time'}
+        assert set(job.keys()) == {'name', 'job_id', 'user_id', 'status_code', 'request_time', 'priority'}
         assert job['request_time'] <= dynamo.util.format_time(datetime.now(timezone.utc))
         assert job['user_id'] == 'user1'
         assert job['status_code'] == 'PENDING'
 
     response = tables.jobs_table.scan()
     assert response['Items'] == jobs
+
+
+def test_put_jobs_priority(tables):
+    jobs = dynamo.jobs.put_jobs('user1', [{}])
+    jobs.extend(dynamo.jobs.put_jobs('user1', [{}, {}]))
+    jobs.extend(dynamo.jobs.put_jobs('user2', [{}]))
+    assert [job['priority'] for job in jobs] == [9999, 9998, 9997, 9999]
 
 
 def test_get_job(tables):


### PR DESCRIPTION
https://aws.amazon.com/blogs/hpc/introducing-fair-share-scheduling-for-aws-batch/

I've put the priority calculation at the data-access layer in `dynamo.jobs.put_jobs`. That feels like the correct place; every job will be assigned a priority when it's created, but the job-creators (api, process-new-granules) don't have to know about it. Could consider calculating it as part of the step function prior to submitting the job to batch, but that doesn't feel like a compelling place for it to me.

Cloudformation and step function changes haven't yet been tested, only linted.

`dynamo.jobs.get_quota_status` arguably deserves a test.