### PR TITLE
ASF Deployment documentation

### DIFF
--- a/docs/deployments/ASF-deployment-ci-cf.yml
+++ b/docs/deployments/ASF-deployment-ci-cf.yml
@@ -62,11 +62,11 @@ Resources:
                 Resource: !GetAtt CloudformationDeploymentRole.Arn
                 Condition:
                   StringLike:
-                    iam:AssociatedResourceArn: !Sub "arn:aws:cloudformation:us-west-2:${AWS::AccountId}:stack/*"
+                    iam:AssociatedResourceArn: !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*"
 
               - Effect: Allow
                 Action: s3:PutObject
-                Resource: !Sub "arn:aws:s3::${CFBucket}:/*"
+                Resource: !Sub "arn:aws:s3:::${CFBucket}/*"
 
               - Effect: Allow
                 Action:
@@ -78,7 +78,7 @@ Resources:
                   - cloudformation:ExecuteChangeSet
                   - cloudformation:DeleteChangeSet
                   - cloudformation:GetTemplateSummary
-                Resource: !Sub "arn:aws:cloudformation:us-west-2:${AWS::AccountId}:stack/*"
+                Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*"
 
   ApiGatewayLoggingRole:
     Type: AWS::IAM::Role

--- a/docs/deployments/ASF-deployment-ci-cf.yml
+++ b/docs/deployments/ASF-deployment-ci-cf.yml
@@ -2,7 +2,7 @@ AWSTemplateFormatVersion: 2010-09-09
 
 Parameters:
   TemplateBucketName:
-    Description: AWS S3 bucket fo uploading CloudFormation templates
+    Description: AWS S3 bucket name for uploading CloudFormation templates
     Type: String
 
 Resources:

--- a/docs/deployments/ASF-deployment-ci-cf.yml
+++ b/docs/deployments/ASF-deployment-ci-cf.yml
@@ -31,13 +31,13 @@ Resources:
               - secretsmanager:*
               - kms:*
             Resource": "*"
-    AssumeRolePolicyDocument:
-      Version: 2012-10-17
-      Statement:
-        Action: sts:AssumeRole
-        Principal:
-          AWS: !Ref AWS::AccountId
-        Effect: Allow
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Action: sts:AssumeRole
+          Principal:
+            AWS: !Ref AWS::AccountId
+          Effect: Allow
 
   GithubActionsUser:
     Type: AWS::IAM::User

--- a/docs/deployments/ASF-deployment-ci-cf.yml
+++ b/docs/deployments/ASF-deployment-ci-cf.yml
@@ -1,0 +1,88 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Parameters:
+  CFBucket:
+      Description: AWS S3 bucket fo uploading CloudFormation templates
+      Type: String
+
+Resources:
+  CloudformationDeploymentRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Policies:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - ec2:*
+              - s3:*
+              - ecs:*
+              - batch:*
+              - events:*
+              - logs:*
+              - iam:*
+              - lambda:*
+              - ssm:GetParameters
+              - apigateway:*
+              - states:*
+              - dynamodb:*
+              - cloudwatch:*
+              - sns:*
+              - secretsmanager:*
+              - kms:*
+            Resource": "*"
+
+  GithubActionsUser:
+    Type: AWS::IAM::User
+    UserName: github-actions
+    Properties:
+      Policies:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - cloudformation:ValidateTemplate
+              - cloudformation:DescribeStacks
+              - ssm:GetParameters
+            Resource: "*"
+
+          - Effect: Allow
+            Action: iam:PassRole
+            Resource: !GetAtt CloudformationDeploymentRole.Arn
+            Condition:
+              StringLike:
+                iam:AssociatedResourceArn: !Sub "arn:aws:cloudformation:us-west-2:${AWS::AccountId}:stack/*"
+
+          - Effect: Allow
+            Action: s3:PutObject
+            Resource: !Sub "arn:aws:s3::${CFBucket}:/*"
+
+          - Effect: Allow
+            Action:
+              - cloudformation:SetStackPolicy
+              - cloudformation:CreateStack
+              - cloudformation:UpdateStack
+              - cloudformation:CreateChangeSet
+              - cloudformation:DescribeChangeSet
+              - cloudformation:ExecuteChangeSet
+              - cloudformation:DeleteChangeSet
+              - cloudformation:GetTemplateSummary
+            Resource: !Sub "arn:aws:cloudformation:us-west-2:${AWS::AccountId}:stack/*"
+
+  ApiGatewayLoggingRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Action: sts:AssumeRole
+          Principal:
+            Service: apigateway.amazonaws.com
+          Effect: Allow
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+
+  ApiGatewayLoggingPermission:
+    Type: AWS::ApiGateway::Account
+    Properties:
+      CloudWatchRoleArn: !GetAtt ApiGatewayLoggingRole.Arn

