### PR TITLE
use explicit launch template version in compute environment definition

### DIFF
--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -83,7 +83,7 @@ Resources:
           - !Ref SecurityGroup
         LaunchTemplate:
           LaunchTemplateId: !Ref LaunchTemplate
-          Version: $Latest
+          Version: !GetAtt LaunchTemplate.LatestVersionNumber
         Tags:
           Name: !Ref AWS::StackName
 


### PR DESCRIPTION
https://github.com/ASFHyP3/hyp3/pull/829 merged and deployed successfully, creating a new version of the launch template. However, the derived template used by the Batch Compute Environment was *not* updated. Per https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-computeenvironment-launchtemplatespecification.html :

> After the compute environment is created, the launch template version that's used isn't changed, even if the $Default or $Latest version for the launch template is updated. To use a new launch template version, create a new compute environment, add the new compute environment to the existing job queue, remove the old compute environment from the job queue, and delete the old compute environment.

At a minimum this PR will make the version of the launch template being used more explicit. I'm also hopeful this will force a new new Compute Environment to be generated when the launch template changes, but we'll have to merge and see.