### PR TITLE
Fix mock

### DIFF
--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -4,7 +4,6 @@
 -r requirements-apps-start-execution.txt
 -r requirements-apps-update-db.txt
 boto3==1.21.29
-botocore<1.24.30
 jinja2==3.1.1
 moto==1.3.14
 pytest==7.1.1

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -5,7 +5,7 @@
 -r requirements-apps-update-db.txt
 boto3==1.21.29
 jinja2==3.1.1
-moto==1.3.14
+moto==3.1.3
 pytest==7.1.1
 PyYAML==6.0
 responses==0.20.0


### PR DESCRIPTION
The botocore v1.24.30 release broke `moto` v3.1.3, which we're using to mock AWS services, causing this error:
```
ImportError while loading conftest '/home/runner/work/hyp3/hyp3/tests/conftest.py'.
tests/conftest.py:5: in <module>
    from moto import mock_dynamodb2
/opt/hostedtoolcache/Python/3.9.[10](https://github.com/ASFHyP3/hyp3/runs/5766246246?check_suite_focus=true#step:5:10)/x64/lib/python3.9/site-packages/moto/__init__.py:33: in <module>
    from .iotdata import mock_iotdata  # noqa
/opt/hostedtoolcache/Python/3.9.10/x64/lib/python3.9/site-packages/moto/iotdata/__init__.py:5: in <module>
    iotdata_backend = iotdata_backends["us-east-1"]
E   KeyError: 'us-east-1'
```

This reverts the temporary botocore pinning and pins `moto` to 3.1.4.