### PR TITLE
add .$ to step function field name so input values are correctly tran…

### DIFF
--- a/apps/step-function.json.j2
+++ b/apps/step-function.json.j2
@@ -95,7 +95,7 @@
         "JobName.$": "$.job_id",
         "JobQueue": "${JobQueueArn}",
         "ShareIdentifier": "default",
-        "SchedulingPriorityOverride": "$.priority",
+        "SchedulingPriorityOverride.$": "$.priority",
         "Parameters.$": "$.job_parameters",
         "ContainerOverrides.$": "$.container_overrides",
         "RetryStrategy": {


### PR DESCRIPTION
…sformed

Was previously trying to pass the literal string `$.priority` as the value. Now the input value should be correctly transformed, per https://states-language.net/spec.html#payload-template

> If any field within the Payload Template (however deeply nested) has a name ending with the characters ".$", its value is transformed according to rules below and the field is renamed to strip the ".$" suffix.
If the field value begins with only one "$", the value MUST be a Path. In this case, the Path is applied to the Payload Template’s input and is the new field value.

~We'll still see a string vs integer conflict, however, since the priority value is a string in the input payload.~
Edit: disregard, it's only the `job_parameters` block we cast to strings at https://github.com/ASFHyP3/hyp3/blob/develop/apps/start-execution/src/start_execution.py#L33, priority should be an integer and good-to-go