### PR TITLE
Custom instance sizes

### DIFF
--- a/.github/actions/deploy-hyp3/action.yml
+++ b/.github/actions/deploy-hyp3/action.yml
@@ -65,6 +65,9 @@ inputs:
   AMI_ID:
     description: "Name of the Systems Manager parameter from which to retrieve the current Ami Id"
     required: true
+  INSTANCE_SIZES:
+    description: "Space separated list of supported instance sizes"
+    required: true
 
 runs:
   using: "composite"
@@ -74,7 +77,7 @@ runs:
         run: |
           pip install --upgrade pip
           make install
-          make files='${{ inputs.JOB_FILES }}' security_environment='${{ inputs.SECURITY_ENVIRONMENT }}' build
+          make files='${{ inputs.JOB_FILES }}' security_environment='${{ inputs.SECURITY_ENVIRONMENT }}' instance_sizes='${{ inputs.instance_sizes }}' build
       - name: Package and deploy
         shell: bash
         run: |

--- a/.github/actions/deploy-hyp3/action.yml
+++ b/.github/actions/deploy-hyp3/action.yml
@@ -65,8 +65,8 @@ inputs:
   AMI_ID:
     description: "Name of the Systems Manager parameter from which to retrieve the current Ami Id"
     required: true
-  INSTANCE_SIZES:
-    description: "Space separated list of supported instance sizes"
+  INSTANCE_TYPES:
+    description: "Space separated list of supported instance types"
     required: true
 
 runs:
@@ -77,7 +77,7 @@ runs:
         run: |
           pip install --upgrade pip
           make install
-          make files='${{ inputs.JOB_FILES }}' security_environment='${{ inputs.SECURITY_ENVIRONMENT }}' instance_sizes='${{ inputs.instance_sizes }}' build
+          make files='${{ inputs.JOB_FILES }}' security_environment='${{ inputs.SECURITY_ENVIRONMENT }}' instance_types='${{ inputs.INSTANCE_TYPES }}' build
       - name: Package and deploy
         shell: bash
         run: |

--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -26,6 +26,7 @@ jobs:
             required_surplus: 1000
             security_environment: ASF
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+            instance_types: r5d.xlarge
 
           - environment: hyp3-test
             domain: hyp3-test-api.asf.alaska.edu
@@ -45,6 +46,7 @@ jobs:
             required_surplus: 1000
             security_environment: ASF
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+            instance_types: r5d.xlarge
 
           - environment: hyp3-edc-prod
             domain: ''
@@ -59,6 +61,7 @@ jobs:
             required_surplus: 1000
             security_environment: EDC
             ami_id: image_id_ecs_amz2
+            instance_types: r5d.xlarge
 
           - environment: hyp3-edc-uat
             domain: ''
@@ -73,6 +76,7 @@ jobs:
             required_surplus: 1000
             security_environment: EDC
             ami_id: image_id_ecs_amz2
+            instance_types: r5d.xlarge
 
     environment:
       name: ${{ matrix.environment }}
@@ -116,6 +120,7 @@ jobs:
           PERMISSIONS_BOUNDARY_ARN: ${{ secrets.PERMISSIONS_BOUNDARY_ARN }}
           SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
           AMI_ID: ${{ matrix.ami_id }}
+          INSTANCE_TYPES: ${{ matrix.instance_types }}
 
   call-bump-version-workflow:
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -46,7 +46,9 @@ jobs:
             required_surplus: 1000
             security_environment: ASF
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
-            instance_types: r5d.xlarge
+            instance_types: >-
+              r5d.xlarge
+              r5dn.xlarge
 
           - environment: hyp3-edc-prod
             domain: ''

--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -24,7 +24,9 @@ jobs:
             required_surplus: 0
             security_environment: JPL
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
-            instance_types: r5d.xlarge
+            instance_types: >-
+              r5d.xlarge
+              r5dn.xlarge
 
           - environment: hyp3-autorift-eu
             domain: hyp3-autorift-eu.asf.alaska.edu

