### PR TITLE
bring watermap branch up to date with develop, remove container version pin

### DIFF
--- a/.github/actions/deploy-hyp3/action.yml
+++ b/.github/actions/deploy-hyp3/action.yml
@@ -81,6 +81,12 @@ runs:
           [ -z ${{ inputs.CLOUDFORMATION_ROLE_ARN }} ] && export ROLE_STATEMENT="" \
             || export ROLE_STATEMENT="--role-arn ${{ inputs.CLOUDFORMATION_ROLE_ARN }}"
 
+          [ -z ${{ inputs.DOMAIN_NAME }} ] && export DOMAIN_NAME="" \
+            || export DOMAIN_NAME="DomainName=${{ inputs.DOMAIN_NAME }}"
+
+          [ -z ${{ inputs.CERTIFICATE_ARN }} ] && export CERTIFICATE_ARN="" \
+            || export CERTIFICATE_ARN="CertificateArn=${{ inputs.CERTIFICATE_ARN }}"
+
           aws cloudformation package \
             --template-file apps/main-cf.yml \
             --s3-bucket ${{ inputs.TEMPLATE_BUCKET }} \
@@ -97,8 +103,8 @@ runs:
                 EDLPassword='${{ inputs.EDL_PASSWORD }}' \
                 ImageTag='${{ inputs.IMAGE_TAG }}' \
                 ProductLifetimeInDays='${{ inputs.PRODUCT_LIFETIME }}' \
-                DomainName='${{ inputs.DOMAIN_NAME }}' \
-                CertificateArn='${{ inputs.CERTIFICATE_ARN }}' \
+                $DOMAIN_NAME \
+                $CERTIFICATE_ARN \
                 MonthlyJobQuotaPerUser='${{ inputs.MONTHLY_JOB_QUOTA_PER_USER }}' \
                 BannedCidrBlocks='${{ inputs.BANNED_CIDR_BLOCKS }}' \
                 DefaultMaxvCpus='${{ inputs.DEFAULT_MAX_VCPUS }}' \

--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -1,4 +1,4 @@
-name: Deploy to AWS
+name: Deploy DAAC Stacks to AWS
 
 on:
   push:
@@ -36,10 +36,10 @@ jobs:
             quota: 1000
             deploy_ref: refs/heads/develop
             job_files: >-
-              job_spec/AUTORIFT.yml 
-              job_spec/INSAR_GAMMA.yml 
-              job_spec/RTC_GAMMA.yml 
-              job_spec/INSAR_ISCE.yml   
+              job_spec/AUTORIFT.yml
+              job_spec/INSAR_GAMMA.yml
+              job_spec/RTC_GAMMA.yml
+              job_spec/INSAR_ISCE.yml
               job_spec/WATER_MAP.yml
             default_max_vcpus: 600
             expanded_max_vcpus: 1600
@@ -74,90 +74,6 @@ jobs:
             required_surplus: 1000
             security_environment: EDC
             ami_id: image_id_ecs_amz2
-
-          - environment: hyp3-its-live
-            domain: hyp3-its-live.asf.alaska.edu
-            template_bucket: cf-templates-3o5lnspmwmzg-us-west-2
-            image_tag: latest
-            product_lifetime_in_days: 180
-            quota: 0
-            deploy_ref: refs/heads/main
-            job_files: job_spec/AUTORIFT_ITS_LIVE.yml
-            default_max_vcpus: 1600
-            expanded_max_vcpus: 1600
-            required_surplus: 0
-            security_environment: JPL
-            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
-
-          - environment: hyp3-autorift
-            domain: hyp3-autorift.asf.alaska.edu
-            template_bucket: cf-templates-igavixdzdy7k-us-west-2
-            image_tag: latest
-            product_lifetime_in_days: 180
-            quota: 0
-            deploy_ref: refs/heads/main
-            job_files: job_spec/AUTORIFT_ITS_LIVE.yml
-            default_max_vcpus: 1600
-            expanded_max_vcpus: 1600
-            required_surplus: 0
-            security_environment: ASF
-            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
-
-          - environment: hyp3-autorift-eu
-            domain: hyp3-autorift-eu.asf.alaska.edu
-            template_bucket: cf-templates-autorift-eu-central-1
-            image_tag: latest
-            product_lifetime_in_days: 180
-            quota: 0
-            deploy_ref: refs/heads/main
-            job_files: job_spec/AUTORIFT_ITS_LIVE_EU.yml
-            default_max_vcpus: 1600
-            expanded_max_vcpus: 1600
-            required_surplus: 0
-            security_environment: ASF
-            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
-
-          - environment: hyp3-isce
-            domain: hyp3-isce.asf.alaska.edu
-            template_bucket: cf-templates-t790khv4btdq-us-west-2
-            image_tag: latest
-            product_lifetime_in_days: 180
-            quota: 0
-            deploy_ref: refs/heads/main
-            job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
-            default_max_vcpus: 1600
-            expanded_max_vcpus: 1600
-            required_surplus: 0
-            security_environment: ASF
-            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
-
-          - environment: hyp3-tibet
-            domain: hyp3-tibet.asf.alaska.edu
-            template_bucket: cf-templates-ejaipnrxq7xg-us-west-2
-            image_tag: latest
-            product_lifetime_in_days: 180
-            quota: 0
-            deploy_ref: refs/heads/main
-            job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
-            default_max_vcpus: 1600
-            expanded_max_vcpus: 1600
-            required_surplus: 0
-            security_environment: ASF
-            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
-
-          - environment: hyp3-watermap
-            domain: hyp3-watermap.asf.alaska.edu
-            template_bucket: cf-templates-1217di08q7vwl-us-west-2
-            image_tag: 5.1.2
-            product_lifetime_in_days: 14
-            quota: 0
-            deploy_ref: refs/heads/watermap
-            job_files: job_spec/RTC_GAMMA.yml job_spec/WATER_MAP.yml
-            default_max_vcpus: 640
-            expanded_max_vcpus: 640
-            required_surplus: 0
-            security_environment: ASF
-            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
 
     environment:
       name: ${{ matrix.environment }}

