### PR TITLE
revist hyp3-tibet vcpus to 3,200

### DIFF
--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -50,8 +50,8 @@ jobs:
             quota: 0
             job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
             instance_types: c5d.xlarge
-            default_max_vcpus: 10000
-            expanded_max_vcpus: 10000
+            default_max_vcpus: 3200
+            expanded_max_vcpus: 3200
             required_surplus: 0
             security_environment: ASF
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id


### PR DESCRIPTION
AWS ultimately upped our vcpu limit for hyp3-tibet to 3,200 (not the requested 10,000), so I'm updating the hyp3 parameters to match the number of machines we can actually launch.

![Screenshot from 2022-05-02 15-16-29](https://user-images.githubusercontent.com/17994518/166341228-0bd8d181-e9fe-4161-8a94-55edc7bf0352.png)