--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -24,6 +24,7 @@ jobs:
             required_surplus: 0
             security_environment: JPL
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+            instance_types: r5d.xlarge
 
           - environment: hyp3-autorift-eu
             domain: hyp3-autorift-eu.asf.alaska.edu
@@ -37,6 +38,7 @@ jobs:
             required_surplus: 0
             security_environment: ASF
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+            instance_types: r5d.xlarge
 
           - environment: hyp3-isce
             domain: hyp3-isce.asf.alaska.edu
@@ -50,6 +52,7 @@ jobs:
             required_surplus: 0
             security_environment: ASF
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+            instance_types: r5d.xlarge
 
           - environment: hyp3-tibet
             domain: hyp3-tibet.asf.alaska.edu
@@ -63,6 +66,7 @@ jobs:
             required_surplus: 0
             security_environment: ASF
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+            instance_types: r5d.xlarge
 
           - environment: hyp3-a19-jpl
             domain: hyp3-a19-jpl.asf.alaska.edu
@@ -76,6 +80,7 @@ jobs:
             required_surplus: 0
             security_environment: JPL
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+            instance_types: r5d.xlarge
 
     environment:
       name: ${{ matrix.environment }}
@@ -118,3 +123,4 @@ jobs:
           PERMISSIONS_BOUNDARY_ARN: ${{ secrets.PERMISSIONS_BOUNDARY_ARN }}
           SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
           AMI_ID: ${{ matrix.ami_id }}
+          INSTANCE_TYPES: ${{ matrix.instance_types }}

--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -52,7 +52,7 @@ jobs:
             required_surplus: 0
             security_environment: ASF
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
-            instance_types: r5d.xlarge
+            instance_types: c5d.xlarge
 
           - environment: hyp3-tibet
             domain: hyp3-tibet.asf.alaska.edu
@@ -66,7 +66,7 @@ jobs:
             required_surplus: 0
             security_environment: ASF
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
-            instance_types: r5d.xlarge
+            instance_types: c5d.xlarge
 
           - environment: hyp3-a19-jpl
             domain: hyp3-a19-jpl.asf.alaska.edu
@@ -80,7 +80,7 @@ jobs:
             required_surplus: 0
             security_environment: JPL
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
-            instance_types: r5d.xlarge
+            instance_types: c5d.xlarge
 
     environment:
       name: ${{ matrix.environment }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         security_environment: [ASF, EDC, JPL]
-        instance_sizes: ['r5d.xlarge', 'r5d.xlarge cd.large']
+        instance_types: ['r5d.xlarge', 'r5d.xlarge c5d.large']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
@@ -33,7 +33,7 @@ jobs:
           make install
 
       - run: |
-          make security_environment=${{ matrix.security_environment }} instance_sizes=${{ matrix.instance_sizes }} cfn-lint
+          make security_environment=${{ matrix.security_environment }} instance_types='${{ matrix.instance_types }}' cfn-lint
 
   openapi-spec-validator:
     runs-on: ubuntu-latest

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -22,6 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         security_environment: [ASF, EDC, JPL]
+        instance_sizes: ['r5d.xlarge', 'r5d.xlarge cd.large']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v1
@@ -32,7 +33,7 @@ jobs:
           make install
 
       - run: |
-          make security_environment=${{ matrix.security_environment }} cfn-lint
+          make security_environment=${{ matrix.security_environment }} instance_sizes=${{ matrix.instance_sizes }} cfn-lint
 
   openapi-spec-validator:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.12.0]
+### Added
+- Instance types available to the compute environment is configurable when rendering CloudFormation templates
+  via the `--instance-types` argument to [`render_cf.py`](apps/render_cf.py).
+
+### Changed
+- The `job_spec_files` positional argument to [`render_cf.py`](apps/render_cf.py) has been switched to a
+  required `--job-spec-files` optional argument to support multiple open-ended arguments.
+
+
 ## [2.11.0]
 ### Changed
 - The HyP3 API is now implemented as an API Gateway REST API, supporting private API deployments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `job_spec_files` positional argument to [`render_cf.py`](apps/render_cf.py) has been switched to a
   required `--job-spec-files` optional argument to support multiple open-ended arguments.
 
