### PR TITLE
On April 11: Bump ITS_LIVE back to 10K vCPUs for S1 campaign

### DIFF
--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -21,7 +21,7 @@ jobs:
             job_files: job_spec/AUTORIFT_ITS_LIVE.yml
             instance_types: r5d.xlarge,r5dn.xlarge
             default_max_vcpus: 10000
-            expanded_max_vcpus: 1000
+            expanded_max_vcpus: 10000
             required_surplus: 0
             security_environment: JPL-public
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id

--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -20,8 +20,8 @@ jobs:
             quota: 0
             job_files: job_spec/AUTORIFT_ITS_LIVE.yml
             instance_types: r5d.xlarge,r5dn.xlarge
-            default_max_vcpus: 3500
-            expanded_max_vcpus: 3500
+            default_max_vcpus: 10000
+            expanded_max_vcpus: 1000
             required_surplus: 0
             security_environment: JPL-public
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id


### PR DESCRIPTION
Sentinel-2 campaign should be done on April 9th, which we had to limit the vCPUs for. This bumps the vCPUs back to 10K in prep for the Sentinel-1 campaign. 

*Note: Do not merge before April 11; but **release** before submitting S1 jobs that day*