--- a/docs/deployments/ASF-deployment-ci-cf.yml
+++ b/docs/deployments/ASF-deployment-ci-cf.yml
@@ -14,7 +14,7 @@ Resources:
         Statement:
           Action: sts:AssumeRole
           Principal:
-            AWS: !Ref AWS::AccountId
+            Service: cloudformation.amazonaws.com
           Effect: Allow
       Policies:
         - PolicyName: cloud-formation-deployment-policy

--- a/docs/deployments/ASF-deployment-ci-cf.yml
+++ b/docs/deployments/ASF-deployment-ci-cf.yml
@@ -1,7 +1,7 @@
 AWSTemplateFormatVersion: 2010-09-09
 
 Parameters:
-  CFBucket:
+  TemplateBucketName:
     Description: AWS S3 bucket fo uploading CloudFormation templates
     Type: String
 
@@ -9,6 +9,13 @@ Resources:
   CloudformationDeploymentRole:
     Type: AWS::IAM::Role
     Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Action: sts:AssumeRole
+          Principal:
+            AWS: !Ref AWS::AccountId
+          Effect: Allow
       Policies:
         - PolicyName: cloud-formation-deployment-policy
           PolicyDocument:
@@ -33,13 +40,6 @@ Resources:
                   - secretsmanager:*
                   - kms:*
                 Resource: "*"
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          Action: sts:AssumeRole
-          Principal:
-            AWS: !Ref AWS::AccountId
-          Effect: Allow
 
   GithubActionsUser:
     Type: AWS::IAM::User
@@ -66,7 +66,7 @@ Resources:
 
               - Effect: Allow
                 Action: s3:PutObject
-                Resource: !Sub "arn:aws:s3:::${CFBucket}/*"
+                Resource: !Sub "arn:aws:s3:::${TemplateBucketName}/*"
 
               - Effect: Allow
                 Action:

--- a/docs/deployments/ASF-deployment-ci-cf.yml
+++ b/docs/deployments/ASF-deployment-ci-cf.yml
@@ -2,35 +2,37 @@ AWSTemplateFormatVersion: 2010-09-09
 
 Parameters:
   CFBucket:
-      Description: AWS S3 bucket fo uploading CloudFormation templates
-      Type: String
+    Description: AWS S3 bucket fo uploading CloudFormation templates
+    Type: String
 
 Resources:
   CloudformationDeploymentRole:
     Type: AWS::IAM::Role
     Properties:
       Policies:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Action:
-              - ec2:*
-              - s3:*
-              - ecs:*
-              - batch:*
-              - events:*
-              - logs:*
-              - iam:*
-              - lambda:*
-              - ssm:GetParameters
-              - apigateway:*
-              - states:*
-              - dynamodb:*
-              - cloudwatch:*
-              - sns:*
-              - secretsmanager:*
-              - kms:*
-            Resource": "*"
+        - PolicyName: cloud-formation-deployment-policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:*
+                  - s3:*
+                  - ecs:*
+                  - batch:*
+                  - events:*
+                  - logs:*
+                  - iam:*
+                  - lambda:*
+                  - ssm:GetParameters
+                  - apigateway:*
+                  - states:*
+                  - dynamodb:*
+                  - cloudwatch:*
+                  - sns:*
+                  - secretsmanager:*
+                  - kms:*
+                Resource: "*"
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -41,40 +43,42 @@ Resources:
 
   GithubActionsUser:
     Type: AWS::IAM::User
-    UserName: github-actions
     Properties:
+      UserName: github-actions
       Policies:
-        Version: 2012-10-17
-        Statement:
-          - Effect: Allow
-            Action:
-              - cloudformation:ValidateTemplate
-              - cloudformation:DescribeStacks
-              - ssm:GetParameters
-            Resource: "*"
+        - PolicyName: github-actions-user-policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - cloudformation:ValidateTemplate
+                  - cloudformation:DescribeStacks
+                  - ssm:GetParameters
+                Resource: "*"
 
