### PR TITLE
use jinja templating instead of cloudformation conditions for EDC-spe…

### DIFF
--- a/.github/actions/deploy-hyp3/action.yml
+++ b/.github/actions/deploy-hyp3/action.yml
@@ -90,6 +90,9 @@ runs:
           [ -z ${{ inputs.CERTIFICATE_ARN }} ] && export CERTIFICATE_ARN="" \
             || export CERTIFICATE_ARN="CertificateArn=${{ inputs.CERTIFICATE_ARN }}"
 
+          [ -z ${{ inputs.PERMISSIONS_BOUNDARY_ARN }} ] && export PERMISSIONS_BOUNDARY_ARN="" \
+            || export PERMISSIONS_BOUNDARY_ARN="PermissionsBoundaryPolicyArn=${{ inputs.PERMISSIONS_BOUNDARY_ARN }}"
+
           aws cloudformation package \
             --template-file apps/main-cf.yml \
             --s3-bucket ${{ inputs.TEMPLATE_BUCKET }} \
@@ -108,12 +111,12 @@ runs:
                 ProductLifetimeInDays='${{ inputs.PRODUCT_LIFETIME }}' \
                 $DOMAIN_NAME \
                 $CERTIFICATE_ARN \
+                $PERMISSIONS_BOUNDARY_ARN \
                 MonthlyJobQuotaPerUser='${{ inputs.MONTHLY_JOB_QUOTA_PER_USER }}' \
                 BannedCidrBlocks='${{ inputs.BANNED_CIDR_BLOCKS }}' \
                 DefaultMaxvCpus='${{ inputs.DEFAULT_MAX_VCPUS }}' \
                 ExpandedMaxvCpus='${{ inputs.EXPANDED_MAX_VCPUS }}' \
                 MonthlyComputeBudget='${{ inputs.MONTHLY_COMPUTE_BUDGET }}' \
                 RequiredSurplus='${{ inputs.REQUIRED_SURPLUS }}' \
-                PermissionsBoundaryPolicyArn='${{ inputs.PERMISSIONS_BOUNDARY_ARN }}' \
                 AmiId='${{ inputs.AMI_ID }}' \
                 InstanceTypes='${{ inputs.INSTANCE_TYPES }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.12.2]
+### Changed
+- Cloudformation stack parameters that are specific to Earthdata Cloud environments are now managed via Jinja templates,
+  rather than CloudFormation conditions.
+
 ## [2.12.1]
 ### Added
 - A `JPL-public` security environment when rendering CloudFormation templates which will

--- a/apps/check-processing-time/check-processing-time-cf.yml.j2
+++ b/apps/check-processing-time/check-processing-time-cf.yml.j2
@@ -1,5 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 
+{% if security_environment == 'EDC' %}
 Parameters:
 
   PermissionsBoundaryPolicyArn:
@@ -10,12 +11,7 @@ Parameters:
 
   SubnetIds:
     Type: CommaDelimitedList
-
-Conditions:
-
-  UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryPolicyArn, ""]]
-
-  LambdasInVpc: !Not [!Equals [!Ref SecurityGroupId, ""]]
+{% endif %}
 
 Outputs:
 
@@ -44,10 +40,12 @@ Resources:
           Principal:
             Service: lambda.amazonaws.com
           Effect: Allow
-      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
       ManagedPolicyArns:
-        - !If [LambdasInVpc, arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole, !Ref AWS::NoValue]
         - !Ref Policy
+      {% if security_environment == 'EDC' %}
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
+      {% endif %}
 
   Policy:
     Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}
@@ -74,10 +72,9 @@ Resources:
       Role: !GetAtt Role.Arn
       Runtime: python3.8
       Timeout: 30
+      {% if security_environment == 'EDC' %}
       VpcConfig:
