### PR TITLE
retry Batch.ServerException errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Jobs are now assigned a `priority` attribute when submitted. `priority` is calculated based on jobs already
   submitted month-to-date by the same user. Jobs with a higher `priority` value will run before jobs with a lower value.
+- `Batch.ServerException` errors encountered by the Step Function are now retried, to address intermittent errors when
+  the Step Functions service calls Batch service.
 
 ## [2.8.0](https://github.com/ASFHyP3/hyp3/compare/v2.7.7...v2.8.0)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Jobs are now assigned a `priority` attribute when submitted. `priority` is calculated based on jobs already
   submitted month-to-date by the same user. Jobs with a higher `priority` value will run before jobs with a lower value.
 - `Batch.ServerException` errors encountered by the Step Function are now retried, to address intermittent errors when
-  the Step Functions service calls Batch service.
+  the Step Functions service calls the Batch SubmitJob API.
 
 ## [2.8.0](https://github.com/ASFHyP3/hyp3/compare/v2.7.7...v2.8.0)
 ### Added

--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -89,10 +89,6 @@ Resources:
 
   SchedulingPolicy:
     Type: AWS::Batch::SchedulingPolicy
-    Properties:
-      FairsharePolicy:
-        ShareDistribution:
-          - ShareIdentifier: default
 
   BatchJobQueue:
     Type: AWS::Batch::JobQueue

--- a/apps/step-function.json.j2
+++ b/apps/step-function.json.j2
@@ -107,6 +107,12 @@
       "Retry": [
         {
           "ErrorEquals": [
+            "Batch.ServerException"
+          ],
+          "MaxAttempts": 2
+        },
+        {
+          "ErrorEquals": [
             "States.ALL"
           ],
           "MaxAttempts": 0


### PR DESCRIPTION
Step Function error handling is documented at https://states-language.net/spec.html#errors

This is intended to resolve intermittent `TaskSubmitFailed` errors introduced by https://github.com/ASFHyP3/hyp3/pull/790 , but should have the added advantage of retrying other intermittent failures when the Step Function interacts with the Batch SubmitJob API.
```
{
  "resourceType": "batch",
  "resource": "submitJob.sync",
  "error": "Batch.ServerException",
  "cause": "Failed to create shareIdentifier default (Service: AWSBatch; Status Code: 500; Error Code: ServerException; Request ID: 2bbaad70-481a-475e-b07b-a21477f85e0f; Proxy: null)"
}
```