-          - Effect: Allow
-            Action: iam:PassRole
-            Resource: !GetAtt CloudformationDeploymentRole.Arn
-            Condition:
-              StringLike:
-                iam:AssociatedResourceArn: !Sub "arn:aws:cloudformation:us-west-2:${AWS::AccountId}:stack/*"
+              - Effect: Allow
+                Action: iam:PassRole
+                Resource: !GetAtt CloudformationDeploymentRole.Arn
+                Condition:
+                  StringLike:
+                    iam:AssociatedResourceArn: !Sub "arn:aws:cloudformation:us-west-2:${AWS::AccountId}:stack/*"
 
-          - Effect: Allow
-            Action: s3:PutObject
-            Resource: !Sub "arn:aws:s3::${CFBucket}:/*"
+              - Effect: Allow
+                Action: s3:PutObject
+                Resource: !Sub "arn:aws:s3::${CFBucket}:/*"
 
-          - Effect: Allow
-            Action:
-              - cloudformation:SetStackPolicy
-              - cloudformation:CreateStack
-              - cloudformation:UpdateStack
-              - cloudformation:CreateChangeSet
-              - cloudformation:DescribeChangeSet
-              - cloudformation:ExecuteChangeSet
-              - cloudformation:DeleteChangeSet
-              - cloudformation:GetTemplateSummary
-            Resource: !Sub "arn:aws:cloudformation:us-west-2:${AWS::AccountId}:stack/*"
+              - Effect: Allow
+                Action:
+                  - cloudformation:SetStackPolicy
+                  - cloudformation:CreateStack
+                  - cloudformation:UpdateStack
+                  - cloudformation:CreateChangeSet
+                  - cloudformation:DescribeChangeSet
+                  - cloudformation:ExecuteChangeSet
+                  - cloudformation:DeleteChangeSet
+                  - cloudformation:GetTemplateSummary
+                Resource: !Sub "arn:aws:cloudformation:us-west-2:${AWS::AccountId}:stack/*"
 
   ApiGatewayLoggingRole:
     Type: AWS::IAM::Role

--- a/docs/deployments/ASF-deployment-ci-cf.yml
+++ b/docs/deployments/ASF-deployment-ci-cf.yml
@@ -31,6 +31,13 @@ Resources:
               - secretsmanager:*
               - kms:*
             Resource": "*"
+    AssumeRolePolicyDocument:
+      Version: 2012-10-17
+      Statement:
+        Action: sts:AssumeRole
+        Principal:
+          AWS: !Ref AWS::AccountId
+        Effect: Allow
 
   GithubActionsUser:
     Type: AWS::IAM::User

--- a/docs/deployments/ASF-deployment.md
+++ b/docs/deployments/ASF-deployment.md
@@ -40,12 +40,14 @@ aws cloudformation deploy \
 
 ## 3. Deploy HyP3 to JPL
 
-Once the service user has been created, you can create a set of AWS Access Keys
-which can be used to deploy HyP3 via CI/CD tooling, or manually. 
+Once the `github-actions` IAM user has been created, you can create a set of AWS
+Access Keys for that user, which can be used to deploy HyP3 via CI/CD tooling. 
+You may want to deploy HyP3 manually with the `github-actions` IAM user access keys
+to verify that the `github-actions` user has sufficient deployment permissions.
 
-To deploy HyP3 manually, run these commands from the repository root,
-replacing any `<*>` with appropriate values, and adding any other needed parameter
-overrides for the deployment:
+To deploy HyP3 manually, using either the `github-actions` access keys or your own,
+run these commands from the repository root, replacing any `<*>` with appropriate
+values, and adding any other needed parameter overrides for the deployment:
 
 ```shell
 export AWS_ACCESS_KEY_ID=<service-user-access-key-id>

--- a/docs/deployments/ASF-deployment.md
+++ b/docs/deployments/ASF-deployment.md
@@ -35,6 +35,7 @@ These can be done by deploying the `hyp3-ci` stack. From the repository root, ru
 aws cloudformation deploy \
     --stack-name hyp3-ci \
     --template-file docs/deployments/ASF-deployment-ci-cf.yml \
+    --capabilities CAPABILITY_NAMED_IAM \
     --parameter-overrides TemplateBucketName=<template-bucket>
 ```
 