-
 ## [2.11.0]
 ### Changed
 - The HyP3 API is now implemented as an API Gateway REST API, supporting private API deployments.

--- a/Makefile
+++ b/Makefile
@@ -30,8 +30,9 @@ install:
 
 files ?= job_spec/*.yml
 security_environment ?= ASF
+instance_sizes ?= rd5.xlarge
 render:
-	@echo rendering $(files) for $(security_environment); python apps/render_cf.py $(files) -s $(security_environment)
+	@echo rendering $(files) for $(security_environment); python apps/render_cf.py -j $(files) -s $(security_environment) -i $(instance_sizes)
 
 static: flake8 openapi-validate cfn-lint
 

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,9 @@ install:
 
 files ?= job_spec/*.yml
 security_environment ?= ASF
-instance_sizes ?= rd5.xlarge
+instance_types ?= rd5.xlarge
 render:
-	@echo rendering $(files) for $(security_environment); python apps/render_cf.py -j $(files) -s $(security_environment) -i $(instance_sizes)
+	@echo rendering $(files) for $(security_environment); python apps/render_cf.py -j $(files) -s $(security_environment) -i $(instance_types)
 
 static: flake8 openapi-validate cfn-lint
 

--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -75,8 +75,8 @@ Resources:
         MinvCpus: 0
         MaxvCpus: !Ref MaxvCpus
         InstanceTypes:
-          {% for instance_size in instance_sizes %}
-          - {{ instance_size }}
+          {% for instance_type in instance_types %}
+          - {{ instance_type }}
           {% endfor %}
         ImageId: !Ref AmiId
         Subnets: !Ref SubnetIds

--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -75,7 +75,9 @@ Resources:
         MinvCpus: 0
         MaxvCpus: !Ref MaxvCpus
         InstanceTypes:
-          - r5d.xlarge
+          {% for instance_size in instance_sizes %}
+          - {{ instance_size }}
+          {% endfor %}
         ImageId: !Ref AmiId
         Subnets: !Ref SubnetIds
         InstanceRole: !Ref InstanceProfile

--- a/apps/render_cf.py
+++ b/apps/render_cf.py
@@ -11,7 +11,7 @@ def snake_to_pascal_case(input_string: str):
     return ''.join([i.title() for i in split_string])
 
 
-def render_templates(job_types, security_environment, instance_sizes):
+def render_templates(job_types, security_environment, instance_types):
     env = jinja2.Environment(
         loader=jinja2.FileSystemLoader('./'),
         autoescape=jinja2.select_autoescape(default=True, disabled_extensions=('j2',)),
@@ -27,7 +27,7 @@ def render_templates(job_types, security_environment, instance_sizes):
         output = template.render(
             job_types=job_types,
             security_environment=security_environment,
-            instance_sizes=instance_sizes,
+            instance_types=instance_types,
             json=json,
             snake_to_pascal_case=snake_to_pascal_case
         )
@@ -45,7 +45,7 @@ def main():
     job_types = {}
     for file in args.job_spec_files:
         job_types.update(yaml.safe_load(file.read_text()))
-    render_templates(job_types, args.security_environment, args.instance_sizes)
+    render_templates(job_types, args.security_environment, args.instance_types)
 
 
 if __name__ == '__main__':

--- a/apps/render_cf.py
+++ b/apps/render_cf.py
@@ -39,7 +39,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-j', '--job-spec-files', required=True, nargs='+', type=Path)
     parser.add_argument('-s', '--security-environment', default='ASF', choices=['ASF', 'EDC', 'JPL'])
-    parser.add_argument('-i', '--instance-sizes', default=['r5d.xlarge'], nargs='*')
+    parser.add_argument('-i', '--instance-types', default=['r5d.xlarge'], nargs='*')
     args = parser.parse_args()
 
     job_types = {}

--- a/apps/render_cf.py
+++ b/apps/render_cf.py
@@ -11,7 +11,7 @@ def snake_to_pascal_case(input_string: str):
     return ''.join([i.title() for i in split_string])
 
 
-def render_templates(job_types, security_environment):
+def render_templates(job_types, security_environment, instance_sizes):
     env = jinja2.Environment(
         loader=jinja2.FileSystemLoader('./'),
         autoescape=jinja2.select_autoescape(default=True, disabled_extensions=('j2',)),
@@ -27,6 +27,7 @@ def render_templates(job_types, security_environment):
         output = template.render(
             job_types=job_types,
             security_environment=security_environment,
+            instance_sizes=instance_sizes,
             json=json,
             snake_to_pascal_case=snake_to_pascal_case
         )
@@ -36,14 +37,15 @@ def render_templates(job_types, security_environment):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('job_spec_files', nargs='+', type=Path)
+    parser.add_argument('-j', '--job-spec-files', required=True, nargs='+', type=Path)
     parser.add_argument('-s', '--security-environment', default='ASF', choices=['ASF', 'EDC', 'JPL'])
+    parser.add_argument('-i', '--instance-sizes', default=['r5d.xlarge'], nargs='*')
     args = parser.parse_args()
 
     job_types = {}
     for file in args.job_spec_files:
         job_types.update(yaml.safe_load(file.read_text()))
-    render_templates(job_types, args.security_environment)
+    render_templates(job_types, args.security_environment, args.instance_sizes)
 
 
 if __name__ == '__main__':

--- a/apps/workflow-cf.yml.j2
+++ b/apps/workflow-cf.yml.j2
@@ -58,9 +58,9 @@ Resources:
         ExecutionRoleArn: !GetAtt ExecutionRole.Arn
         ResourceRequirements:
           - Type: VCPU
-            Value: "1"
+            Value: "{{ job_spec['vcpu'] }}"
           - Type: MEMORY
-            Value: "31600"
+            Value: "{{ job_spec['memory'] }}"
         Command:
           {% for command in job_spec['command'] %}
           - {{ command }}

--- a/job_spec/AUTORIFT.yml
+++ b/job_spec/AUTORIFT.yml
@@ -53,4 +53,4 @@ AUTORIFT:
   validators: []
   timeout: 10800
   vcpu: 1
-  mememory: 31600
+  memory: 31600

--- a/job_spec/AUTORIFT.yml
+++ b/job_spec/AUTORIFT.yml
@@ -52,3 +52,5 @@ AUTORIFT:
     - Ref::granules
   validators: []
   timeout: 10800
+  vcpu: 1
+  mememory: 31600

--- a/job_spec/AUTORIFT_ITS_LIVE.yml
+++ b/job_spec/AUTORIFT_ITS_LIVE.yml
@@ -53,4 +53,4 @@ AUTORIFT:
   validators: []
   timeout: 10800
   vcpu: 1
-  mememory: 31600
+  memory: 31600

--- a/job_spec/AUTORIFT_ITS_LIVE.yml
+++ b/job_spec/AUTORIFT_ITS_LIVE.yml
@@ -52,3 +52,5 @@ AUTORIFT:
     - Ref::granules
   validators: []
   timeout: 10800
+  vcpu: 1
+  mememory: 31600

--- a/job_spec/AUTORIFT_ITS_LIVE_EU.yml
+++ b/job_spec/AUTORIFT_ITS_LIVE_EU.yml
@@ -53,4 +53,4 @@ AUTORIFT:
   validators: []
   timeout: 10800
   vcpu: 1
-  mememory: 31600
+  memory: 31600

--- a/job_spec/AUTORIFT_ITS_LIVE_EU.yml
+++ b/job_spec/AUTORIFT_ITS_LIVE_EU.yml
@@ -52,3 +52,5 @@ AUTORIFT:
     - Ref::granules
   validators: []
   timeout: 10800
+  vcpu: 1
+  mememory: 31600

--- a/job_spec/INSAR_GAMMA.yml
+++ b/job_spec/INSAR_GAMMA.yml
@@ -91,3 +91,5 @@ INSAR_GAMMA:
   validators:
     - check_dem_coverage
   timeout: 10800
+  vcpu: 1
+  mememory: 31600

--- a/job_spec/INSAR_GAMMA.yml
+++ b/job_spec/INSAR_GAMMA.yml
@@ -92,4 +92,4 @@ INSAR_GAMMA:
     - check_dem_coverage
   timeout: 10800
   vcpu: 1
-  mememory: 31600
+  memory: 31600

--- a/job_spec/INSAR_ISCE.yml
+++ b/job_spec/INSAR_ISCE.yml
@@ -42,4 +42,4 @@ INSAR_ISCE:
   validators: []
   timeout: 10800
   vcpu: 1
-  memory: 31600
+  memory: 7600

--- a/job_spec/INSAR_ISCE.yml
+++ b/job_spec/INSAR_ISCE.yml
@@ -41,3 +41,5 @@ INSAR_ISCE:
     - Ref::secondary_granules
   validators: []
   timeout: 10800
+  vcpu: 1
+  mememory: 31600

--- a/job_spec/INSAR_ISCE.yml
+++ b/job_spec/INSAR_ISCE.yml
@@ -42,4 +42,4 @@ INSAR_ISCE:
   validators: []
   timeout: 10800
   vcpu: 1
-  memory: 7600
+  memory: 7500

--- a/job_spec/INSAR_ISCE.yml
+++ b/job_spec/INSAR_ISCE.yml
@@ -42,4 +42,4 @@ INSAR_ISCE:
   validators: []
   timeout: 10800
   vcpu: 1
-  mememory: 31600
+  memory: 31600

--- a/job_spec/INSAR_ISCE_TEST.yml
+++ b/job_spec/INSAR_ISCE_TEST.yml
@@ -43,4 +43,4 @@ INSAR_ISCE_TEST:
   validators: []
   timeout: 10800
   vcpu: 1
-  memory: 7600
+  memory: 7500

--- a/job_spec/INSAR_ISCE_TEST.yml
+++ b/job_spec/INSAR_ISCE_TEST.yml
@@ -43,4 +43,4 @@ INSAR_ISCE_TEST:
   validators: []
   timeout: 10800
   vcpu: 1
-  mememory: 31600
+  memory: 31600

--- a/job_spec/INSAR_ISCE_TEST.yml
+++ b/job_spec/INSAR_ISCE_TEST.yml
@@ -42,3 +42,5 @@ INSAR_ISCE_TEST:
     - Ref::secondary_granules
   validators: []
   timeout: 10800
+  vcpu: 1
+  mememory: 31600

--- a/job_spec/INSAR_ISCE_TEST.yml
+++ b/job_spec/INSAR_ISCE_TEST.yml
@@ -43,4 +43,4 @@ INSAR_ISCE_TEST:
   validators: []
   timeout: 10800
   vcpu: 1
-  memory: 31600
+  memory: 7600

--- a/job_spec/RTC_GAMMA.yml
+++ b/job_spec/RTC_GAMMA.yml
@@ -119,3 +119,5 @@ RTC_GAMMA:
   validators:
     - check_dem_coverage
   timeout: 5400
+  vcpu: 1
+  mememory: 31600

--- a/job_spec/RTC_GAMMA.yml
+++ b/job_spec/RTC_GAMMA.yml
@@ -120,4 +120,4 @@ RTC_GAMMA:
     - check_dem_coverage
   timeout: 5400
   vcpu: 1
-  mememory: 31600
+  memory: 31600

--- a/job_spec/WATER_MAP.yml
+++ b/job_spec/WATER_MAP.yml
@@ -88,4 +88,4 @@ WATER_MAP:
     - check_dem_coverage
   timeout: 5400
   vcpu: 1
-  mememory: 31600
+  memory: 31600

--- a/job_spec/WATER_MAP.yml
+++ b/job_spec/WATER_MAP.yml
@@ -87,3 +87,5 @@ WATER_MAP:
   validators:
     - check_dem_coverage
   timeout: 5400
+  vcpu: 1
+  mememory: 31600


### PR DESCRIPTION
* makes instance sizes available to the compute environment customizable at render
* makes the vCPU and Memory configuration a job_spec paremter

This should allow us to, for example, 
* deploy a custom GUNW stack with an optimized instance size
* finally bring the watermap deployment into our normal deployment worklfow

