### PR TITLE
Reorganize deployments

### DIFF
--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -1,4 +1,4 @@
-name: Deploy to AWS
+name: Deploy DAAC Stacks to AWS
 
 on:
   push:
@@ -73,62 +73,6 @@ jobs:
             required_surplus: 1000
             security_environment: EDC
             ami_id: image_id_ecs_amz2
-
-          #- environment: hyp3-its-live
-          #  domain: hyp3-its-live.asf.alaska.edu
-          #  template_bucket: cf-templates-3o5lnspmwmzg-us-west-2
-          #  image_tag: latest
-          #  product_lifetime_in_days: 180
-          #  quota: 0
-          #  deploy_ref: refs/heads/main
-          #  job_files: job_spec/AUTORIFT_ITS_LIVE.yml
-          #  default_max_vcpus: 1600
-          #  expanded_max_vcpus: 1600
-          #  required_surplus: 0
-          #  security_environment: JPL
-          #  ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
-
-          - environment: hyp3-autorift-eu
-            domain: hyp3-autorift-eu.asf.alaska.edu
-            template_bucket: cf-templates-autorift-eu-central-1
-            image_tag: latest
-            product_lifetime_in_days: 180
-            quota: 0
-            deploy_ref: refs/heads/main
-            job_files: job_spec/AUTORIFT_ITS_LIVE_EU.yml
-            default_max_vcpus: 1600
-            expanded_max_vcpus: 1600
-            required_surplus: 0
-            security_environment: ASF
-            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
-
-          #- environment: hyp3-isce
-          #  domain: hyp3-isce.asf.alaska.edu
-          #  template_bucket: cf-templates-t790khv4btdq-us-west-2
-          #  image_tag: latest
-          #  product_lifetime_in_days: 180
-          #  quota: 0
-          #  deploy_ref: refs/heads/main
-          #  job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
-          #  default_max_vcpus: 1600
-          #  expanded_max_vcpus: 1600
-          #  required_surplus: 0
-          #  security_environment: ASF
-          #  ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
-
-          #- environment: hyp3-tibet
-          #  domain: hyp3-tibet.asf.alaska.edu
-          #  template_bucket: cf-templates-ejaipnrxq7xg-us-west-2
-          #  image_tag: latest
-          #  product_lifetime_in_days: 180
-          #  quota: 0
-          #  deploy_ref: refs/heads/main
-          #  job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
-          #  default_max_vcpus: 1600
-          #  expanded_max_vcpus: 1600
-          #  required_surplus: 0
-          #  security_environment: ASF
-          #  ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
 
     environment:
       name: ${{ matrix.environment }}