--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - develop
-      - watermap
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -1,0 +1,134 @@
+name: Deploy Enterprise Stacks to AWS
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - environment: hyp3-its-live
+            domain: hyp3-its-live.asf.alaska.edu
+            template_bucket: cf-templates-3o5lnspmwmzg-us-west-2
+            image_tag: latest
+            product_lifetime_in_days: 180
+            quota: 0
+            job_files: job_spec/AUTORIFT_ITS_LIVE.yml
+            default_max_vcpus: 2640
+            expanded_max_vcpus: 2640
+            required_surplus: 0
+            security_environment: JPL
+            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+
+          - environment: hyp3-autorift-eu
+            domain: hyp3-autorift-eu.asf.alaska.edu
+            template_bucket: cf-templates-autorift-eu-central-1
+            image_tag: latest
+            product_lifetime_in_days: 180
+            quota: 0
+            job_files: job_spec/AUTORIFT_ITS_LIVE_EU.yml
+            default_max_vcpus: 1600
+            expanded_max_vcpus: 1600
+            required_surplus: 0
+            security_environment: ASF
+            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+
+          - environment: hyp3-isce
+            domain: hyp3-isce.asf.alaska.edu
+            template_bucket: cf-templates-t790khv4btdq-us-west-2
+            image_tag: latest
+            product_lifetime_in_days: 180
+            quota: 0
+            job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
+            default_max_vcpus: 1600
+            expanded_max_vcpus: 1600
+            required_surplus: 0
+            security_environment: ASF
+            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+
+          - environment: hyp3-tibet
+            domain: hyp3-tibet.asf.alaska.edu
+            template_bucket: cf-templates-ejaipnrxq7xg-us-west-2
+            image_tag: latest
+            product_lifetime_in_days: 180
+            quota: 0
+            job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
+            default_max_vcpus: 1600
+            expanded_max_vcpus: 1600
+            required_surplus: 0
+            security_environment: ASF
+            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+
+          - environment: hyp3-a19-jpl
+            domain: hyp3-a19-jpl.asf.alaska.edu
+            template_bucket: cf-templates-v4pvone059de-us-west-2
+            image_tag: latest
+            product_lifetime_in_days: 180
+            quota: 0
+            job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
+            default_max_vcpus: 1600
+            expanded_max_vcpus: 1600
+            required_surplus: 0
+            security_environment: JPL
+            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+
+          - environment: hyp3-watermap
+            domain: hyp3-watermap.asf.alaska.edu
+            template_bucket: cf-templates-1217di08q7vwl-us-west-2
+            image_tag: latest
+            product_lifetime_in_days: 14
+            quota: 0
+            deploy_ref: refs/heads/watermap
+            job_files: job_spec/RTC_GAMMA.yml job_spec/WATER_MAP.yml
+            default_max_vcpus: 640
+            expanded_max_vcpus: 640
+            required_surplus: 0
+            security_environment: ASF
+            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+
+    environment:
+      name: ${{ matrix.environment }}
+      url: https://${{ matrix.domain }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.V2_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.V2_AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.V2_AWS_SESSION_TOKEN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - uses: ./.github/actions/deploy-hyp3
+        with:
+          TEMPLATE_BUCKET:  ${{ matrix.template_bucket }}
+          STACK_NAME: ${{ matrix.environment }}
+          DOMAIN_NAME: ${{ matrix.domain }}
+          CERTIFICATE_ARN:  ${{ secrets.CERTIFICATE_ARN }}
+          IMAGE_TAG: ${{ matrix.image_tag }}
+          PRODUCT_LIFETIME: ${{ matrix.product_lifetime_in_days }}
+          VPC_ID: ${{ secrets.VPC_ID }}
+          SUBNET_IDS: ${{ secrets.SUBNET_IDS }}
+          EDL_USERNAME: ${{ secrets.EDL_USERNAME }}
+          EDL_PASSWORD: ${{ secrets.EDL_PASSWORD }}
+          CLOUDFORMATION_ROLE_ARN: ${{ secrets.CLOUDFORMATION_ROLE_ARN }}
+          MONTHLY_JOB_QUOTA_PER_USER: ${{ matrix.quota }}
+          JOB_FILES: ${{ matrix.job_files }}
+          BANNED_CIDR_BLOCKS: ${{ secrets.BANNED_CIDR_BLOCKS }}
+          DEFAULT_MAX_VCPUS: ${{ matrix.default_max_vcpus }}
+          EXPANDED_MAX_VCPUS: ${{ matrix.expanded_max_vcpus }}
+          MONTHLY_COMPUTE_BUDGET: ${{ secrets.MONTHLY_COMPUTE_BUDGET }}
+          REQUIRED_SURPLUS: ${{ matrix.required_surplus }}
+          PERMISSIONS_BOUNDARY_ARN: ${{ secrets.PERMISSIONS_BOUNDARY_ARN }}
+          SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
+          AMI_ID: ${{ matrix.ami_id }}

--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -77,20 +77,6 @@ jobs:
             security_environment: JPL
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
 
-          - environment: hyp3-watermap
-            domain: hyp3-watermap.asf.alaska.edu
-            template_bucket: cf-templates-1217di08q7vwl-us-west-2
-            image_tag: latest
-            product_lifetime_in_days: 14
-            quota: 0
-            deploy_ref: refs/heads/watermap
-            job_files: job_spec/RTC_GAMMA.yml job_spec/WATER_MAP.yml
-            default_max_vcpus: 640
-            expanded_max_vcpus: 640
-            required_surplus: 0
-            security_environment: ASF
-            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
-
     environment:
       name: ${{ matrix.environment }}
       url: https://${{ matrix.domain }}

--- a/.github/workflows/deploy-watermap.yml
+++ b/.github/workflows/deploy-watermap.yml
@@ -1,4 +1,4 @@
-name: Deploy Enterprise Stacks to AWS
+name: Deploy hyp3-watermap Stack to AWS
 
 on:
   push:

--- a/.github/workflows/deploy-watermap.yml
+++ b/.github/workflows/deploy-watermap.yml
@@ -1,0 +1,68 @@
+name: Deploy Enterprise Stacks to AWS
+
+on:
+  push:
+    branches:
+      - watermap
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - environment: hyp3-watermap
+            domain: hyp3-watermap.asf.alaska.edu
+            template_bucket: cf-templates-1217di08q7vwl-us-west-2
+            image_tag: latest
+            product_lifetime_in_days: 14
+            quota: 0
+            job_files: job_spec/RTC_GAMMA.yml job_spec/WATER_MAP.yml
+            default_max_vcpus: 640
+            expanded_max_vcpus: 640
+            required_surplus: 0
+            security_environment: ASF
+            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+
+    environment:
+      name: ${{ matrix.environment }}
+      url: https://${{ matrix.domain }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.V2_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.V2_AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.V2_AWS_SESSION_TOKEN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - uses: ./.github/actions/deploy-hyp3
+        with:
+          TEMPLATE_BUCKET:  ${{ matrix.template_bucket }}
+          STACK_NAME: ${{ matrix.environment }}
+          DOMAIN_NAME: ${{ matrix.domain }}
+          CERTIFICATE_ARN:  ${{ secrets.CERTIFICATE_ARN }}
+          IMAGE_TAG: ${{ matrix.image_tag }}
+          PRODUCT_LIFETIME: ${{ matrix.product_lifetime_in_days }}
+          VPC_ID: ${{ secrets.VPC_ID }}
+          SUBNET_IDS: ${{ secrets.SUBNET_IDS }}
+          EDL_USERNAME: ${{ secrets.EDL_USERNAME }}
+          EDL_PASSWORD: ${{ secrets.EDL_PASSWORD }}
+          CLOUDFORMATION_ROLE_ARN: ${{ secrets.CLOUDFORMATION_ROLE_ARN }}
+          MONTHLY_JOB_QUOTA_PER_USER: ${{ matrix.quota }}
+          JOB_FILES: ${{ matrix.job_files }}
+          BANNED_CIDR_BLOCKS: ${{ secrets.BANNED_CIDR_BLOCKS }}
+          DEFAULT_MAX_VCPUS: ${{ matrix.default_max_vcpus }}
+          EXPANDED_MAX_VCPUS: ${{ matrix.expanded_max_vcpus }}
+          MONTHLY_COMPUTE_BUDGET: ${{ secrets.MONTHLY_COMPUTE_BUDGET }}
+          REQUIRED_SURPLUS: ${{ matrix.required_surplus }}
+          PERMISSIONS_BOUNDARY_ARN: ${{ secrets.PERMISSIONS_BOUNDARY_ARN }}
+          SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
+          AMI_ID: ${{ matrix.ami_id }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.11.0]
+### Changed
+- The HyP3 API is now implemented as an API Gateway REST API, supporting private API deployments.
+
+## [2.10.0]
+### Added
+- AutoRIFT jobs now allow submission with Landsat 9 Collection 2 granules
+
+## [2.9.0]
+### Added
+- Add `processing_time_in_seconds` to the `job` API schema to allow plugin developers to check processing time.
+
+## [2.8.4](https://github.com/ASFHyP3/hyp3/compare/v2.8.3...v2.8.4)
+### Security
+- Encrypt Earthdata username and password using AWS Secrets Manager.
+### Added
+- Documentation about deploying to a JPL-managed commercial AWS account has been added to
+  [`docs/deployments`](docs/deployments).
+
 ## [2.8.3](https://github.com/ASFHyP3/hyp3/compare/v2.8.2...v2.8.3)
 ### Changed
 - Increase monthly job quota per user from 250 to 1,000.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 API = ${PWD}/apps/api/src
