### PR TITLE
Temporarily commenting out deployments with active processing campaigns

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,10 +35,10 @@ jobs:
             quota: 1000
             deploy_ref: refs/heads/develop
             job_files: >-
-              job_spec/AUTORIFT.yml 
-              job_spec/INSAR_GAMMA.yml 
-              job_spec/RTC_GAMMA.yml 
-              job_spec/INSAR_ISCE.yml   
+              job_spec/AUTORIFT.yml
+              job_spec/INSAR_GAMMA.yml
+              job_spec/RTC_GAMMA.yml
+              job_spec/INSAR_ISCE.yml
               job_spec/WATER_MAP.yml
             default_max_vcpus: 600
             expanded_max_vcpus: 1600
@@ -74,19 +74,19 @@ jobs:
             security_environment: EDC
             ami_id: image_id_ecs_amz2
 
-          - environment: hyp3-its-live
-            domain: hyp3-its-live.asf.alaska.edu
-            template_bucket: cf-templates-3o5lnspmwmzg-us-west-2
-            image_tag: latest
-            product_lifetime_in_days: 180
-            quota: 0
-            deploy_ref: refs/heads/main
-            job_files: job_spec/AUTORIFT_ITS_LIVE.yml
-            default_max_vcpus: 1600
-            expanded_max_vcpus: 1600
-            required_surplus: 0
-            security_environment: JPL
-            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+          #- environment: hyp3-its-live
+          #  domain: hyp3-its-live.asf.alaska.edu
+          #  template_bucket: cf-templates-3o5lnspmwmzg-us-west-2
+          #  image_tag: latest
+          #  product_lifetime_in_days: 180
+          #  quota: 0
+          #  deploy_ref: refs/heads/main
+          #  job_files: job_spec/AUTORIFT_ITS_LIVE.yml
+          #  default_max_vcpus: 1600
+          #  expanded_max_vcpus: 1600
+          #  required_surplus: 0
+          #  security_environment: JPL
+          #  ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
 
           - environment: hyp3-autorift
             domain: hyp3-autorift.asf.alaska.edu
@@ -116,33 +116,33 @@ jobs:
             security_environment: ASF
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
 
-          - environment: hyp3-isce
-            domain: hyp3-isce.asf.alaska.edu
-            template_bucket: cf-templates-t790khv4btdq-us-west-2
-            image_tag: latest
-            product_lifetime_in_days: 180
-            quota: 0
-            deploy_ref: refs/heads/main
-            job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
-            default_max_vcpus: 1600
-            expanded_max_vcpus: 1600
-            required_surplus: 0
-            security_environment: ASF
-            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+          #- environment: hyp3-isce
+          #  domain: hyp3-isce.asf.alaska.edu
+          #  template_bucket: cf-templates-t790khv4btdq-us-west-2
+          #  image_tag: latest
+          #  product_lifetime_in_days: 180
+          #  quota: 0
+          #  deploy_ref: refs/heads/main
+          #  job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
+          #  default_max_vcpus: 1600
+          #  expanded_max_vcpus: 1600
+          #  required_surplus: 0
+          #  security_environment: ASF
+          #  ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
 
-          - environment: hyp3-tibet
-            domain: hyp3-tibet.asf.alaska.edu
-            template_bucket: cf-templates-ejaipnrxq7xg-us-west-2
-            image_tag: latest
-            product_lifetime_in_days: 180
-            quota: 0
-            deploy_ref: refs/heads/main
-            job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
-            default_max_vcpus: 1600
-            expanded_max_vcpus: 1600
-            required_surplus: 0
-            security_environment: ASF
-            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+          #- environment: hyp3-tibet
+          #  domain: hyp3-tibet.asf.alaska.edu
+          #  template_bucket: cf-templates-ejaipnrxq7xg-us-west-2
+          #  image_tag: latest
+          #  product_lifetime_in_days: 180
+          #  quota: 0
+          #  deploy_ref: refs/heads/main
+          #  job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
+          #  default_max_vcpus: 1600
+          #  expanded_max_vcpus: 1600
+          #  required_surplus: 0
+          #  security_environment: ASF
+          #  ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
 
     environment:
       name: ${{ matrix.environment }}


### PR DESCRIPTION
This is a stop-gap measure until we put processes in place to manage releases/deployments w/out stepping on active processing campaigns. 