### PR TITLE
Job name length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.15.1]
+### Changed
+- Increased job name length limit to 100 characters.
+
 ## [2.15.0]
 ### Added
 - Added flood depth options to water map job (currently limited to `hyp3-test`).

--- a/apps/api/src/hyp3_api/api-spec/job_parameters.yml.j2
+++ b/apps/api/src/hyp3_api/api-spec/job_parameters.yml.j2
@@ -61,7 +61,7 @@ components:
         name:
           type: string
           minLength: 1
-          maxLength: 20
+          maxLength: 100
         job_parameters:
           $ref: "#/components/schemas/{{ job_type }}Parameters"
 
@@ -80,7 +80,7 @@ components:
         name:
           type: string
           minLength: 1
-          maxLength: 20
+          maxLength: 100
         job_parameters:
           type: object
           additionalProperties: false

--- a/tests/test_api/test_submit_job.py
+++ b/tests/test_api/test_submit_job.py
@@ -163,7 +163,7 @@ def test_submit_job_with_empty_name(client):
 def test_submit_job_with_long_name(client):
     login(client)
     batch = [
-        make_job(name='X' * 21)
+        make_job(name='X' * 101)
     ]
     setup_requests_mock(batch)
     response = submit_batch(client, batch)


### PR DESCRIPTION
Increase the job name length limit to 100 characters.