### PR TITLE
provide string formatted default for iterative-bounds container parameter

### DIFF
--- a/job_spec/WATER_MAP.yml
+++ b/job_spec/WATER_MAP.yml
@@ -85,6 +85,7 @@ WATER_MAP:
         enum:
           - 30.0
     iterative_bounds:
+      default: '0.0 15.0'
       api_schema:
         description: Bounds used for iterative method. Ignored when include_flood_depth is false.
         type: array

--- a/job_spec/WATER_MAP_10M.yml
+++ b/job_spec/WATER_MAP_10M.yml
@@ -86,6 +86,7 @@ WATER_MAP:
         enum:
           - 30.0
     iterative_bounds:
+      default: '0.0 15.0'
       api_schema:
         description: Bounds used for iterative method. Ignored when include_flood_depth is false.
         type: array


### PR DESCRIPTION
previous deployment failed when trying to create the updated WaterMap job definition:
![Screenshot from 2022-04-13 09-57-45](https://user-images.githubusercontent.com/17994518/163254394-c86d03ce-3a69-476c-8110-276d9e2e384f.png)

The default value for `iterative-bounds` is a json list for the api specification, but needs to be a space-delimited string for the container job definition. Fortunately, our templating allows us to specify a separate default for the job definition. It will use the `<parameter>.default` element from the job_spec yml if present, otherwise it uses the `<parameter>.api_schema.default`: https://github.com/ASFHyP3/hyp3/blob/develop/apps/workflow-cf.yml.j2#L50