### PR TITLE
update logical name of batch queue to force replacement to update SchedulingPolicyArn

### DIFF
--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -31,7 +31,7 @@ Outputs:
     Value: !Ref ComputeEnvironment
 
   JobQueueArn:
-    Value: !Ref JobQueue
+    Value: !Ref BatchJobQueue
 
   TaskRoleArn:
     Value: !GetAtt TaskRole.Arn

--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -90,7 +90,7 @@ Resources:
   SchedulingPolicy:
     Type: AWS::Batch::SchedulingPolicy
 
-  JobQueue:
+  BatchJobQueue:
     Type: AWS::Batch::JobQueue
     Properties:
       Priority: 1


### PR DESCRIPTION
Merging this PR will likely interrupt in-progress jobs when the Batch Job Queue is replaced.