--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -1,0 +1,107 @@
+name: Deploy Enterprize Stacks to AWS
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - environment: hyp3-its-live
+            domain: hyp3-its-live.asf.alaska.edu
+            template_bucket: cf-templates-3o5lnspmwmzg-us-west-2
+            image_tag: latest
+            product_lifetime_in_days: 180
+            quota: 0
+            job_files: job_spec/AUTORIFT_ITS_LIVE.yml
+            default_max_vcpus: 2640
+            expanded_max_vcpus: 2640
+            required_surplus: 0
+            security_environment: JPL
+            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+
+          - environment: hyp3-autorift-eu
+            domain: hyp3-autorift-eu.asf.alaska.edu
+            template_bucket: cf-templates-autorift-eu-central-1
+            image_tag: latest
+            product_lifetime_in_days: 180
+            quota: 0
+            job_files: job_spec/AUTORIFT_ITS_LIVE_EU.yml
+            default_max_vcpus: 1600
+            expanded_max_vcpus: 1600
+            required_surplus: 0
+            security_environment: ASF
+            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+
+          - environment: hyp3-isce
+            domain: hyp3-isce.asf.alaska.edu
+            template_bucket: cf-templates-t790khv4btdq-us-west-2
+            image_tag: latest
+            product_lifetime_in_days: 180
+            quota: 0
+            job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
+            default_max_vcpus: 1600
+            expanded_max_vcpus: 1600
+            required_surplus: 0
+            security_environment: ASF
+            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+
+          - environment: hyp3-tibet
+            domain: hyp3-tibet.asf.alaska.edu
+            template_bucket: cf-templates-ejaipnrxq7xg-us-west-2
+            image_tag: latest
+            product_lifetime_in_days: 180
+            quota: 0
+            job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
+            default_max_vcpus: 1600
+            expanded_max_vcpus: 1600
+            required_surplus: 0
+            security_environment: ASF
+            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+
+    environment:
+      name: ${{ matrix.environment }}
+      url: https://${{ matrix.domain }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.V2_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.V2_AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.V2_AWS_SESSION_TOKEN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - uses: ./.github/actions/deploy-hyp3
+        with:
+          TEMPLATE_BUCKET:  ${{ matrix.template_bucket }}
+          STACK_NAME: ${{ matrix.environment }}
+          DOMAIN_NAME: ${{ matrix.domain }}
+          CERTIFICATE_ARN:  ${{ secrets.CERTIFICATE_ARN }}
+          IMAGE_TAG: ${{ matrix.image_tag }}
+          PRODUCT_LIFETIME: ${{ matrix.product_lifetime_in_days }}
+          VPC_ID: ${{ secrets.VPC_ID }}
+          SUBNET_IDS: ${{ secrets.SUBNET_IDS }}
+          EDL_USERNAME: ${{ secrets.EDL_USERNAME }}
+          EDL_PASSWORD: ${{ secrets.EDL_PASSWORD }}
+          CLOUDFORMATION_ROLE_ARN: ${{ secrets.CLOUDFORMATION_ROLE_ARN }}
+          MONTHLY_JOB_QUOTA_PER_USER: ${{ matrix.quota }}
+          JOB_FILES: ${{ matrix.job_files }}
+          BANNED_CIDR_BLOCKS: ${{ secrets.BANNED_CIDR_BLOCKS }}
+          DEFAULT_MAX_VCPUS: ${{ matrix.default_max_vcpus }}
+          EXPANDED_MAX_VCPUS: ${{ matrix.expanded_max_vcpus }}
+          MONTHLY_COMPUTE_BUDGET: ${{ secrets.MONTHLY_COMPUTE_BUDGET }}
+          REQUIRED_SURPLUS: ${{ matrix.required_surplus }}
+          PERMISSIONS_BOUNDARY_ARN: ${{ secrets.PERMISSIONS_BOUNDARY_ARN }}
+          SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
+          AMI_ID: ${{ matrix.ami_id }}

--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -1,4 +1,4 @@
-name: Deploy Enterprize Stacks to AWS
+name: Deploy Enterprise Stacks to AWS
 
 on:
   push:


### PR DESCRIPTION
We've seen a divergence of the pace at which we'd like to update deployments. 

* For our DAAC deployments, we tend to develop rapidly and want to release frequently to quickly bring improvements to users
* For our Enterprise deployment, we tend to have active processing campaigns that might get clobbered by a new deployment, so we want to deploy improvements between large processing efforts

This:
* Separates out all Enterprise deployments to a `deploy-enterprise.yml` workflow, which only runs on merges to `main`
* Renames `deploy.yml` to `deploy-daac.yml`
* bumps the ITS_LIVE deployment to use all currently available vCPUs for Batch

Separately, I've 
* added an environment protection rule to the enterprise deployments, which will require manual approvals of deployments before deploying (GitHub will notify and action will wait for approval before running. After one month, if approval hasn't been granted, action will fail.) 
![image](https://user-images.githubusercontent.com/7882693/154333185-afb2890d-f504-4076-b3b4-3a3b5b54cb58.png)

* created a @ASFHyP3/enterprise-operations team (me only, for now) that will be requested to approve deployments

This will allow use to deploy at will, without risk of clobbering active campaigns. But does add a manual review step to deploy our enterprise stacks. 