-        !If
-          - LambdasInVpc
-          - SecurityGroupIds:
-              - !Ref SecurityGroupId
-            SubnetIds: !Ref SubnetIds
-          - !Ref AWS::NoValue
+        SecurityGroupIds:
+          - !Ref SecurityGroupId
+        SubnetIds: !Ref SubnetIds
+      {% endif %}

--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -18,15 +18,13 @@ Parameters:
   ContentBucket:
     Type: String
 
-  PermissionsBoundaryPolicyArn:
-    Type: String
-
   InstanceTypes:
     Type: CommaDelimitedList
 
-Conditions:
-
-  UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryPolicyArn, ""]]
+  {% if security_environment == 'EDC' %}
+  PermissionsBoundaryPolicyArn:
+    Type: String
+  {% endif %}
 
 Outputs:
 
@@ -115,7 +113,9 @@ Resources:
           Principal:
             Service: ecs-tasks.amazonaws.com
           Effect: Allow
-      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
+      {% if security_environment == 'EDC' %}
+      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
+      {% endif %}
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
         - !Ref TaskPolicy
@@ -151,7 +151,9 @@ Resources:
           Principal:
             Service: batch.amazonaws.com
           Effect: Allow
-      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
+      {% if security_environment == 'EDC' %}
+      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
+      {% endif %}
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole
 
@@ -169,7 +171,9 @@ Resources:
           Principal:
             Service: ec2.amazonaws.com
           Effect: Allow
-      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
+      {% if security_environment == 'EDC' %}
+      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
+      {% endif %}
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
 

--- a/apps/get-files/get-files-cf.yml.j2
+++ b/apps/get-files/get-files-cf.yml.j2
@@ -5,6 +5,7 @@ Parameters:
   Bucket:
     Type: String
 
+  {% if security_environment == 'EDC' %}
   PermissionsBoundaryPolicyArn:
     Type: String
 
@@ -13,12 +14,7 @@ Parameters:
 
   SubnetIds:
     Type: CommaDelimitedList
-
-Conditions:
-
-  UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryPolicyArn, ""]]
-
-  LambdasInVpc: !Not [!Equals [!Ref SecurityGroupId, ""]]
+  {% endif %}
 
 Outputs:
 
@@ -47,10 +43,12 @@ Resources:
           Principal:
             Service: lambda.amazonaws.com
           Effect: Allow
-      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
       ManagedPolicyArns:
-        - !If [LambdasInVpc, arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole, !Ref AWS::NoValue]
         - !Ref Policy
+      {% if security_environment == 'EDC' %}
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
+      {% endif %}
 
   Policy:
     Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}
@@ -88,10 +86,9 @@ Resources:
       Role: !GetAtt Role.Arn
       Runtime: python3.8
       Timeout: 30
+      {% if security_environment == 'EDC' %}
       VpcConfig:
-        !If
-          - LambdasInVpc
-          - SecurityGroupIds:
-              - !Ref SecurityGroupId
-            SubnetIds: !Ref SubnetIds
-          - !Ref AWS::NoValue
+        SecurityGroupIds:
+          - !Ref SecurityGroupId
+        SubnetIds: !Ref SubnetIds
+      {% endif %}

--- a/apps/main-cf.yml.j2
+++ b/apps/main-cf.yml.j2
@@ -55,10 +55,6 @@ Parameters:
     Type: String
     Default: ""
 
-  PermissionsBoundaryPolicyArn:
-    Type: String
-    Default: ""
-
   AmiId:
     Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
     Default: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
@@ -100,6 +96,11 @@ Parameters:
   CertificateArn:
     Description: ARN of Certificate in AWS Certificate Manager setup previously for this domain name.
     Type: String
+
+  {% else %}
+  PermissionsBoundaryPolicyArn:
+    Type: String
+    Default: ""
   {% endif %}
 
 Conditions:
@@ -145,8 +146,10 @@ Resources:
         MaxvCpus: !Ref DefaultMaxvCpus
         AmiId: !Ref AmiId
         ContentBucket: !Ref ContentBucket
