### PR TITLE
explicitly define default ShareIdentifier in Scheduling Policy defini…

### DIFF
--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -89,6 +89,10 @@ Resources:
 
   SchedulingPolicy:
     Type: AWS::Batch::SchedulingPolicy
+    Properties:
+      FairsharePolicy:
+        ShareDistribution:
+          - ShareIdentifier: default
 
   BatchJobQueue:
     Type: AWS::Batch::JobQueue


### PR DESCRIPTION
…tion

We've seen the following error for 4 of ~650 Batch jobs submitted using the current `develop` branch:

```
{
  "resourceType": "batch",
  "resource": "submitJob.sync",
  "error": "Batch.ServerException",
  "cause": "Failed to create shareIdentifier default (Service: AWSBatch; Status Code: 500; Error Code: ServerException; Request ID: e7dbfaef-1a2f-49e5-8cf1-04562525b2bc; Proxy: null)"
}
```

This PR is an experiment to see if explicitly defining the `default` fair share identifier as part of the scheduling policy resolves this error. See https://docs.aws.amazon.com/batch/latest/userguide/scheduling-policy-parameters.html for more details on Scheduling Policy configuration.