### PR TITLE
convert float values to Decimals in dynamo.jobs.update_job

### DIFF
--- a/lib/dynamo/dynamo/jobs.py
+++ b/lib/dynamo/dynamo/jobs.py
@@ -115,8 +115,11 @@ def update_job(job):
     table = DYNAMODB_RESOURCE.Table(environ['JOBS_TABLE_NAME'])
     primary_key = 'job_id'
     key = {'job_id': job[primary_key]}
-    update_expression = 'SET {}'.format(','.join(f'{k}=:{k}' for k in job if k != primary_key))
-    expression_attribute_values = {f':{k}': v for k, v in job.items() if k != primary_key}
+
+    prepared_job = convert_floats_to_decimals(job)
+    update_expression = 'SET {}'.format(','.join(f'{k}=:{k}' for k in prepared_job if k != primary_key))
+    expression_attribute_values = {f':{k}': v for k, v in prepared_job.items() if k != primary_key}
+
     table.update_item(
         Key=key,
         UpdateExpression=update_expression,

--- a/tests/test_dynamo/test_jobs.py
+++ b/tests/test_dynamo/test_jobs.py
@@ -426,7 +426,7 @@ def test_update_job(tables):
     for item in table_items:
         tables.jobs_table.put_item(Item=item)
 
-    job = {'job_id': 'job1', 'status_code': 'status2'}
+    job = {'job_id': 'job1', 'status_code': 'status2', 'processing_time_in_seconds': 1.23}
     dynamo.jobs.update_job(job)
 
     response = tables.jobs_table.scan()
@@ -437,6 +437,7 @@ def test_update_job(tables):
             'user_id': 'user1',
             'status_code': 'status2',
             'request_time': '2000-01-01T00:00:00+00:00',
+            'processing_time_in_seconds': Decimal('1.23'),
         },
     ]
     assert response['Items'] == expected_response


### PR DESCRIPTION
DynamoDB doesn't support the `float` data type in Python; any data values of type `Number` in dynamodb should be of type `Decimal` in python.

We correctly convert any float values to decimals before inserting them into the database in dynamo.jobs.put_jobs: https://github.com/ASFHyP3/hyp3/blob/dbd9c7703525ed1c01faa4e3fc51055ed7fe3c05/lib/dynamo/dynamo/jobs.py#L52

but we'd missed doing the necessary conversion in dynamo.jobs.update_job.