-        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
         InstanceTypes: !Join [",", !Ref InstanceTypes]
+        {% if security_environment == 'EDC' %}
+        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
+        {% endif %}
       TemplateURL: compute-cf.yml
 
   ScaleCluster:
@@ -159,9 +162,11 @@ Resources:
         ExpandedMaxvCpus: !Ref ExpandedMaxvCpus
         MonthlyComputeBudget: !Ref MonthlyComputeBudget
         RequiredSurplus: !Ref RequiredSurplus
+        {% if security_environment == 'EDC' %}
         PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
-        SecurityGroupId: {{ '!GetAtt Cluster.Outputs.SecurityGroupId' if security_environment == 'EDC' else '""' }}
-        SubnetIds: {{ '!Join [",", !Ref SubnetIds]' if security_environment == 'EDC' else '""' }}
+        SecurityGroupId: !GetAtt Cluster.Outputs.SecurityGroupId
+        SubnetIds: !Join [",", !Ref SubnetIds]
+        {% endif %}
       TemplateURL: scale-cluster/scale-cluster-cf.yml
 
   ProcessNewGranules:
@@ -172,9 +177,11 @@ Resources:
         UsersTable: !Ref UsersTable
         SubscriptionsTable: !Ref SubscriptionsTable
         MonthlyJobQuotaPerUser: !Ref MonthlyJobQuotaPerUser
+        {% if security_environment == 'EDC' %}
         PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
-        SecurityGroupId: {{ '!GetAtt Cluster.Outputs.SecurityGroupId' if security_environment == 'EDC' else '""' }}
-        SubnetIds: {{ '!Join [",", !Ref SubnetIds]' if security_environment == 'EDC' else '""' }}
+        SecurityGroupId: !GetAtt Cluster.Outputs.SecurityGroupId
+        SubnetIds: !Join [",", !Ref SubnetIds]
+        {% endif %}
       TemplateURL: process-new-granules/process-new-granules-cf.yml
 
   StepFunction:
@@ -186,10 +193,12 @@ Resources:
         JobsTable: !Ref JobsTable
         Bucket: !Ref ContentBucket
         ImageTag: !Ref ImageTag
-        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
-        SecurityGroupId: {{ '!GetAtt Cluster.Outputs.SecurityGroupId' if security_environment == 'EDC' else '""' }}
-        SubnetIds: {{ '!Join [",", !Ref SubnetIds]' if security_environment == 'EDC' else '""' }}
         SecretArn: !Ref Secret
+        {% if security_environment == 'EDC' %}
+        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
+        SecurityGroupId: !GetAtt Cluster.Outputs.SecurityGroupId
+        SubnetIds: !Join [",", !Ref SubnetIds]
+        {% endif %}
       TemplateURL: workflow-cf.yml
 
   Monitoring:

--- a/apps/process-new-granules/process-new-granules-cf.yml.j2
+++ b/apps/process-new-granules/process-new-granules-cf.yml.j2
@@ -14,6 +14,7 @@ Parameters:
   MonthlyJobQuotaPerUser:
     Type: Number
 
+  {% if security_environment == 'EDC' %}
   PermissionsBoundaryPolicyArn:
     Type: String
 
@@ -22,12 +23,7 @@ Parameters:
 
   SubnetIds:
     Type: CommaDelimitedList
-
-Conditions:
-
-  UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryPolicyArn, ""]]
-
-  LambdasInVpc: !Not [!Equals [!Ref SecurityGroupId, ""]]
+  {% endif %}
 
 Outputs:
 
@@ -56,10 +52,12 @@ Resources:
           Principal:
             Service: lambda.amazonaws.com
           Effect: Allow
-      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
       ManagedPolicyArns:
-        - !If [LambdasInVpc, arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole, !Ref AWS::NoValue]
         - !Ref Policy
+      {% if security_environment == 'EDC' %}
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
+      {% endif %}
 
   Policy:
     Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}
