### PR TITLE
Update hyp3-watermap to HyP3 2.12.0

### DIFF
--- a/.github/actions/deploy-hyp3/action.yml
+++ b/.github/actions/deploy-hyp3/action.yml
@@ -65,6 +65,9 @@ inputs:
   AMI_ID:
     description: "Name of the Systems Manager parameter from which to retrieve the current Ami Id"
     required: true
+  INSTANCE_TYPES:
+    description: "Comma separated list of supported EC2 instance types"
+    required: true
 
 runs:
   using: "composite"
@@ -112,4 +115,5 @@ runs:
                 MonthlyComputeBudget='${{ inputs.MONTHLY_COMPUTE_BUDGET }}' \
                 RequiredSurplus='${{ inputs.REQUIRED_SURPLUS }}' \
                 PermissionsBoundaryPolicyArn='${{ inputs.PERMISSIONS_BOUNDARY_ARN }}' \
-                AmiId='${{ inputs.AMI_ID }}'
+                AmiId='${{ inputs.AMI_ID }}' \
+                InstanceTypes='${{ inputs.INSTANCE_TYPES }}'

--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -21,6 +21,7 @@ jobs:
             quota: 1000
             deploy_ref: refs/heads/main
             job_files: job_spec/AUTORIFT.yml job_spec/INSAR_GAMMA.yml job_spec/RTC_GAMMA.yml
+            instance_types: r5d.xlarge,r5dn.xlarge
             default_max_vcpus: 600
             expanded_max_vcpus: 1600
             required_surplus: 1000
@@ -40,6 +41,7 @@ jobs:
               job_spec/RTC_GAMMA.yml
               job_spec/INSAR_ISCE.yml
               job_spec/WATER_MAP.yml
+            instance_types: r5d.xlarge,r5dn.xlarge
             default_max_vcpus: 600
             expanded_max_vcpus: 1600
             required_surplus: 1000
@@ -54,6 +56,7 @@ jobs:
             quota: 1000
             deploy_ref: refs/heads/main
             job_files: job_spec/AUTORIFT.yml job_spec/INSAR_GAMMA.yml job_spec/RTC_GAMMA.yml
+            instance_types: r5d.xlarge,r5dn.xlarge
             default_max_vcpus: 600
             expanded_max_vcpus: 1600
             required_surplus: 1000
@@ -68,6 +71,7 @@ jobs:
             quota: 1000
             deploy_ref: refs/heads/develop
             job_files: job_spec/AUTORIFT.yml job_spec/INSAR_GAMMA.yml job_spec/RTC_GAMMA.yml
+            instance_types: r5d.xlarge,r5dn.xlarge
             default_max_vcpus: 600
             expanded_max_vcpus: 1600
             required_surplus: 1000
@@ -116,6 +120,7 @@ jobs:
           PERMISSIONS_BOUNDARY_ARN: ${{ secrets.PERMISSIONS_BOUNDARY_ARN }}
           SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
           AMI_ID: ${{ matrix.ami_id }}
+          INSTANCE_TYPES: ${{ matrix.instance_types }}
 
   call-bump-version-workflow:
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -19,8 +19,9 @@ jobs:
             product_lifetime_in_days: 180
             quota: 0
             job_files: job_spec/AUTORIFT_ITS_LIVE.yml
-            default_max_vcpus: 2640
-            expanded_max_vcpus: 2640
+            instance_types: r5d.xlarge,r5dn.xlarge
+            default_max_vcpus: 5000
+            expanded_max_vcpus: 5000
             required_surplus: 0
             security_environment: JPL
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
@@ -32,6 +33,7 @@ jobs:
             product_lifetime_in_days: 180
             quota: 0
             job_files: job_spec/AUTORIFT_ITS_LIVE_EU.yml
+            instance_types: r5d.xlarge,r5dn.xlarge
             default_max_vcpus: 1600
             expanded_max_vcpus: 1600
             required_surplus: 0
@@ -45,6 +47,7 @@ jobs:
             product_lifetime_in_days: 180
             quota: 0
             job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
+            instance_types: c5d.xlarge
             default_max_vcpus: 1600
             expanded_max_vcpus: 1600
             required_surplus: 0
@@ -58,23 +61,11 @@ jobs:
             product_lifetime_in_days: 180
             quota: 0
             job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
+            instance_types: c5d.xlarge
             default_max_vcpus: 1600
             expanded_max_vcpus: 1600
             required_surplus: 0
             security_environment: ASF
