### PR TITLE
Add missing instance type to hyp3-a19-jpl

### DIFF
--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -75,6 +75,7 @@ jobs:
             product_lifetime_in_days: 180
             quota: 0
             job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
+            instance_types: c5d.xlarge
             default_max_vcpus: 1600
             expanded_max_vcpus: 1600
             required_surplus: 0


### PR DESCRIPTION
Last deployment to `hyp3-a19-jpl` failed due to no instance type being specified:
https://github.com/ASFHyP3/hyp3/runs/5468414744?check_suite_focus=true

```
2022-03-08 09:40:48 UTC-0900 | ComputeEnvironment | UPDATE_FAILED |1 validation error detected: Value 'Error executing request, Exception : Instance type can only be one of [m6g.xlarge,...
```