@@ -105,13 +103,12 @@ Resources:
       Role: !GetAtt Role.Arn
       Runtime: python3.8
       Timeout: 900
+      {% if security_environment == 'EDC' %}
       VpcConfig:
-        !If
-          - LambdasInVpc
-          - SecurityGroupIds:
-              - !Ref SecurityGroupId
-            SubnetIds: !Ref SubnetIds
-          - !Ref AWS::NoValue
+        SecurityGroupIds:
+          - !Ref SecurityGroupId
+        SubnetIds: !Ref SubnetIds
+      {% endif %}
 
   EventInvokeConfig:
     Type: AWS::Lambda::EventInvokeConfig

--- a/apps/scale-cluster/scale-cluster-cf.yml.j2
+++ b/apps/scale-cluster/scale-cluster-cf.yml.j2
@@ -21,6 +21,7 @@ Parameters:
     Type: Number
     MinValue: 0
 
+  {% if security_environment == 'EDC' %}
   PermissionsBoundaryPolicyArn:
     Type: String
 
@@ -29,12 +30,7 @@ Parameters:
 
   SubnetIds:
     Type: CommaDelimitedList
-
-Conditions:
-
-  UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryPolicyArn, ""]]
-
-  LambdasInVpc: !Not [!Equals [!Ref SecurityGroupId, ""]]
+  {% endif %}
 
 Resources:
 
@@ -58,10 +54,12 @@ Resources:
           Principal:
             Service: lambda.amazonaws.com
           Effect: Allow
-      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
       ManagedPolicyArns:
-        - !If [LambdasInVpc, arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole, !Ref AWS::NoValue]
         - !Ref Policy
+      {% if security_environment == 'EDC' %}
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
+      {% endif %}
 
   Policy:
     Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}
@@ -103,13 +101,12 @@ Resources:
       Role: !GetAtt Role.Arn
       Runtime: python3.8
       Timeout: 30
+      {% if security_environment == 'EDC' %}
       VpcConfig:
-        !If
-          - LambdasInVpc
-          - SecurityGroupIds:
-              - !Ref SecurityGroupId
-            SubnetIds: !Ref SubnetIds
-          - !Ref AWS::NoValue
+        SecurityGroupIds:
+          - !Ref SecurityGroupId
+        SubnetIds: !Ref SubnetIds
+      {% endif %}
 
   EventInvokeConfig:
     Type: AWS::Lambda::EventInvokeConfig

--- a/apps/start-execution/start-execution-cf.yml.j2
+++ b/apps/start-execution/start-execution-cf.yml.j2
@@ -8,6 +8,7 @@ Parameters:
   StepFunctionArn:
     Type: String
 
+  {% if security_environment == 'EDC' %}
   PermissionsBoundaryPolicyArn:
     Type: String
 
@@ -16,12 +17,7 @@ Parameters:
 
   SubnetIds:
     Type: CommaDelimitedList
-
-Conditions:
-
-  UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryPolicyArn, ""]]
-
-  LambdasInVpc: !Not [!Equals [!Ref SecurityGroupId, ""]]
+  {% endif %}
 
 Resources:
 
@@ -45,10 +41,12 @@ Resources:
           Principal:
             Service: lambda.amazonaws.com
           Effect: Allow
-      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
       ManagedPolicyArns:
-        - !If [LambdasInVpc, arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole, !Ref AWS::NoValue]
         - !Ref Policy
+      {% if security_environment == 'EDC' %}
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
+      {% endif %}
 
   Policy:
     Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}
@@ -85,13 +83,12 @@ Resources:
       Role: !GetAtt Role.Arn
       Runtime: python3.8
       Timeout: 45
+      {% if security_environment == 'EDC' %}
       VpcConfig:
