### PR TITLE
Differentiate JPL security environments

### DIFF
--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -22,7 +22,7 @@ jobs:
             default_max_vcpus: 2640
             expanded_max_vcpus: 2640
             required_surplus: 0
-            security_environment: JPL
+            security_environment: JPL-public
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
 
           - environment: hyp3-autorift-eu

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        security_environment: [ASF, EDC, JPL]
+        security_environment: [ASF, EDC, JPL, JPL-public]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.11.1]
+### Added
+- A `JPL-public` security environment when rendering CloudFormation templates which will
+  deploy a public bucket policy. To use this environment, the AWS S3 account level Block All Public Access
+  setting must have been turned off by the JPL Cloud team.
+
+### Fixed
+- The `JPL` security environment, when rendering CloudFormation templates, will no longer
+  deploy a public bucket policy as this is disallowed by default for JPL commercial cloud accounts.
+
 ## [2.11.0]
 ### Changed
 - The HyP3 API is now implemented as an API Gateway REST API, supporting private API deployments.

--- a/apps/api/api-cf.yml.j2
+++ b/apps/api/api-cf.yml.j2
@@ -134,9 +134,9 @@ Resources:
       RetentionInDays: 90
 
   LambdaRole:
-    Type: {{ 'Custom::JplRole' if security_environment == 'JPL' else 'AWS::IAM::Role' }}
+    Type: {{ 'Custom::JplRole' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::Role' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplRole::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}
@@ -157,9 +157,9 @@ Resources:
         - !Ref LambdaPolicy
 
   LambdaPolicy:
-    Type: {{ 'Custom::JplPolicy' if security_environment == 'JPL' else 'AWS::IAM::ManagedPolicy' }}
+    Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplPolicy::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}

--- a/apps/check-processing-time/check-processing-time-cf.yml.j2
+++ b/apps/check-processing-time/check-processing-time-cf.yml.j2
@@ -31,9 +31,9 @@ Resources:
       RetentionInDays: 90
 
   Role:
-    Type: {{ 'Custom::JplRole' if security_environment == 'JPL' else 'AWS::IAM::Role' }}
+    Type: {{ 'Custom::JplRole' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::Role' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplRole::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}
@@ -50,9 +50,9 @@ Resources:
         - !Ref Policy
 
   Policy:
-    Type: {{ 'Custom::JplPolicy' if security_environment == 'JPL' else 'AWS::IAM::ManagedPolicy' }}
+    Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplPolicy::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}

--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -100,9 +100,9 @@ Resources:
       SchedulingPolicyArn: !Ref SchedulingPolicy
 
   TaskRole:
-    Type: {{ 'Custom::JplRole' if security_environment == 'JPL' else 'AWS::IAM::Role' }}
+    Type: {{ 'Custom::JplRole' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::Role' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplRole::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}
@@ -119,9 +119,9 @@ Resources:
         - !Ref TaskPolicy
 
   TaskPolicy:
-    Type: {{ 'Custom::JplPolicy' if security_environment == 'JPL' else 'AWS::IAM::ManagedPolicy' }}
+    Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplPolicy::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}
@@ -136,9 +136,9 @@ Resources:
             Resource: !Sub "arn:aws:s3:::${ContentBucket}/*"
 
   BatchServiceRole:
-    Type: {{ 'Custom::JplRole' if security_environment == 'JPL' else 'AWS::IAM::Role' }}
+    Type: {{ 'Custom::JplRole' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::Role' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplRole::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}
@@ -154,9 +154,9 @@ Resources:
         - arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole
 
   InstanceRole:
-    Type: {{ 'Custom::JplRole' if security_environment == 'JPL' else 'AWS::IAM::Role' }}
+    Type: {{ 'Custom::JplRole' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::Role' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplRole::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}
@@ -174,7 +174,7 @@ Resources:
   InstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       Path: /account-managed/hyp3/
       {% endif %}
       Roles:

--- a/apps/get-files/get-files-cf.yml.j2
+++ b/apps/get-files/get-files-cf.yml.j2
@@ -34,9 +34,9 @@ Resources:
       RetentionInDays: 90
 
   Role:
-    Type: {{ 'Custom::JplRole' if security_environment == 'JPL' else 'AWS::IAM::Role' }}
+    Type: {{ 'Custom::JplRole' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::Role' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplRole::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}
@@ -53,9 +53,9 @@ Resources:
         - !Ref Policy
 
   Policy:
-    Type: {{ 'Custom::JplPolicy' if security_environment == 'JPL' else 'AWS::IAM::ManagedPolicy' }}
+    Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplPolicy::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}

--- a/apps/main-cf.yml.j2
+++ b/apps/main-cf.yml.j2
@@ -245,7 +245,7 @@ Resources:
             AllowedOrigins:
               - "*.asf.alaska.edu"
 
-  {% if security_environment != 'EDC' %}
+  {% if security_environment in ('ASF', 'JPL-public') %}
   BucketPolicy:
     Type: AWS::S3::BucketPolicy
     Properties:

--- a/apps/process-new-granules/process-new-granules-cf.yml.j2
+++ b/apps/process-new-granules/process-new-granules-cf.yml.j2
@@ -43,9 +43,9 @@ Resources:
       RetentionInDays: 90
 
   Role:
-    Type: {{ 'Custom::JplRole' if security_environment == 'JPL' else 'AWS::IAM::Role' }}
+    Type: {{ 'Custom::JplRole' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::Role' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplRole::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}
@@ -62,9 +62,9 @@ Resources:
         - !Ref Policy
 
   Policy:
-    Type: {{ 'Custom::JplPolicy' if security_environment == 'JPL' else 'AWS::IAM::ManagedPolicy' }}
+    Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplPolicy::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}

--- a/apps/render_cf.py
+++ b/apps/render_cf.py
@@ -37,7 +37,7 @@ def render_templates(job_types, security_environment):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('job_spec_files', nargs='+', type=Path)
-    parser.add_argument('-s', '--security-environment', default='ASF', choices=['ASF', 'EDC', 'JPL'])
+    parser.add_argument('-s', '--security-environment', default='ASF', choices=['ASF', 'EDC', 'JPL', 'JPL-public'])
     args = parser.parse_args()
 
     job_types = {}

--- a/apps/scale-cluster/scale-cluster-cf.yml.j2
+++ b/apps/scale-cluster/scale-cluster-cf.yml.j2
@@ -45,9 +45,9 @@ Resources:
       RetentionInDays: 90
 
   Role:
-    Type: {{ 'Custom::JplRole' if security_environment == 'JPL' else 'AWS::IAM::Role' }}
+    Type: {{ 'Custom::JplRole' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::Role' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplRole::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}
@@ -64,9 +64,9 @@ Resources:
         - !Ref Policy
 
   Policy:
-    Type: {{ 'Custom::JplPolicy' if security_environment == 'JPL' else 'AWS::IAM::ManagedPolicy' }}
+    Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplPolicy::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}

--- a/apps/start-execution/start-execution-cf.yml.j2
+++ b/apps/start-execution/start-execution-cf.yml.j2
@@ -32,9 +32,9 @@ Resources:
       RetentionInDays: 90
 
   Role:
-    Type: {{ 'Custom::JplRole' if security_environment == 'JPL' else 'AWS::IAM::Role' }}
+    Type: {{ 'Custom::JplRole' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::Role' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplRole::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}
@@ -51,9 +51,9 @@ Resources:
         - !Ref Policy
 
   Policy:
-    Type: {{ 'Custom::JplPolicy' if security_environment == 'JPL' else 'AWS::IAM::ManagedPolicy' }}
+    Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplPolicy::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}

--- a/apps/update-db/update-db-cf.yml.j2
+++ b/apps/update-db/update-db-cf.yml.j2
@@ -34,9 +34,9 @@ Resources:
       RetentionInDays: 90
 
   Role:
-    Type: {{ 'Custom::JplRole' if security_environment == 'JPL' else 'AWS::IAM::Role' }}
+    Type: {{ 'Custom::JplRole' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::Role' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplRole::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}
@@ -53,9 +53,9 @@ Resources:
         - !Ref Policy
 
   Policy:
-    Type: {{ 'Custom::JplPolicy' if security_environment == 'JPL' else 'AWS::IAM::ManagedPolicy' }}
+    Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplPolicy::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}

--- a/apps/upload-log/upload-log-cf.yml.j2
+++ b/apps/upload-log/upload-log-cf.yml.j2
@@ -34,9 +34,9 @@ Resources:
       RetentionInDays: 90
 
   Role:
-    Type: {{ 'Custom::JplRole' if security_environment == 'JPL' else 'AWS::IAM::Role' }}
+    Type: {{ 'Custom::JplRole' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::Role' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplRole::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}
@@ -53,9 +53,9 @@ Resources:
         - !Ref Policy
 
   Policy:
-    Type: {{ 'Custom::JplPolicy' if security_environment == 'JPL' else 'AWS::IAM::ManagedPolicy' }}
+    Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplPolicy::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}

--- a/apps/workflow-cf.yml.j2
+++ b/apps/workflow-cf.yml.j2
@@ -90,9 +90,9 @@ Resources:
         UploadLogLambdaArn: !GetAtt UploadLog.Outputs.LambdaArn
 
   StepFunctionRole:
-    Type: {{ 'Custom::JplRole' if security_environment == 'JPL' else 'AWS::IAM::Role' }}
+    Type: {{ 'Custom::JplRole' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::Role' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplRole::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}
@@ -108,9 +108,9 @@ Resources:
         - !Ref StepFunctionPolicy
 
   StepFunctionPolicy:
-    Type: {{ 'Custom::JplPolicy' if security_environment == 'JPL' else 'AWS::IAM::ManagedPolicy' }}
+    Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplPolicy::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}
@@ -189,9 +189,9 @@ Resources:
       TemplateURL: upload-log/upload-log-cf.yml
 
   ExecutionRole:
-    Type: {{ 'Custom::JplRole' if security_environment == 'JPL' else 'AWS::IAM::Role' }}
+    Type: {{ 'Custom::JplRole' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::Role' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplRole::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}
@@ -208,9 +208,9 @@ Resources:
         - !Ref ExecutionPolicy
 
   ExecutionPolicy:
-    Type: {{ 'Custom::JplPolicy' if security_environment == 'JPL' else 'AWS::IAM::ManagedPolicy' }}
+    Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}
     Properties:
-      {% if security_environment == 'JPL' %}
+      {% if security_environment in ('JPL', 'JPL-public') %}
       ServiceToken: !ImportValue Custom::JplPolicy::ServiceToken
       Path: /account-managed/hyp3/
       {% endif %}

--- a/docs/deployments/JPL-deployment.md
+++ b/docs/deployments/JPL-deployment.md
@@ -50,7 +50,7 @@ export AWS_ACCESS_KEY_ID=<service-user-access-key-id>
 export AWS_SECRET_ACCESS_KEY=<service-user-secret-access-key>
 export AWS_REGION=<deployment-region>
 
-make files=<supported-job-spec-files> build
+make files=<supported-job-spec-files> security_environment=JPL build
 
 aws cloudformation package \
     --template-file apps/main-cf.yml \


### PR DESCRIPTION
JPL by default disallows public buckets in accounts via the account wide S3 Block All Public Access settings. With some effort, Block All Public Access can be disabled by the JPL Cloud team at the account level which allows deployment of public buckets. 

This 
* changes the `JPL` security environment to *not* add a public bucket policy to the HyP3 content bucket
* Adds a `JPL-public` secuirt environment that *will* add a public bucket policy to the HyP3 content bucket 

