### PR TITLE
Add water map job to HyP3 test

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,7 +32,7 @@ jobs:
             product_lifetime_in_days: 14
             quota: 250
             deploy_ref: refs/heads/develop
-            job_files: job_spec/AUTORIFT.yml job_spec/INSAR_GAMMA.yml job_spec/RTC_GAMMA.yml
+            job_files: job_spec/AUTORIFT.yml job_spec/INSAR_GAMMA.yml job_spec/RTC_GAMMA.yml job_spec/WATER_MAP.yml
             default_max_vcpus: 600
             expanded_max_vcpus: 1600
             required_surplus: 1000

--- a/job_spec/WATER_MAP.yml
+++ b/job_spec/WATER_MAP.yml
@@ -1,0 +1,93 @@
+WATER_MAP:
+  image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma
+  required_parameters:
+    - granules
+  parameters:
+    granules:
+      default: '""'
+      api_schema:
+        type: array
+        minItems: 1
+        maxItems: 1
+        items:
+          anyOf:
+            - description: The name of the IW VV+VH Sentinel-1 GRDH granule to process
+              type: string
+              pattern: "^S1[AB]_IW_GRDH_1SDV"
+              minLength: 67
+              maxLength: 67
+              example: S1A_IW_GRDH_1SDV_20210413T235641_20210413T235706_037439_0469D0_3F2B
+            - description: The name of the IW VV+VH Sentinel-1 SLC granule to process
+              type: string
+              pattern: "^S1[AB]_IW_SLC__1SDV"
+              minLength: 67
+              maxLength: 67
+              example: S1A_IW_SLC__1SDV_20211110T234815_20211110T234842_040516_04CE0A_E717
+    bucket_prefix:
+      default:  '""'
+    resolution:
+      api_schema:
+        default:  30.0
+        description: Desired output pixel spacing in meters
+        type: number
+        enum:
+          - 30.0
+    speckle_filter:
+      api_schema:
+        description: Apply an Enhanced Lee speckle filter
+        default: false
+        type: boolean
+    max_vv_threshold:
+      api_schema:
+        description: Maximum threshold value to use for VV polarized raster in decibels (dB)
+        default: -15.5
+        type: number
+    max_vh_threshold:
+      api_schema:
+        description: Maximum threshold value to use for VH polarized raster in decibels (dB)
+        default: -23.0
+        type: number
+    hand_threshold:
+      api_schema:
+        description: The maximum height above nearest drainage in meters to consider a pixel valid
+        default: 15.0
+        type: number
+    hand_fraction:
+      api_schema:
+        description: The minimum fraction of valid HAND pixels required in a tile for thresholding
+        default: 0.8
+        type: number
+    membership_threshold:
+      api_schema:
+        description: The average membership to the fuzzy indicators required for a water pixel
+        default: 0.45
+        type: number
+  command:
+    - ++process
+    - water_map
+    - --username
+    - '!Ref EDLUsername'
+    - --password
+    - '!Ref EDLPassword'
+    - --bucket
+    - '!Ref Bucket'
+    - --bucket-prefix
+    - Ref::bucket_prefix
+    - --resolution
+    - Ref::resolution
+    - --speckle-filter
+    - Ref::speckle_filter
+    - --max-vv-threshold
+    - Ref::max_vv_threshold
+    - --max-vh-threshold
+    - Ref::max_vh_threshold
+    - --hand-threshold
+    - Ref::hand_threshold
+    - --hand-fraction
+    - Ref::hand_fraction
+    - --membership-threshold
+    - Ref::membership_threshold
+    - Ref::granules
+  validators:
+    - check_dem_coverage
+  timeout: 5400


### PR DESCRIPTION
We still can't bring the watermap deployment into our normal deployment workflow because we'd need to parameterize these changes for the `hyp3-watermap` deployment so it can handle 10m jobs :

```diff
diff --git a/apps/compute-cf.yml b/apps/compute-cf.yml
index a2adfff..c98a8d0 100644
--- a/apps/compute-cf.yml
+++ b/apps/compute-cf.yml
@@ -75,7 +75,7 @@ Resources:
         MinvCpus: 0
         MaxvCpus: !Ref MaxvCpus
         InstanceTypes:
-          - r5d.xlarge
+          - r5d.4xlarge
         ImageId: !Ref AmiId
         Subnets: !Ref SubnetIds
         InstanceRole: !Ref InstanceProfile
diff --git a/apps/workflow-cf.yml.j2 b/apps/workflow-cf.yml.j2
index 6e5ee29..c4fd97c 100644
--- a/apps/workflow-cf.yml.j2
+++ b/apps/workflow-cf.yml.j2
@@ -63,7 +63,7 @@ Resources:
           - Type: VCPU
             Value: "1"
           - Type: MEMORY
-            Value: "31600"
+            Value: "126000"
         Command:
           {% for command in job_spec['command'] %}
           - {{ command }}
```

This brings in a 30m-only water map job