-        !If
-          - LambdasInVpc
-          - SecurityGroupIds:
-              - !Ref SecurityGroupId
-            SubnetIds: !Ref SubnetIds
-          - !Ref AWS::NoValue
+        SecurityGroupIds:
+          - !Ref SecurityGroupId
+        SubnetIds: !Ref SubnetIds
+      {% endif %}
 
   EventInvokeConfig:
     Type: AWS::Lambda::EventInvokeConfig

--- a/apps/update-db/update-db-cf.yml.j2
+++ b/apps/update-db/update-db-cf.yml.j2
@@ -5,6 +5,7 @@ Parameters:
   JobsTable:
     Type: String
 
+  {% if security_environment == 'EDC' %}
   PermissionsBoundaryPolicyArn:
     Type: String
 
@@ -13,12 +14,7 @@ Parameters:
 
   SubnetIds:
     Type: CommaDelimitedList
-
-Conditions:
-
-  UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryPolicyArn, ""]]
-
-  LambdasInVpc: !Not [!Equals [!Ref SecurityGroupId, ""]]
+  {% endif %}
 
 Outputs:
 
@@ -47,10 +43,12 @@ Resources:
           Principal:
             Service: lambda.amazonaws.com
           Effect: Allow
-      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
       ManagedPolicyArns:
-        - !If [LambdasInVpc, arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole, !Ref AWS::NoValue]
         - !Ref Policy
+      {% if security_environment == 'EDC' %}
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
+      {% endif %}
 
   Policy:
     Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}
@@ -83,10 +81,9 @@ Resources:
       Role: !GetAtt Role.Arn
       Runtime: python3.8
       Timeout: 30
+      {% if security_environment == 'EDC' %}
       VpcConfig:
-        !If
-          - LambdasInVpc
-          - SecurityGroupIds:
-              - !Ref SecurityGroupId
-            SubnetIds: !Ref SubnetIds
-          - !Ref AWS::NoValue
+        SecurityGroupIds:
+          - !Ref SecurityGroupId
+        SubnetIds: !Ref SubnetIds
+      {% endif %}

--- a/apps/upload-log/upload-log-cf.yml.j2
+++ b/apps/upload-log/upload-log-cf.yml.j2
@@ -5,6 +5,7 @@ Parameters:
   Bucket:
     Type: String
 
+  {% if security_environment == 'EDC' %}
   PermissionsBoundaryPolicyArn:
     Type: String
 
@@ -13,12 +14,7 @@ Parameters:
 
   SubnetIds:
     Type: CommaDelimitedList
-
-Conditions:
-
-  UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryPolicyArn, ""]]
-
-  LambdasInVpc: !Not [!Equals [!Ref SecurityGroupId, ""]]
+  {% endif %}
 
 Outputs:
 
@@ -47,10 +43,12 @@ Resources:
           Principal:
             Service: lambda.amazonaws.com
           Effect: Allow
-      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
       ManagedPolicyArns:
-        - !If [LambdasInVpc, arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole, !Ref AWS::NoValue]
         - !Ref Policy
+      {% if security_environment == 'EDC' %}
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
+      {% endif %}
 
   Policy:
     Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}
@@ -88,10 +86,9 @@ Resources:
       Role: !GetAtt Role.Arn
       Runtime: python3.8
       Timeout: 30
+      {% if security_environment == 'EDC' %}
       VpcConfig:
-        !If
-          - LambdasInVpc
-          - SecurityGroupIds:
-              - !Ref SecurityGroupId
-            SubnetIds: !Ref SubnetIds
-          - !Ref AWS::NoValue
+        SecurityGroupIds:
+          - !Ref SecurityGroupId
+        SubnetIds: !Ref SubnetIds
+      {% endif %}

--- a/apps/workflow-cf.yml.j2
+++ b/apps/workflow-cf.yml.j2
@@ -214,8 +214,8 @@ Resources:
           Effect: Allow
       ManagedPolicyArns:
         - !Ref ExecutionPolicy