--- a/docs/deployments/ASF-deployment.md
+++ b/docs/deployments/ASF-deployment.md
@@ -38,11 +38,12 @@ aws cloudformation deploy \
     --parameter-overrides TemplateBucketName=<template-bucket>
 ```
 
-***Note:** This stack assumes you are only deploy into a single AWS Region! If you
-are deploying into multiple regions, you'll need to adjust the IAM permissions that
-are limited to a single region.*
+***Note:** This stack should only be deployed once per AWS account. This stack also
+assumes you are only deploying into a single AWS Region If you are deploying into
+multiple regions in the same AWS account, you'll need to adjust the IAM permissions
+that are limited to a single region.*
 
-## 3. Deploy HyP3 to ASF
+## 3. Deploy HyP3 to AWS
 
 Once the `github-actions` IAM user has been created, you can create a set of AWS
 Access Keys for that user, which can be used to deploy HyP3 via CI/CD tooling. 

--- a/docs/deployments/ASF-deployment.md
+++ b/docs/deployments/ASF-deployment.md
@@ -34,7 +34,8 @@ These can be done by deploying the `hyp3-ci` stack. From the repository root, ru
 ```shell
 aws cloudformation deploy \
     --stack-name hyp3-ci \
-    --template-file docs/deployments/ASF-deployment-ci-cf.yml
+    --template-file docs/deployments/ASF-deployment-ci-cf.yml \
+    --parameter-overrides TemplateBucketName=<template-bucket>
 ```
 
 ## 3. Deploy HyP3 to JPL
@@ -65,7 +66,7 @@ aws cloudformation deploy \
     --parameter-overrides \
         VpcId=<vpc-ids> \
         SubnetIds=<subnet-ids> \
-        EDLUsername=<erthdata-login-username> \
-        EDLPassword=<erthdata-login-username> \
+        EDLUsername=<earthdata-login-username> \
+        EDLPassword=<earthdata-login-username> \
         MonthlyJobQuotaPerUser=0
 ```

--- a/docs/deployments/ASF-deployment.md
+++ b/docs/deployments/ASF-deployment.md
@@ -38,7 +38,7 @@ aws cloudformation deploy \
     --parameter-overrides TemplateBucketName=<template-bucket>
 ```
 
-## 3. Deploy HyP3 to JPL
+## 3. Deploy HyP3 to ASF
 
 Once the `github-actions` IAM user has been created, you can create a set of AWS
 Access Keys for that user, which can be used to deploy HyP3 via CI/CD tooling. 

--- a/docs/deployments/ASF-deployment.md
+++ b/docs/deployments/ASF-deployment.md
@@ -70,6 +70,7 @@ aws cloudformation package \
 aws cloudformation deploy \
     --stack-name <stack-name> \
     --template-file packaged.yml \
+    --role-arn <cloudformation-deployment-role-arn> \
     --capabilities CAPABILITY_IAM \
     --parameter-overrides \
         VpcId=<vpc-ids> \

--- a/docs/deployments/ASF-deployment.md
+++ b/docs/deployments/ASF-deployment.md
@@ -77,5 +77,6 @@ aws cloudformation deploy \
         SubnetIds=<subnet-ids> \
         EDLUsername=<earthdata-login-username> \
         EDLPassword=<earthdata-login-password> \
-        MonthlyJobQuotaPerUser=0
+        DomainName=<domain-name> \
+        CertificateArn=<certificate-arn>
 ```

--- a/docs/deployments/ASF-deployment.md
+++ b/docs/deployments/ASF-deployment.md
@@ -26,7 +26,7 @@ suitable bucket if you try and create a new CloudFormation Stack in the AWS Cons
 In order to integrate an ASF deployment we'll need:
 * Set the account-wide API Gateway logging permissions
 * A deployment role with the necessary permissions to deploy HyP3
-* A "service user" so that we can generate long-term (90-day) AWS access keys and
+* A "service user" so that we can generate long-term AWS access keys and
   integrate the deployment into our CI/CD pipelines
 
 These can be done by deploying the `hyp3-ci` stack. From the repository root, run:

--- a/docs/deployments/ASF-deployment.md
+++ b/docs/deployments/ASF-deployment.md
@@ -1,0 +1,71 @@
+# Deploying HyP3 to ASF
+
+This guide walks through deploying HyP3 into an ASF managed AWS commercial cloud account.
+It should work for any new ASF account.
+
+## 1. Set up a CloudFormation templates bucket
+
+A new account will not have a bucket for storing AWS CloudFormation templates,
+which is needed to deploy a CloudFormation stack. AWS will automatically make a
+suitable bucket if you try and create a new CloudFormation Stack in the AWS Console:
+* navigating to the CloudFormation service in the region you are going to deploy to
+* Click the orange "Create stack" button 
+* On the create stack screen
+  * For "Prepare template" make select "Template is ready"
+  * For "Template source" select "Upload a template file"
+  * Choose any JSON or YAML formatted file from your computer to upload
+  * Once the file is uploaded, you should see an S3 URL on the bottom indicating the
+    bucket the template file was uploaded. This is your newly created CloudFormation
+    templates bucket and should be named something like `cf-templates-<HASH>-<region>`
+  * Click "Cancel" to exit the CloudFormation stack creation now that we have a
+    templates bucket
+
+
+## 2.  Prepare for deployment
+
+In order to integrate an ASF deployment we'll need:
+* Set the account-wide API Gateway logging permissions
+* A deployment role with the necessary permissions to deploy HyP3
+* A "service user" so that we can generate long-term (90-day) AWS access keys and
+  integrate the deployment into our CI/CD pipelines
+
+These can be done by deploying the `hyp3-ci` stack. From the repository root, run:
+
+```shell
+aws cloudformation deploy \
+    --stack-name hyp3-ci \
+    --template-file docs/deployments/ASF-deployment-ci-cf.yml
+```
+
+## 3. Deploy HyP3 to JPL
+
+Once the service user has been created, you can create a set of AWS Access Keys
+which can be used to deploy HyP3 via CI/CD tooling, or manually. 
+
+To deploy HyP3 manually, run these commands from the repository root,
+replacing any `<*>` with appropriate values, and adding any other needed parameter
+overrides for the deployment:
+
+```shell
+export AWS_ACCESS_KEY_ID=<service-user-access-key-id>
+export AWS_SECRET_ACCESS_KEY=<service-user-secret-access-key>
+export AWS_REGION=<deployment-region>
+
+make files=<supported-job-spec-files> security_environment=ASF build
+
+aws cloudformation package \
+    --template-file apps/main-cf.yml \
+    --s3-bucket <template-bucket> \
+    --output-template-file packaged.yml
+
+aws cloudformation deploy \
+    --stack-name <stack-name> \
+    --template-file packaged.yml \
+    --capabilities CAPABILITY_IAM \
+    --parameter-overrides \
+        VpcId=<vpc-ids> \
+        SubnetIds=<subnet-ids> \
+        EDLUsername=<erthdata-login-username> \
+        EDLPassword=<erthdata-login-username> \
+        MonthlyJobQuotaPerUser=0
+```

--- a/docs/deployments/ASF-deployment.md
+++ b/docs/deployments/ASF-deployment.md
@@ -76,6 +76,6 @@ aws cloudformation deploy \
         VpcId=<vpc-ids> \
         SubnetIds=<subnet-ids> \
         EDLUsername=<earthdata-login-username> \
-        EDLPassword=<earthdata-login-username> \
+        EDLPassword=<earthdata-login-password> \
         MonthlyJobQuotaPerUser=0
 ```

--- a/docs/deployments/ASF-deployment.md
+++ b/docs/deployments/ASF-deployment.md
@@ -38,6 +38,10 @@ aws cloudformation deploy \
     --parameter-overrides TemplateBucketName=<template-bucket>
 ```
 
+***Note:** This stack assumes you are only deploy into a single AWS Region! If you
+are deploying into multiple regions, you'll need to adjust the IAM permissions that
+are limited to a single region.*
+
 ## 3. Deploy HyP3 to ASF
 
 Once the `github-actions` IAM user has been created, you can create a set of AWS


### PR DESCRIPTION
This:
* creates a basic guide to deploying HyP3 into a brand new ASF managed AWS account
* includes a CloudFormation template to setup the CI/CD service user, deployment role, and the account-wide API Gateway logging permissions
