### PR TITLE
increase size of autoscaling fleets in earthdata cloud environments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,9 +54,9 @@ jobs:
             quota: 250
             deploy_ref: refs/heads/main
             job_files: job_spec/AUTORIFT.yml job_spec/INSAR_GAMMA.yml job_spec/RTC_GAMMA.yml
-            default_max_vcpus: 60
-            expanded_max_vcpus: 60
-            required_surplus: 0
+            default_max_vcpus: 600
+            expanded_max_vcpus: 1600
+            required_surplus: 1000
             security_environment: EDC
             ami_id: image_id_ecs_amz2
 
@@ -68,9 +68,9 @@ jobs:
             quota: 250
             deploy_ref: refs/heads/develop
             job_files: job_spec/AUTORIFT.yml job_spec/INSAR_GAMMA.yml job_spec/RTC_GAMMA.yml
-            default_max_vcpus: 60
-            expanded_max_vcpus: 60
-            required_surplus: 0
+            default_max_vcpus: 600
+            expanded_max_vcpus: 1600
+            required_surplus: 1000
             security_environment: EDC
             ami_id: image_id_ecs_amz2
 


### PR DESCRIPTION
Increasing default and maximum sizes of autoscaling fleets in EDC UAT and EDC Prod to match their non-EDC counterparts now that NASD-2782 is complete.