-            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
-
-          - environment: hyp3-a19-jpl
-            domain: hyp3-a19-jpl.asf.alaska.edu
-            template_bucket: cf-templates-v4pvone059de-us-west-2
-            image_tag: latest
-            product_lifetime_in_days: 180
-            quota: 0
-            job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
-            default_max_vcpus: 1600
-            expanded_max_vcpus: 1600
-            required_surplus: 0
-            security_environment: JPL
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
 
     environment:
@@ -118,3 +109,4 @@ jobs:
           PERMISSIONS_BOUNDARY_ARN: ${{ secrets.PERMISSIONS_BOUNDARY_ARN }}
           SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
           AMI_ID: ${{ matrix.ami_id }}
+          INSTANCE_TYPES: ${{ matrix.instance_types }}

--- a/.github/workflows/deploy-watermap.yml
+++ b/.github/workflows/deploy-watermap.yml
@@ -19,6 +19,7 @@ jobs:
             product_lifetime_in_days: 14
             quota: 0
             job_files: job_spec/RTC_GAMMA.yml job_spec/WATER_MAP.yml
+            instance_types: r5d.4xlarge,r5dn.4xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640
             required_surplus: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.12.0]
+### Added
+- New `InstanceTypes` parameter to the cloudformation template to specify which EC2 Instance Types are available to the
+  Compute Environment
+- Added `r5dn.xlarge` as an eligible instance type in most HyP3 deployments
+
+### Changed
+- The `job_spec_files` positional argument to [`render_cf.py`](apps/render_cf.py) has been switched to a
+  required `--job-spec-files` optional argument to support multiple open-ended arguments.
+- Set S3 Object Ownership to `Bucket owner enforced` for all buckets so that access via ACLs is no longer supported.
+
 ## [2.11.0]
 ### Changed
 - The HyP3 API is now implemented as an API Gateway REST API, supporting private API deployments.

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ install:
 files ?= job_spec/*.yml
 security_environment ?= ASF
 render:
-	@echo rendering $(files) for $(security_environment); python apps/render_cf.py $(files) -s $(security_environment)
+	@echo rendering $(files) for $(security_environment); python apps/render_cf.py -j $(files) -s $(security_environment)
 
 static: flake8 openapi-validate cfn-lint
 

--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -21,6 +21,9 @@ Parameters:
   PermissionsBoundaryPolicyArn:
     Type: String
 
+  InstanceTypes:
+    Type: CommaDelimitedList
+
 Conditions:
 
   UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryPolicyArn, ""]]
@@ -74,8 +77,7 @@ Resources:
         AllocationStrategy: SPOT_CAPACITY_OPTIMIZED
         MinvCpus: 0
         MaxvCpus: !Ref MaxvCpus
-        InstanceTypes:
-          - r5d.4xlarge
+        InstanceTypes: !Ref InstanceTypes
         ImageId: !Ref AmiId
         Subnets: !Ref SubnetIds
         InstanceRole: !Ref InstanceProfile

--- a/apps/main-cf.yml.j2
+++ b/apps/main-cf.yml.j2
@@ -87,6 +87,11 @@ Parameters:
     MinValue: 0
     Default: 0
 
+  InstanceTypes:
+    Description: EC2 instance types to include in AWS Batch Compute Environment
+    Type: CommaDelimitedList
+    Default: r5d.xlarge
+
   {% if security_environment != 'EDC' %}
   DomainName:
     Description: DNS domain name that will be used to invoke this api.
@@ -141,6 +146,7 @@ Resources:
         AmiId: !Ref AmiId
         ContentBucket: !Ref ContentBucket
         PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
+        InstanceTypes: !Join [",", !Ref InstanceTypes]
       TemplateURL: compute-cf.yml
 
   ScaleCluster:
@@ -208,6 +214,27 @@ Resources:
           - ServerSideEncryptionByDefault:
               SSEAlgorithm: AES256
             BucketKeyEnabled: true
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
+
+  LogBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref LogBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: logging.s3.amazonaws.com
+            Action: s3:PutObject
+            Resource: !Sub "${LogBucket.Arn}/*"
+            Condition:
+              ArnLike:
+                "aws:SourceArn": !GetAtt ContentBucket.Arn
+              StringEquals:
+                "aws:SourceAccount": !Ref AWS::AccountId
 
   ContentBucket:
     Type: AWS::S3::Bucket
@@ -244,6 +271,9 @@ Resources:
               - HEAD
             AllowedOrigins:
               - "*.asf.alaska.edu"
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: BucketOwnerEnforced
 
   {% if security_environment != 'EDC' %}
   BucketPolicy:

--- a/apps/render_cf.py
+++ b/apps/render_cf.py
@@ -36,7 +36,7 @@ def render_templates(job_types, security_environment):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('job_spec_files', nargs='+', type=Path)
+    parser.add_argument('-j', '--job-spec-files', required=True, nargs='+', type=Path)
     parser.add_argument('-s', '--security-environment', default='ASF', choices=['ASF', 'EDC', 'JPL'])
     args = parser.parse_args()
 

--- a/apps/workflow-cf.yml.j2
+++ b/apps/workflow-cf.yml.j2
@@ -58,9 +58,9 @@ Resources:
         ExecutionRoleArn: !GetAtt ExecutionRole.Arn
         ResourceRequirements:
           - Type: VCPU
-            Value: "1"
+            Value: "{{ job_spec['vcpu'] }}"
           - Type: MEMORY
-            Value: "126000"
+            Value: "{{ job_spec['memory'] }}"
         Command:
           {% for command in job_spec['command'] %}
           - {{ command }}

--- a/job_spec/AUTORIFT.yml
+++ b/job_spec/AUTORIFT.yml
@@ -52,3 +52,5 @@ AUTORIFT:
     - Ref::granules
   validators: []
   timeout: 10800
+  vcpu: 1
+  memory: 31600

--- a/job_spec/AUTORIFT_ITS_LIVE.yml
+++ b/job_spec/AUTORIFT_ITS_LIVE.yml
@@ -52,3 +52,5 @@ AUTORIFT:
     - Ref::granules
   validators: []
   timeout: 10800
+  vcpu: 1
+  memory: 31600

--- a/job_spec/AUTORIFT_ITS_LIVE_EU.yml
+++ b/job_spec/AUTORIFT_ITS_LIVE_EU.yml
@@ -52,3 +52,5 @@ AUTORIFT:
     - Ref::granules
   validators: []
   timeout: 10800
+  vcpu: 1
+  memory: 31600

--- a/job_spec/INSAR_GAMMA.yml
+++ b/job_spec/INSAR_GAMMA.yml
@@ -91,3 +91,5 @@ INSAR_GAMMA:
   validators:
     - check_dem_coverage
   timeout: 10800
+  vcpu: 1
+  memory: 31600

--- a/job_spec/INSAR_ISCE.yml
+++ b/job_spec/INSAR_ISCE.yml
@@ -41,3 +41,5 @@ INSAR_ISCE:
     - Ref::secondary_granules
   validators: []
   timeout: 10800
+  vcpu: 1
+  memory: 7500

--- a/job_spec/INSAR_ISCE_TEST.yml
+++ b/job_spec/INSAR_ISCE_TEST.yml
@@ -42,3 +42,5 @@ INSAR_ISCE_TEST:
     - Ref::secondary_granules
   validators: []
   timeout: 10800
+  vcpu: 1
+  memory: 7500

--- a/job_spec/RTC_GAMMA.yml
+++ b/job_spec/RTC_GAMMA.yml
@@ -120,3 +120,5 @@ RTC_GAMMA:
   validators:
     - check_dem_coverage
   timeout: 10800
+  vcpu: 1
+  memory: 126000

--- a/job_spec/WATER_MAP.yml
+++ b/job_spec/WATER_MAP.yml
@@ -88,3 +88,5 @@ WATER_MAP:
   validators:
     - check_dem_coverage
   timeout: 10800
+  vcpu: 1
+  memory: 126000

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -3,7 +3,7 @@
 -r requirements-apps-scale-cluster.txt
 -r requirements-apps-start-execution.txt
 -r requirements-apps-update-db.txt
-boto3==1.21.7
+boto3==1.21.12
 jinja2==3.0.3
 moto==1.3.14
 pytest==7.0.1


### PR DESCRIPTION
Diff between watermap and develop now only differs in the job_spec files for RTC_GAMMA and WATER_MAP jobs, so the stage is potentially set to deploy hyp3-watermap from `main` instead of it's own fork. This PR keep the fork for the moment but gets some of the merge conflicts out of the way.

Here's the diff that shows the only watermap changes now: https://github.com/ASFHyP3/hyp3/compare/develop...watermap-update