### PR TITLE
Expand the fleet size for hyp3-its-live

### DIFF
--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -19,8 +19,8 @@ jobs:
             product_lifetime_in_days: 180
             quota: 0
             job_files: job_spec/AUTORIFT_ITS_LIVE.yml
-            default_max_vcpus: 2640
-            expanded_max_vcpus: 2640
+            default_max_vcpus: 5000
+            expanded_max_vcpus: 5000
             required_surplus: 0
             security_environment: JPL
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id


### PR DESCRIPTION
We can now go up to 10K vCPUs 
![image](https://user-images.githubusercontent.com/7882693/156663602-5bde1a6b-0063-4275-badd-b7000aff4363.png)

Moves to 1/2 way there, doubling our current capacity. 