+CHECK_PROCESSING_TIME = ${PWD}/apps/check-processing-time/src
 GET_FILES = ${PWD}/apps/get-files/src
 PROCESS_NEW_GRANULES = ${PWD}/apps/process-new-granules/src
 SCALE_CLUSTER = ${PWD}/apps/scale-cluster/src
@@ -6,7 +7,7 @@ START_EXECUTION = ${PWD}/apps/start-execution/src
 UPDATE_DB = ${PWD}/apps/update-db/src
 UPLOAD_LOG = ${PWD}/apps/upload-log/src
 DYNAMO = ${PWD}/lib/dynamo
-export PYTHONPATH = ${API}:${GET_FILES}:${PROCESS_NEW_GRANULES}:${SCALE_CLUSTER}:${START_EXECUTION}:${UPDATE_DB}:${UPLOAD_LOG}:${DYNAMO}
+export PYTHONPATH = ${API}:${CHECK_PROCESSING_TIME}:${GET_FILES}:${PROCESS_NEW_GRANULES}:${SCALE_CLUSTER}:${START_EXECUTION}:${UPDATE_DB}:${UPLOAD_LOG}:${DYNAMO}
 
 
 build: render
@@ -35,7 +36,7 @@ render:
 static: flake8 openapi-validate cfn-lint
 
 flake8:
-	flake8 --max-line-length=120 --import-order-style=pycharm --statistics --application-import-names hyp3_api,get_files,start_execution,update_db,upload_log,dynamo,process_new_granules,scale_cluster apps tests lib
+	flake8 --max-line-length=120 --import-order-style=pycharm --statistics --application-import-names hyp3_api,get_files,check_processing_time,start_execution,update_db,upload_log,dynamo,process_new_granules,scale_cluster apps tests lib
 
 openapi-validate: render
 	prance validate --backend=openapi-spec-validator apps/api/src/hyp3_api/api-spec/openapi-spec.yml

--- a/README.md
+++ b/README.md
@@ -18,16 +18,24 @@ A processing environment for HyP3 Plugins in AWS.
 
 ## Deployment
 
+The deployment steps below describe how to deploy to a general AWS account you own/administer.
+HyP3 does support deploying to more secure environments which may require additional steps and are
+described in [`docs/deployments`](docs/deployments).
+
 ### Prerequisites
 These resources are required for a successful deployment, but managed separately:
 
 - HyP3 plugin container images and tags. Current plugins are defined in [`job_spec`](./job_spec).
 - S3 bucket for CloudFormation deployment artifacts
-- DNS record for custom API domain name
-- SSL certificate in AWS Certificate Manager for custom API domain name
 - EarthData Login account authorized to download data from ASF
+- IAM role configured for [REST API access logging](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html#set-up-access-logging-permissions)
 - default VPC
 - IAM user and roles for automated CloudFormation deployments (if desired)
+- For Earthdata Cloud deployments:
+  - An IAM permissions boundary policy ARN
+- For non-Earthdata Cloud deployments:
+  - DNS record for custom API domain name
+  - SSL certificate in AWS Certificate Manager for custom API domain name
 
 ### Stack Parameters
 Review the parameters in [cloudformation.yml](apps/main-cf.yml) for deploy time configuration options.

--- a/apps/api/api-cf.yml.j2
+++ b/apps/api/api-cf.yml.j2
@@ -15,12 +15,6 @@ Parameters:
   AuthAlgorithm:
     Type: String
 
-  DomainName:
-    Type: String
-
-  CertificateArn:
-    Type: String
-
   MonthlyJobQuotaPerUser:
     Type: Number
 
@@ -30,7 +24,11 @@ Parameters:
   BannedCidrBlocks:
     Type: String
 
+  {% if security_environment == 'EDC' %}
   PermissionsBoundaryPolicyArn:
+    Type: String
+
+  VpcId:
     Type: String
 
   SecurityGroupId:
@@ -39,49 +37,82 @@ Parameters:
   SubnetIds:
     Type: CommaDelimitedList
 
-Conditions:
+  {% else %}
+  DomainName:
+    Type: String
 
-  UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryPolicyArn, ""]]
-
-  LambdasInVpc: !Not [!Equals [!Ref SecurityGroupId, ""]]
-
-  UseCustomDomainName: !Not [!Equals [!Ref DomainName, ""]]
+  CertificateArn:
+    Type: String
+  {% endif %}
 
 Outputs:
 
   Url:
-    Value: !If [UseCustomDomainName, !Sub "https://${CustomDomainName}/ui", !Sub "${Api.ApiEndpoint}/ui"]
+    Value: {{ '!Sub "https://${RestApi}.execute-api.${AWS::Region}.amazonaws.com/${Stage}/ui"' if security_environment == 'EDC' else '!Sub "https://${CustomDomainName}/ui"' }}
 
   ApiId:
-    Value: !Ref Api
+    Value: !Ref RestApi
 
 Resources:
 
-  Api:
-    Type: AWS::ApiGatewayV2::Api
+  RestApi:
+    Type: AWS::ApiGateway::RestApi
     Properties:
-      Name: !Ref AWS::StackName
-      ProtocolType: HTTP
-      Target: !GetAtt Lambda.Arn
-      CredentialsArn: !GetAtt ApiRole.Arn
+      EndpointConfiguration:
+        Types:
+          - {{ 'PRIVATE' if security_environment == 'EDC' else 'REGIONAL' }}
+      Body:
+        openapi: 3.0.3
+        paths:
+          /:
+            x-amazon-apigateway-any-method:
+              x-amazon-apigateway-integration:
+                type: aws_proxy
+                uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${Lambda.Arn}/invocations"
+                httpMethod: POST
+          /{proxy+}:
+            x-amazon-apigateway-any-method:
+              x-amazon-apigateway-integration:
+                type: aws_proxy
+                uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${Lambda.Arn}/invocations"
+                httpMethod: POST
+      {% if security_environment == 'EDC' %}
+      Policy:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal: "*"
+            Action: execute-api:Invoke
+            Resource: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:*"
+            Condition:
+              StringEquals:
+                aws:SourceVpc: !Ref VpcId
+      {% endif %}
 
-  ApiOverrides:
-    Type: AWS::ApiGatewayV2::ApiGatewayManagedOverrides
+  {% set random_id = range(1, 999999) | random %}
+  Deployment{{ random_id }}:
+    Type: AWS::ApiGateway::Deployment
     Properties:
-      ApiId: !Ref Api
-      Stage:
-        AccessLogSettings:
-          DestinationArn: !GetAtt ApiLogGroup.Arn
-          Format: '{"sourceIp":"$context.identity.sourceIp","httpMethod":"$context.httpMethod","path":"$context.path","status":"$context.status","responseLength":"$context.responseLength","responseLatency":"$context.responseLatency","requestTime":"$context.requestTime","protocol":"$context.protocol","userAgent":"$context.identity.userAgent","requestId":"$context.requestId"}'
+      RestApiId: !Ref RestApi
+
+  Stage:
+    Type: AWS::ApiGateway::Stage
+    Properties:
+      StageName: api
+      RestApiId: !Ref RestApi
+      DeploymentId: !Ref Deployment{{ random_id }}
+      AccessLogSetting:
+        DestinationArn: !GetAtt ApiLogGroup.Arn
+        Format: '{"sourceIp":"$context.identity.sourceIp","httpMethod":"$context.httpMethod","path":"$context.path","status":"$context.status","responseLength":"$context.responseLength","responseLatency":"$context.responseLatency","requestTime":"$context.requestTime","protocol":"$context.protocol","userAgent":"$context.identity.userAgent","requestId":"$context.requestId"}'
 
   ApiLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       RetentionInDays: 180
 
+  {% if security_environment != 'EDC' %}
   CustomDomainName:
     Type: AWS::ApiGatewayV2::DomainName
-    Condition: UseCustomDomainName
     Properties:
       DomainName: !Ref DomainName
       DomainNameConfigurations:
@@ -90,43 +121,11 @@ Resources:
 
   ApiMapping:
     Type: AWS::ApiGatewayV2::ApiMapping
-    Condition: UseCustomDomainName
     Properties:
-      ApiId: !Ref Api
+      ApiId: !Ref RestApi
       DomainName: !Ref CustomDomainName
-      Stage: $default
-
-  ApiRole:
-    Type: {{ 'Custom::JplRole' if security_environment == 'JPL' else 'AWS::IAM::Role' }}
-    Properties:
-      {% if security_environment == 'JPL' %}
-      ServiceToken: !ImportValue Custom::JplRole::ServiceToken
-      Path: /account-managed/hyp3/
-      {% endif %}
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          Action: sts:AssumeRole
-          Principal:
-            Service: apigateway.amazonaws.com
-          Effect: Allow
-      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
-      ManagedPolicyArns:
-        - !Ref ApiPolicy
-
-  ApiPolicy:
-    Type: {{ 'Custom::JplPolicy' if security_environment == 'JPL' else 'AWS::IAM::ManagedPolicy' }}
-    Properties:
-      {% if security_environment == 'JPL' %}
-      ServiceToken: !ImportValue Custom::JplPolicy::ServiceToken
-      Path: /account-managed/hyp3/
-      {% endif %}
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Action: lambda:InvokeFunction
-            Resource: !GetAtt Lambda.Arn
+      Stage: !Ref Stage
+  {% endif %}
 
   LambdaLogGroup:
     Type: AWS::Logs::LogGroup
@@ -148,9 +147,13 @@ Resources:
           Principal:
             Service: lambda.amazonaws.com
           Effect: Allow
-      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
+      {% if security_environment == 'EDC' %}
+      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
+      {% endif %}
       ManagedPolicyArns:
-        - !If [LambdasInVpc, arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole, !Ref AWS::NoValue]
+        {% if security_environment == 'EDC' %}
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        {% endif %}
         - !Ref LambdaPolicy
 
   LambdaPolicy:
@@ -204,10 +207,17 @@ Resources:
       Role: !GetAtt LambdaRole.Arn
       Runtime: python3.8
       Timeout: 30
+      {% if security_environment == 'EDC' %}
       VpcConfig:
-        !If
-          - LambdasInVpc
-          - SecurityGroupIds:
-              - !Ref SecurityGroupId
-            SubnetIds: !Ref SubnetIds
-          - !Ref AWS::NoValue
+        SecurityGroupIds:
+          - !Ref SecurityGroupId
+        SubnetIds: !Ref SubnetIds
+      {% endif %}
+
+  LambdaPermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !GetAtt Lambda.Arn
+      Action: lambda:InvokeFunction
+      Principal: apigateway.amazonaws.com
+      SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${RestApi}/*"

--- a/apps/api/src/hyp3_api/api-spec/openapi-spec.yml
+++ b/apps/api/src/hyp3_api/api-spec/openapi-spec.yml
@@ -426,6 +426,8 @@ components:
           $ref: "#/components/schemas/list_of_urls"
         expiration_time:
           $ref: "#/components/schemas/datetime"
+        processing_time_in_seconds:
+          $ref: "#/components/schemas/processing_time_in_seconds"
         priority:
           $ref: "#/components/schemas/priority"
 
@@ -522,6 +524,14 @@ components:
       type: integer
       minimum: 0
       maximum: 9999
+
+    processing_time_in_seconds:
+      description: >
+        Run time in seconds for the final processing attempt (regardless of whether it succeeded). A value of zero
+        likely indicates that the job failed before reaching the processing step, although it may also indicate that the
+        job failed after reaching the processing step but before calculating the processing time.
+      type: number
+      minimum: 0
 
   securitySchemes:
     EarthDataLogin:

--- a/apps/check-processing-time/check-processing-time-cf.yml.j2
+++ b/apps/check-processing-time/check-processing-time-cf.yml.j2
@@ -2,9 +2,6 @@ AWSTemplateFormatVersion: 2010-09-09
 
 Parameters:
 
-  Bucket:
-    Type: String
-
   PermissionsBoundaryPolicyArn:
     Type: String
 
@@ -67,23 +64,12 @@ Resources:
               - logs:CreateLogStream
               - logs:PutLogEvents
             Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*"
-          - Effect: Allow
-            Action: s3:ListBucket
-            Resource: !Sub "arn:aws:s3:::${Bucket}"
-          - Effect: Allow
-            Action:
-              - s3:GetObject
-              - s3:GetObjectTagging
-            Resource: !Sub "arn:aws:s3:::${Bucket}/*"
 
   Lambda:
     Type: AWS::Lambda::Function
     Properties:
-      Environment:
-        Variables:
-          BUCKET: !Ref Bucket
       Code: src/
-      Handler: get_files.lambda_handler
+      Handler: check_processing_time.lambda_handler
       MemorySize: 128
       Role: !GetAtt Role.Arn
       Runtime: python3.8

--- a/apps/check-processing-time/src/check_processing_time.py
+++ b/apps/check-processing-time/src/check_processing_time.py
@@ -1,0 +1,16 @@
+import json
+
+
+def get_time_from_attempts(attempts):
+    attempts.sort(key=lambda attempt: attempt['StartedAt'])
+    final_attempt = attempts[-1]
+    return (final_attempt['StoppedAt'] - final_attempt['StartedAt']) / 1000
+
+
+def lambda_handler(event, context):
+    results = event['processing_results']
+    if 'Attempts' in results:
+        attempts = results['Attempts']
+    else:
+        attempts = json.loads(results['Cause'])['Attempts']
+    return get_time_from_attempts(attempts)

--- a/apps/main-cf.yml.j2
+++ b/apps/main-cf.yml.j2
@@ -37,16 +37,6 @@ Parameters:
     Type: String
     Default: RS256
 
-  DomainName:
-    Description: DNS domain name that will be used to invoke this api.
-    Type: String
-    Default: ""
-
-  CertificateArn:
-    Description: ARN of Certificate in AWS Certificate Manager setup previously for this domain name.
-    Type: String
-    Default: ""
-
   MonthlyJobQuotaPerUser:
     Description: Number of jobs each user is allowed per month.
     Type: Number
@@ -97,6 +87,16 @@ Parameters:
     MinValue: 0
     Default: 0
 
+  {% if security_environment != 'EDC' %}
+  DomainName:
+    Description: DNS domain name that will be used to invoke this api.
+    Type: String
+
+  CertificateArn:
+    Description: ARN of Certificate in AWS Certificate Manager setup previously for this domain name.
+    Type: String
+  {% endif %}
+
 Conditions:
 
   ScaleCluster: !Not [!Equals [!Ref DefaultMaxvCpus, !Ref ExpandedMaxvCpus]]
@@ -117,14 +117,18 @@ Resources:
         SubscriptionsTable: !Ref SubscriptionsTable
         AuthPublicKey: !Ref AuthPublicKey
         AuthAlgorithm: !Ref AuthAlgorithm
-        DomainName: !Ref DomainName
-        CertificateArn: !Ref CertificateArn
         MonthlyJobQuotaPerUser: !Ref MonthlyJobQuotaPerUser
         SystemAvailable: !Ref SystemAvailable
         BannedCidrBlocks: !Ref BannedCidrBlocks
+        {% if security_environment == 'EDC' %}
         PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
-        SecurityGroupId: {{ '!GetAtt Cluster.Outputs.SecurityGroupId' if security_environment == 'EDC' else '""' }}
-        SubnetIds: {{ '!Join [",", !Ref SubnetIds]' if security_environment == 'EDC' else '""' }}
+        VpcId: !Ref VpcId
+        SecurityGroupId: !GetAtt Cluster.Outputs.SecurityGroupId
+        SubnetIds: !Join [",", !Ref SubnetIds]
+        {% else %}
+        DomainName: !Ref DomainName
+        CertificateArn: !Ref CertificateArn
+        {% endif %}
       TemplateURL: api/api-cf.yml
 
   Cluster:
@@ -174,13 +178,12 @@ Resources:
         JobQueueArn: !GetAtt Cluster.Outputs.JobQueueArn
         TaskRoleArn: !GetAtt Cluster.Outputs.TaskRoleArn
         JobsTable: !Ref JobsTable
-        EDLUsername: !Ref EDLUsername
-        EDLPassword: !Ref EDLPassword
         Bucket: !Ref ContentBucket
         ImageTag: !Ref ImageTag
         PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
         SecurityGroupId: {{ '!GetAtt Cluster.Outputs.SecurityGroupId' if security_environment == 'EDC' else '""' }}
         SubnetIds: {{ '!Join [",", !Ref SubnetIds]' if security_environment == 'EDC' else '""' }}
+        SecretArn: !Ref Secret
       TemplateURL: workflow-cf.yml
 
   Monitoring:
@@ -328,3 +331,8 @@ Resources:
               KeyType: RANGE
           Projection:
             ProjectionType: ALL
+
+  Secret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      SecretString: !Sub '{"username": "${EDLUsername}", "password": "${EDLPassword}"}'

--- a/apps/step-function.json.j2
+++ b/apps/step-function.json.j2
@@ -1,6 +1,14 @@
 {
-  "StartAt": "JOB_RUNNING",
+  "StartAt": "SET_DEFAULT_RESULTS",
   "States": {
+    "SET_DEFAULT_RESULTS": {
+      "Type": "Pass",
+      "Result": {
+        "processing_time_in_seconds": 0
+      },
+      "ResultPath": "$.results",
+      "Next": "JOB_RUNNING"
+    },
     "JOB_RUNNING": {
       "Type": "Task",
       "Resource": "${UpdateDBLambdaArn}",
@@ -181,6 +189,24 @@
         }
       ],
       "ResultPath": "$.results.get_files",
+      "Next": "CHECK_PROCESSING_TIME"
+    },
+    "CHECK_PROCESSING_TIME": {
+      "Type": "Task",
+      "Resource": "${CheckProcessingTimeLambdaArn}",
+      "Parameters": {
+        "processing_results.$": "$.results.processing_results"
+      },
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "JOB_FAILED",
+          "ResultPath": "$.results.processing_time_in_seconds"
+        }
+      ],
+      "ResultPath": "$.results.processing_time_in_seconds",
       "Next": "CHECK_STATUS"
     },
     "CHECK_STATUS": {
@@ -202,7 +228,8 @@
         "browse_images.$": "$.results.get_files.browse_images",
         "thumbnail_images.$": "$.results.get_files.thumbnail_images",
         "logs.$": "$.results.get_files.logs",
-        "expiration_time.$": "$.results.get_files.expiration_time"
+        "expiration_time.$": "$.results.get_files.expiration_time",
+        "processing_time_in_seconds.$": "$.results.processing_time_in_seconds"
       },
       "Retry": [
         {
@@ -222,7 +249,8 @@
         "job_id.$": "$.job_id",
         "status_code": "FAILED",
         "logs.$": "$.results.get_files.logs",
-        "expiration_time.$": "$.results.get_files.expiration_time"
+        "expiration_time.$": "$.results.get_files.expiration_time",
+        "processing_time_in_seconds.$": "$.results.processing_time_in_seconds"
       },
       "Retry": [
         {

--- a/apps/workflow-cf.yml.j2
+++ b/apps/workflow-cf.yml.j2
@@ -5,13 +5,6 @@ Parameters:
   JobQueueArn:
     Type: String
 
-  EDLUsername:
-    Type: String
-
-  EDLPassword:
-    Type: String
-    NoEcho: true
-
   JobsTable:
     Type: String
 
@@ -32,6 +25,9 @@ Parameters:
 
   SubnetIds:
     Type: CommaDelimitedList
+
+  SecretArn:
+    Type: String
 
 Conditions:
 
@@ -59,6 +55,7 @@ Resources:
             !Sub "{{ job_spec['image'] }}:${ImageTag}"
           {% endif %}
         JobRoleArn: !Ref TaskRoleArn
+        ExecutionRoleArn: !GetAtt ExecutionRole.Arn
         ResourceRequirements:
           - Type: VCPU
             Value: "1"
@@ -68,6 +65,11 @@ Resources:
           {% for command in job_spec['command'] %}
           - {{ command }}
           {% endfor %}
+        Secrets:
+          - Name: EARTHDATA_USERNAME
+            ValueFrom: !Sub "${SecretArn}:username::"
+          - Name: EARTHDATA_PASSWORD
+            ValueFrom: !Sub "${SecretArn}:password::"
       Timeout:
         AttemptDurationSeconds: {{ job_spec['timeout'] }}
   {% endfor %}
@@ -84,6 +86,7 @@ Resources:
         {% endfor %}
         UpdateDBLambdaArn: !GetAtt UpdateDB.Outputs.LambdaArn
         GetFilesLambdaArn: !GetAtt GetFiles.Outputs.LambdaArn
+        CheckProcessingTimeLambdaArn: !GetAtt CheckProcessingTime.Outputs.LambdaArn
         UploadLogLambdaArn: !GetAtt UploadLog.Outputs.LambdaArn
 
   StepFunctionRole:
@@ -132,6 +135,7 @@ Resources:
             Resource:
              - !GetAtt UpdateDB.Outputs.LambdaArn
              - !GetAtt GetFiles.Outputs.LambdaArn
+             - !GetAtt CheckProcessingTime.Outputs.LambdaArn
              - !GetAtt UploadLog.Outputs.LambdaArn
 
   UpdateDB:
@@ -154,6 +158,15 @@ Resources:
         SubnetIds: !Join [",", !Ref SubnetIds]
       TemplateURL: get-files/get-files-cf.yml
 
+  CheckProcessingTime:
+    Type: AWS::CloudFormation::Stack
+    Properties:
+      Parameters:
+        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
+        SecurityGroupId: !Ref SecurityGroupId
+        SubnetIds: !Join [",", !Ref SubnetIds]
+      TemplateURL: check-processing-time/check-processing-time-cf.yml
+
   StartExecution:
     Type: AWS::CloudFormation::Stack
     Properties:
@@ -174,3 +187,36 @@ Resources:
         SecurityGroupId: !Ref SecurityGroupId
         SubnetIds: !Join [",", !Ref SubnetIds]
       TemplateURL: upload-log/upload-log-cf.yml
+
+  ExecutionRole:
+    Type: {{ 'Custom::JplRole' if security_environment == 'JPL' else 'AWS::IAM::Role' }}
+    Properties:
+      {% if security_environment == 'JPL' %}
+      ServiceToken: !ImportValue Custom::JplRole::ServiceToken
+      Path: /account-managed/hyp3/
+      {% endif %}
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Action: sts:AssumeRole
+          Principal:
+            Service: ecs-tasks.amazonaws.com
+          Effect: Allow
+      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+        - !Ref ExecutionPolicy
+
+  ExecutionPolicy:
+    Type: {{ 'Custom::JplPolicy' if security_environment == 'JPL' else 'AWS::IAM::ManagedPolicy' }}
+    Properties:
+      {% if security_environment == 'JPL' %}
+      ServiceToken: !ImportValue Custom::JplPolicy::ServiceToken
+      Path: /account-managed/hyp3/
+      {% endif %}
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action: secretsmanager:GetSecretValue
+            Resource: !Ref SecretArn

--- a/docs/deployments/JPL-deployment-policy-cf.yml
+++ b/docs/deployments/JPL-deployment-policy-cf.yml
@@ -1,0 +1,78 @@
+AWSTemplateFormatVersion: 2010-09-09
+Resources:
+  DeployPolicy:
+    Type: Custom::JplPolicy
+    Properties:
+      ServiceToken: !ImportValue Custom::JplPolicy::ServiceToken
+      Path: /account-managed/hyp3/
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - apigateway:*
+              - batch:*
+              - cloudformation:DescribeStacks
+              - cloudformation:ValidateTemplate
+              - cloudwatch:*
+              - dynamodb:*
+              - ec2:*
+              - ecs:*
+              - events:*
+              - iam:CreateServiceLinkedRole
+              - iam:DeleteServiceLinkedRole
+              - iam:Get*
+              - iam:List*
+              - iam:PassRole
+              - kms:*
+              - lambda:*
+              - logs:*
+              - s3:*
+              - secretsmanager:*
+              - sns:*
+              - ssm:GetParameters
+              - states:*
+              - sts:AssumeRole
+            Resource: "*"
+
+          - Effect: Allow
+            Action:
+              - iam:AddRoleToInstanceProfile
+              - iam:CreateInstanceProfile
+              - iam:DeleteInstanceProfile
+              - iam:RemoveRoleFromInstanceProfile
+              - iam:TagInstanceProfile
+              - iam:UntagInstanceProfile
+            Resource: !Sub "arn:aws:iam::${AWS::AccountId}:instance-profile/account-managed/*"
+
+          - Effect: Allow
+            Action:
+              - cloudformation:SetStackPolicy
+              - cloudformation:CreateStack
+              - cloudformation:UpdateStack
+              - cloudformation:CreateChangeSet
+              - cloudformation:DescribeChangeSet
+              - cloudformation:ExecuteChangeSet
+              - cloudformation:DeleteChangeSet
+              - cloudformation:GetTemplateSummary
+            Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*"
+
+  ApiGatewayLoggingRole:
+    Type: Custom::JplRole
+    Properties:
+      ServiceToken: !ImportValue Custom::JplRole::ServiceToken
+      Path: /account-managed/hyp3/
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Action: sts:AssumeRole
+          Principal:
+            Service: apigateway.amazonaws.com
+          Effect: Allow
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+
+  ApiGatewayLoggingPermission:
+    Type: AWS::ApiGateway::Account
+    Properties:
+      CloudWatchRoleArn: !GetAtt ApiGatewayLoggingRole.Arn

--- a/docs/deployments/JPL-deployment.md
+++ b/docs/deployments/JPL-deployment.md
@@ -1,0 +1,70 @@
+# Deploying HyP3 to JPL
+
+HyP3 can be deployed into a JPL managed AWS commercial account as long as JPL's `roles-as-code`
+tooling is provided in the account and in same region as the deployment. Currently, the only
+regions supported are `us-west-1`, `us-west-2`, `us-east-1`, and `us-east-2`.
+
+To request `roles-as-code` tooling be deployed in a JPL account, open a 
+[Cloud Team Service Desk](https://itsd-jira.jpl.nasa.gov/servicedesk/customer/portal/13) request here:
+https://itsd-jira.jpl.nasa.gov/servicedesk/customer/portal/13/create/461?q=roles&q_time=1644889220558
+
+
+For more information about `roles-as-code`, see:
+* https://wiki.jpl.nasa.gov/display/cloudcomputing/IAM+Roles+and+Policies
+* https://github.jpl.nasa.gov/cloud/roles-as-code/blob/master/Documentation.md
+
+*Note: you must be on the JPL VPN to view the JPL `.jpl.nasa.gov` links in this document.*
+
+## 1. Roles-as-code
+
+JPL deployment uses a JPL-created service user with a deployment policy attached.
+An appropriate deployment policy can be created in a JPL account by deploying the
+`hyp3-ci` stack. From the repository root, run:
+
+```shell
+aws cloudformation deploy \
+    --stack-name hyp3-ci \
+    --template-file docs/deployments/JPL-deployment-policy-cf.yml
+```
+
+Then open a [Cloud Team Service Desk](https://itsd-jira.jpl.nasa.gov/servicedesk/customer/portal/13)
+request for a service user account here:
+https://itsd-jira.jpl.nasa.gov/servicedesk/customer/portal/13/create/416?q=service%20user&q_time=1643746791578
+with the deployed policy name in the "Managed Permissions to be Attached" field. 
+The policy name should look like `hyp3-ci-DeployPolicy-*`, and can be found either
+in the [IAM console](https://console.aws.amazon.com/iamv2/home?#/policies) or listed under 
+the `hyp3-ci` CloudFormation Stack Resources.   
+
+
+## 2. Deploy HyP3 to JPL
+
+Once the JPL service user has been created, you should receive a set of AWS Access Keys
+which can be used to deploy HyP3 via CI/CD tooling, or manually. 
+
+To deploy HyP3 manually into a JPL account, run these commands from the repository root,
+replacing any `<*>` with appropriate values, and adding any other needed parameter
+overrides for the deployment:
+
+```shell
+export AWS_ACCESS_KEY_ID=<service-user-access-key-id>
+export AWS_SECRET_ACCESS_KEY=<service-user-secret-access-key>
+export AWS_REGION=<deployment-region>
+
+make files=<supported-job-spec-files> build
+
+aws cloudformation package \
+    --template-file apps/main-cf.yml \
+    --s3-bucket <template-bucket> \
+    --output-template-file packaged.yml
+
+aws cloudformation deploy \
+    --stack-name <stack-name> \
+    --template-file packaged.yml \
+    --capabilities CAPABILITY_IAM \
+    --parameter-overrides \
+        VpcId=<vpc-ids> \
+        SubnetIds=<subnet-ids> \
+        EDLUsername=<erthdata-login-username> \
+        EDLPassword=<erthdata-login-username> \
+        MonthlyJobQuotaPerUser=0
+```

--- a/job_spec/AUTORIFT.yml
+++ b/job_spec/AUTORIFT.yml
@@ -32,19 +32,15 @@ AUTORIFT:
               minLength: 23
               maxLength: 24
               example: S2A_22WEB_20200627_0_L1C
-            - description: The name of the Landsat 8 Collection 2 granule to process
+            - description: The name of the Landsat 8 or 9 Collection 2 granule to process
               type: string
-              pattern: "^L[CO]08_"
+              pattern: "^L[CO]0[89]_"
               minLength: 40
               maxLength: 40
               example: LC08_L1GT_118112_20210107_20210107_02_RT
     bucket_prefix:
       default:  '""'
   command:
-    - --username
-    - '!Ref EDLUsername'
-    - --password
-    - '!Ref EDLPassword'
     - --bucket
     - '!Ref Bucket'
     - --bucket-prefix

--- a/job_spec/AUTORIFT_ITS_LIVE.yml
+++ b/job_spec/AUTORIFT_ITS_LIVE.yml
@@ -32,19 +32,15 @@ AUTORIFT:
               minLength: 23
               maxLength: 24
               example: S2A_22WEB_20200627_0_L1C
-            - description: The name of the Landsat 8 Collection 2 granule to process
+            - description: The name of the Landsat 8 or 9 Collection 2 granule to process
               type: string
-              pattern: "^L[CO]08_"
+              pattern: "^L[CO]0[89]_"
               minLength: 40
               maxLength: 40
               example: LC08_L1GT_118112_20210107_20210107_02_RT
     bucket_prefix:
       default:  '""'
   command:
-    - --username
-    - '!Ref EDLUsername'
-    - --password
-    - '!Ref EDLPassword'
     - --bucket
     - '!Ref Bucket'
     - --bucket-prefix

--- a/job_spec/AUTORIFT_ITS_LIVE_EU.yml
+++ b/job_spec/AUTORIFT_ITS_LIVE_EU.yml
@@ -32,19 +32,15 @@ AUTORIFT:
               minLength: 23
               maxLength: 24
               example: S2A_22WEB_20200627_0_L1C
-            - description: The name of the Landsat 8 Collection 2 granule to process
+            - description: The name of the Landsat 8 or 9 Collection 2 granule to process
               type: string
-              pattern: "^L[CO]08_"
+              pattern: "^L[CO]0[89]_"
               minLength: 40
               maxLength: 40
               example: LC08_L1GT_118112_20210107_20210107_02_RT
     bucket_prefix:
       default:  '""'
   command:
-    - --username
-    - '!Ref EDLUsername'
-    - --password
-    - '!Ref EDLPassword'
     - --bucket
     - '!Ref Bucket'
     - --bucket-prefix

--- a/job_spec/INSAR_GAMMA.yml
+++ b/job_spec/INSAR_GAMMA.yml
@@ -67,10 +67,6 @@ INSAR_GAMMA:
   command:
     - ++process
     - insar
-    - --username
-    - '!Ref EDLUsername'
-    - --password
-    - '!Ref EDLPassword'
     - --bucket
     - '!Ref Bucket'
     - --bucket-prefix

--- a/job_spec/INSAR_ISCE.yml
+++ b/job_spec/INSAR_ISCE.yml
@@ -31,10 +31,6 @@ INSAR_ISCE:
     bucket_prefix:
       default:  '""'
   command:
-    - --username
-    - '!Ref EDLUsername'
-    - --password
-    - '!Ref EDLPassword'
     - --bucket
     - '!Ref Bucket'
     - --bucket-prefix

--- a/job_spec/INSAR_ISCE_TEST.yml
+++ b/job_spec/INSAR_ISCE_TEST.yml
@@ -32,10 +32,6 @@ INSAR_ISCE_TEST:
     bucket_prefix:
       default:  '""'
   command:
-    - --username
-    - '!Ref EDLUsername'
-    - --password
-    - '!Ref EDLPassword'
     - --bucket
     - '!Ref Bucket'
     - --bucket-prefix

--- a/job_spec/RTC_GAMMA.yml
+++ b/job_spec/RTC_GAMMA.yml
@@ -92,10 +92,6 @@ RTC_GAMMA:
   command:
     - ++process
     - rtc
-    - --username
-    - '!Ref EDLUsername'
-    - --password
-    - '!Ref EDLPassword'
     - --bucket
     - '!Ref Bucket'
     - --bucket-prefix

--- a/job_spec/WATER_MAP.yml
+++ b/job_spec/WATER_MAP.yml
@@ -66,10 +66,6 @@ WATER_MAP:
   command:
     - ++process
     - water_map
-    - --username
-    - '!Ref EDLUsername'
-    - --password
-    - '!Ref EDLPassword'
     - --bucket
     - '!Ref Bucket'
     - --bucket-prefix

--- a/lib/dynamo/dynamo/jobs.py
+++ b/lib/dynamo/dynamo/jobs.py
@@ -115,8 +115,11 @@ def update_job(job):
     table = DYNAMODB_RESOURCE.Table(environ['JOBS_TABLE_NAME'])
     primary_key = 'job_id'
     key = {'job_id': job[primary_key]}
-    update_expression = 'SET {}'.format(','.join(f'{k}=:{k}' for k in job if k != primary_key))
-    expression_attribute_values = {f':{k}': v for k, v in job.items() if k != primary_key}
+
+    prepared_job = convert_floats_to_decimals(job)
+    update_expression = 'SET {}'.format(','.join(f'{k}=:{k}' for k in prepared_job if k != primary_key))
+    expression_attribute_values = {f':{k}': v for k, v in prepared_job.items() if k != primary_key}
+
     table.update_item(
         Key=key,
         UpdateExpression=update_expression,

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -3,17 +3,17 @@
 -r requirements-apps-scale-cluster.txt
 -r requirements-apps-start-execution.txt
 -r requirements-apps-update-db.txt
-boto3==1.20.45
+boto3==1.21.7
 jinja2==3.0.3
 moto==1.3.14
-pytest==6.2.5
+pytest==7.0.1
 PyYAML==6.0
-responses==0.17.0
+responses==0.18.0
 flake8==4.0.1
 flake8-import-order==0.18.1
 flake8-blind-except==0.2.0
 flake8-builtins==1.5.3
 openapi-spec-validator==0.4.0
-click==8.0.3
+click==8.0.4
 prance==0.21.8.0
-cfn-lint==0.58.0
+cfn-lint==0.58.2

--- a/requirements-apps-api.txt
+++ b/requirements-apps-api.txt
@@ -6,6 +6,6 @@ prance==0.21.8.0
 PyJWT==2.3.0
 requests==2.27.1
 serverless_wsgi==3.0.0
-shapely==1.8.0
+shapely==1.8.1.post1
 strict-rfc3339==0.7
 ./lib/dynamo/

--- a/tests/test_api/test_submit_job.py
+++ b/tests/test_api/test_submit_job.py
@@ -243,6 +243,7 @@ def test_submit_bad_rtc_granule_names(client):
         'S2A_MSIL1C_20200627T150921_N0209_R025_T22WEB_20200627T170912',
         'S2B_22WEB_20200612_0_L1C',
         'LC08_L1TP_009011_20200820_20200905_02_T1',
+        'LC09_L1GT_215109_20220125_20220125_02_T2',
     ]
     for granule in bad_granule_names:
         batch = [
@@ -263,6 +264,8 @@ def test_submit_good_autorift_granule_names(client, tables):
         'S2B_22WEB_20200612_0_L1C',
         'LC08_L1TP_009011_20200820_20200905_02_T1',
         'LO08_L1GT_043001_20201106_20201110_02_T2',
+        'LC09_L1GT_215109_20220125_20220125_02_T2',
+        'LO09_L1GT_215109_20220210_20220210_02_T2',
     ]
     for granule in good_granule_names:
         batch = [
@@ -295,6 +298,7 @@ def test_submit_bad_autorift_granule_names(client):
         'S1A_IW_GRDH_1SSH_20171122T184459_20171122T184524_019381_020DD8_B825',
         # bad L8 sensor mode
         'LT08_L1GT_041001_20200125_20200925_02_T2',
+        'LT09_L1GT_215109_20220125_20220125_02_T2',
     ]
     for granule in bad_granule_names:
         batch = [

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -155,10 +155,11 @@ def test_check_granules_exist():
     validation.check_granules_exist(['scene1', 'scene2'], granule_metadata)
 
     with raises(validation.GranuleValidationError) as e:
-        validation.check_granules_exist(['scene1', 'scene2', 'scene3', 'scene4', 'S2_foo', 'LC08_bar'],
+        validation.check_granules_exist(['scene1', 'scene2', 'scene3', 'scene4', 'S2_foo', 'LC08_bar', 'LC09_bar'],
                                         granule_metadata)
     assert 'S2_foo' not in str(e)
     assert 'LC08_bar' not in str(e)
+    assert 'LC09_bar' not in str(e)
     assert 'scene1' not in str(e)
     assert 'scene2' not in str(e)
     assert 'scene3' in str(e)
@@ -171,6 +172,9 @@ def test_is_third_party_granule():
     assert validation.is_third_party_granule('LC08_L1TP_009011_20200820_20200905_02_T1')
     assert validation.is_third_party_granule('LO08_L1GT_043001_20201106_20201110_02_T2')
     assert validation.is_third_party_granule('LT08_L1GT_041001_20200125_20200925_02_T2')
+    assert validation.is_third_party_granule('LC09_L1GT_215109_20220125_20220125_02_T2')
+    assert validation.is_third_party_granule('LO09_L1GT_215109_20220210_20220210_02_T2')
+    assert validation.is_third_party_granule('LT09_L1GT_215109_20220210_20220210_02_T2')
     assert not validation.is_third_party_granule('S1A_IW_SLC__1SSH_20150608T205059_20150608T205126_006287_0083E8_C4F0')
     assert not validation.is_third_party_granule('foo')
 

--- a/tests/test_check_processing_time.py
+++ b/tests/test_check_processing_time.py
@@ -1,0 +1,54 @@
+import check_processing_time
+
+
+def test_single_attempt():
+    attempts = [{'Container': {}, 'StartedAt': 500, 'StatusReason': '', 'StoppedAt': 2800}]
+    result = check_processing_time.get_time_from_attempts(attempts)
+    assert result == 2.3
+
+
+def test_multiple_attempts():
+    attempts = [
+        {'Container': {}, 'StartedAt': 500, 'StatusReason': '', 'StoppedAt': 1000},
+        {'Container': {}, 'StartedAt': 3000, 'StatusReason': '', 'StoppedAt': 8700}
+    ]
+    result = check_processing_time.get_time_from_attempts(attempts)
+    assert result == 5.7
+
+
+def test_unsorted_attempts():
+    # I'm not sure if the lambda would ever be given unsorted attempts, but it seems worth testing that it doesn't
+    # depend on the list to be sorted.
+    attempts = [
+        {'Container': {}, 'StartedAt': 3000, 'StatusReason': '', 'StoppedAt': 8700},
+        {'Container': {}, 'StartedAt': 500, 'StatusReason': '', 'StoppedAt': 1000}
+    ]
+    result = check_processing_time.get_time_from_attempts(attempts)
+    assert result == 5.7
+
+
+def test_lambda_handler_with_normal_results():
+    event = {
+        'processing_results': {
+            'Attempts': [
+                {'Container': {}, 'StartedAt': 1644609403693, 'StatusReason': '', 'StoppedAt': 1644609919331},
+                {'Container': {}, 'StartedAt': 1644610107570, 'StatusReason': '', 'StoppedAt': 1644611472015}
+            ]
+        }
+    }
+    response = check_processing_time.lambda_handler(event, None)
+    assert response == (1644611472015 - 1644610107570) / 1000
+
+
+def test_lambda_handler_with_failed_results():
+    event = {
+        'processing_results': {
+            'Error': 'States.TaskFailed',
+            'Cause': '{"Attempts": ['
+                     '{"Container": {}, "StartedAt": 1643834765893, "StatusReason": "", "StoppedAt": 1643834766455}, '
+                     '{"Container": {}, "StartedAt": 1643834888866, "StatusReason": "", "StoppedAt": 1643834889448}, '
+                     '{"Container": {}, "StartedAt": 1643834907858, "StatusReason": "", "StoppedAt": 1643834908466}]}'
+        }
+    }
+    response = check_processing_time.lambda_handler(event, None)
+    assert response == (1643834908466 - 1643834907858) / 1000

--- a/tests/test_dynamo/test_jobs.py
+++ b/tests/test_dynamo/test_jobs.py
@@ -426,7 +426,7 @@ def test_update_job(tables):
     for item in table_items:
         tables.jobs_table.put_item(Item=item)
 
-    job = {'job_id': 'job1', 'status_code': 'status2'}
+    job = {'job_id': 'job1', 'status_code': 'status2', 'processing_time_in_seconds': 1.23}
     dynamo.jobs.update_job(job)
 
     response = tables.jobs_table.scan()
@@ -437,6 +437,7 @@ def test_update_job(tables):
             'user_id': 'user1',
             'status_code': 'status2',
             'request_time': '2000-01-01T00:00:00+00:00',
+            'processing_time_in_seconds': Decimal('1.23'),
         },
     ]
     assert response['Items'] == expected_response


### PR DESCRIPTION
Waiting for https://github.com/ASFHyP3/hyp3-gamma/pull/354 to be merged/deployed before merging this PR.

I made the hyp3-watermap deployment it's own Github workflow so that it can deploy off of the `watermap` branch and the enterprise workflow can deploy solely off the `main` branch.

Comparing `watermap-container` to develop shows the watermap-specific changes, for reference: https://github.com/ASFHyP3/hyp3/compare/develop...watermap-container

I don't see any needed changes to environment variables for the hyp3-watermap environment.

I confirmed in my notes that I've already created the newly-required api gateway access logging IAM role in the watermap account.