-      {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      {% if security_environment == 'EDC' %}
       PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
       {% endif %}
 

--- a/apps/workflow-cf.yml.j2
+++ b/apps/workflow-cf.yml.j2
@@ -17,6 +17,10 @@ Parameters:
   TaskRoleArn:
     Type: String
 
+  SecretArn:
+    Type: String
+
+  {% if security_environment == 'EDC' %}
   PermissionsBoundaryPolicyArn:
     Type: String
 
@@ -25,13 +29,7 @@ Parameters:
 
   SubnetIds:
     Type: CommaDelimitedList
-
-  SecretArn:
-    Type: String
-
-Conditions:
-
-  UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundaryPolicyArn, ""]]
+  {% endif %}
 
 Outputs:
 
@@ -103,9 +101,11 @@ Resources:
           Principal:
             Service: states.amazonaws.com
           Effect: Allow
-      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
       ManagedPolicyArns:
         - !Ref StepFunctionPolicy
+      {% if security_environment == 'EDC' %}
+      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
+      {% endif %}
 
   StepFunctionPolicy:
     Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}
@@ -143,9 +143,11 @@ Resources:
     Properties:
       Parameters:
         JobsTable: !Ref JobsTable
+        {% if security_environment == 'EDC' %}
         PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
         SecurityGroupId: !Ref SecurityGroupId
         SubnetIds: !Join [",", !Ref SubnetIds]
+        {% endif %}
       TemplateURL: update-db/update-db-cf.yml
 
   GetFiles:
@@ -153,18 +155,22 @@ Resources:
     Properties:
       Parameters:
         Bucket: !Ref Bucket
+        {% if security_environment == 'EDC' %}
         PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
         SecurityGroupId: !Ref SecurityGroupId
         SubnetIds: !Join [",", !Ref SubnetIds]
+        {% endif %}
       TemplateURL: get-files/get-files-cf.yml
 
   CheckProcessingTime:
     Type: AWS::CloudFormation::Stack
     Properties:
+      {% if security_environment == 'EDC' %}
       Parameters:
         PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
         SecurityGroupId: !Ref SecurityGroupId
         SubnetIds: !Join [",", !Ref SubnetIds]
+      {% endif %}
       TemplateURL: check-processing-time/check-processing-time-cf.yml
 
   StartExecution:
@@ -173,9 +179,11 @@ Resources:
       Parameters:
         JobsTable: !Ref JobsTable
         StepFunctionArn: !Ref StepFunction
+        {% if security_environment == 'EDC' %}
         PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
         SecurityGroupId: !Ref SecurityGroupId
         SubnetIds: !Join [",", !Ref SubnetIds]
+        {% endif %}
       TemplateURL: start-execution/start-execution-cf.yml
 
   UploadLog:
@@ -183,9 +191,11 @@ Resources:
     Properties:
       Parameters:
         Bucket: !Ref Bucket
+        {% if security_environment == 'EDC' %}
         PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
         SecurityGroupId: !Ref SecurityGroupId
         SubnetIds: !Join [",", !Ref SubnetIds]
+        {% endif %}
       TemplateURL: upload-log/upload-log-cf.yml
 
   ExecutionRole:
@@ -202,10 +212,12 @@ Resources:
           Principal:
             Service: ecs-tasks.amazonaws.com
           Effect: Allow
-      PermissionsBoundary: !If [UsePermissionsBoundary, !Ref PermissionsBoundaryPolicyArn, !Ref AWS::NoValue]
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
         - !Ref ExecutionPolicy
+      {% if security_environment == 'EDC' %}
+        - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
+      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
+      {% endif %}
 
   ExecutionPolicy:
     Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}


### PR DESCRIPTION
…cific parameters

This extends the model of using templating introduced for the API stack in [v2.11.0](https://github.com/ASFHyP3/hyp3/compare/v2.10.0...v2.11.0) to the rest of the repository.

Also paves the way to add additional EDC-specific stack parameters related to distributing processed data products via AWS CloudFront.