### PR TITLE
Handle missing log stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.16.1]
+### Fixed
+- Handle missing log stream when uploading logs, which should prevent jobs from remaining in `RUNNING` status after failure.
+
 ## [2.16.0]
 ### Added
 - Added `execution_started` field to job schema to indicate whether a step function execution has been started for the job.

--- a/apps/upload-log/src/upload_log.py
+++ b/apps/upload-log/src/upload_log.py
@@ -31,12 +31,15 @@ def get_log_content(log_group, log_stream):
 
 def get_log_content_from_failed_attempts(cause: dict) -> str:
     status = cause['Status']
-    status_reason = cause['StatusReason']
-
     assert status == 'FAILED', status
-    assert status_reason == 'Task failed to start', status_reason
 
-    return '\n'.join(attempt['Container']['Reason'] for attempt in cause['Attempts'])
+    attempts = cause['Attempts']
+    if len(attempts) > 0:
+        content = '\n'.join(attempt['Container']['Reason'] for attempt in attempts)
+    else:
+        content = cause['StatusReason']
+
+    return content
 
 
 def write_log_to_s3(bucket, prefix, content):

--- a/apps/upload-log/src/upload_log.py
+++ b/apps/upload-log/src/upload_log.py
@@ -29,6 +29,16 @@ def get_log_content(log_group, log_stream):
     return '\n'.join(messages)
 
 
+def get_log_content_from_failed_attempts(cause: dict) -> str:
+    status = cause['Status']
+    status_reason = cause['StatusReason']
+
+    assert status == 'FAILED', status
+    assert status_reason == 'Task failed to start', status_reason
+
+    return '\n'.join(attempt['Container']['Reason'] for attempt in cause['Attempts'])
+
+
 def write_log_to_s3(bucket, prefix, content):
     key = f'{prefix}/{prefix}.log'
     S3.put_object(Bucket=bucket, Key=key, Body=content, ContentType='text/plain')
@@ -45,5 +55,12 @@ def write_log_to_s3(bucket, prefix, content):
 
 def lambda_handler(event, context):
     log_stream = get_log_stream(event['processing_results'])
-    log_content = get_log_content(event['log_group'], log_stream)
+    try:
+        log_content = get_log_content(event['log_group'], log_stream)
+    except CLOUDWATCH.exceptions.ResourceNotFoundException as e:
+        if 'specified log stream does not exist' in str(e):
+            assert 'Error' in event['processing_results']
+            log_content = get_log_content_from_failed_attempts(json.loads(event['processing_results']['Cause']))
+        else:
+            raise
     write_log_to_s3(environ['BUCKET'], event['prefix'], log_content)

--- a/tests/test_upload_log.py
+++ b/tests/test_upload_log.py
@@ -71,6 +71,16 @@ def test_get_log_content_from_failed_attempts():
     assert upload_log.get_log_content_from_failed_attempts(cause) == content
 
 
+def test_get_log_content_from_failed_attempts_no_attempts():
+    cause = {
+        'Status': 'FAILED',
+        'StatusReason': 'foo reason',
+        'Attempts': []
+    }
+    content = 'foo reason'
+    assert upload_log.get_log_content_from_failed_attempts(cause) == content
+
+
 def test_upload_log_to_s3(s3_stubber):
     expected_params = {
         'Body': 'myContent',


### PR DESCRIPTION
- [x] Is it worth checking that `StatusReason` is `Task failed to start`, or do we always want to upload logs when there is no log stream, regardless of status reason?