### PR TITLE
fix scale-cluster iam policy

### DIFF
--- a/apps/scale-cluster/scale-cluster-cf.yml
+++ b/apps/scale-cluster/scale-cluster-cf.yml
@@ -68,12 +68,12 @@ Resources:
                   - logs:PutLogEvents
                 Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*"
               - Effect: Allow
-                Action: ce:GetCostAndUsage
+                Action:
+                  - ce:GetCostAndUsage
+                  - batch:UpdateComputeEnvironment
                 Resource: "*"
               - Effect: Allow
-                Action:
-                - batch:DescribeComputeEnvironments
-                - batch:UpdateComputeEnvironment
+                Action: batch:UpdateComputeEnvironment
                 Resource: !Ref ComputeEnvironmentArn
 
   Lambda:

--- a/apps/scale-cluster/scale-cluster-cf.yml
+++ b/apps/scale-cluster/scale-cluster-cf.yml
@@ -70,7 +70,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - ce:GetCostAndUsage
-                  - batch:UpdateComputeEnvironment
+                  - batch:DescribeComputeEnvironments
                 Resource: "*"
               - Effect: Allow
                 Action: batch:UpdateComputeEnvironment


### PR DESCRIPTION
DescribeComputeEnvironments requires `Resource: *`, see https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsbatch.html

```
[ERROR] ClientError: An error occurred (AccessDeniedException) when calling the DescribeComputeEnvironments operation: User: arn:aws:sts::***:assumed-role/hyp3-test-ScaleCluster-***-Role-***/hyp3-test-ScaleCluster-***Lambda-*** is not authorized to perform: batch:DescribeComputeEnvironments on resource: *
Traceback (most recent call last):
  File "/var/task/scale_cluster.py", line 75, in lambda_handler
    desired_vcpus = get_desired_vcpus(environ['COMPUTE_ENVIRONMENT_ARN'])
  File "/var/task/scale_cluster.py", line 37, in get_desired_vcpus
    response = BATCH.describe_compute_environments(computeEnvironments=[compute_environment_arn])
  File "/var/runtime/botocore/client.py", line 386, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/var/runtime/botocore/client.py", line 705, in _make_api_call
    raise error_class(parsed_response, operation_name)
```
