### PR TITLE
Don't write error message to `processing_time_in_seconds` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.16.1]
 ### Fixed
 - Handle missing log stream when uploading logs, which should prevent jobs from remaining in `RUNNING` status after failure.
+- Don't write error messages to `processing_time_in_seconds` field.
 
 ## [2.16.0]
 ### Added

--- a/apps/api/src/hyp3_api/api-spec/openapi-spec.yml
+++ b/apps/api/src/hyp3_api/api-spec/openapi-spec.yml
@@ -534,8 +534,8 @@ components:
     processing_time_in_seconds:
       description: >
         Run time in seconds for the final processing attempt (regardless of whether it succeeded). A value of zero
-        likely indicates that the job failed before reaching the processing step, although it may also indicate that the
-        job failed after reaching the processing step but before calculating the processing time.
+        indicates that the job failed before reaching the processing step or that there was an error in calculating
+        processing time.
       type: number
       minimum: 0
 

--- a/apps/check-processing-time/src/check_processing_time.py
+++ b/apps/check-processing-time/src/check_processing_time.py
@@ -3,7 +3,7 @@ import json
 
 def get_time_from_attempts(attempts):
     if len(attempts) == 0:
-        raise ValueError('list of attempts is empty')
+        raise ValueError('no Batch job attempts')
     attempts.sort(key=lambda attempt: attempt['StoppedAt'])
     final_attempt = attempts[-1]
     return (final_attempt['StoppedAt'] - final_attempt['StartedAt']) / 1000

--- a/apps/check-processing-time/src/check_processing_time.py
+++ b/apps/check-processing-time/src/check_processing_time.py
@@ -2,6 +2,8 @@ import json
 
 
 def get_time_from_attempts(attempts):
+    if len(attempts) == 0:
+        raise ValueError('list of attempts is empty')
     attempts.sort(key=lambda attempt: attempt['StoppedAt'])
     final_attempt = attempts[-1]
     return (final_attempt['StoppedAt'] - final_attempt['StartedAt']) / 1000

--- a/apps/step-function.json.j2
+++ b/apps/step-function.json.j2
@@ -212,7 +212,7 @@
             "States.ALL"
           ],
           "Next": "JOB_FAILED",
-          "ResultPath": "$.results.processing_time_in_seconds"
+          "ResultPath": "$.results.processing_time_in_seconds_error"
         }
       ],
       "ResultPath": "$.results.processing_time_in_seconds",

--- a/tests/test_check_processing_time.py
+++ b/tests/test_check_processing_time.py
@@ -42,7 +42,7 @@ def test_missing_start_time():
 
 
 def test_no_attempts():
-    with pytest.raises(ValueError, match='list of attempts is empty'):
+    with pytest.raises(ValueError, match='no Batch job attempts'):
         check_processing_time.get_time_from_attempts([])
 
 

--- a/tests/test_check_processing_time.py
+++ b/tests/test_check_processing_time.py
@@ -1,3 +1,5 @@
+import pytest
+
 import check_processing_time
 
 
@@ -37,6 +39,11 @@ def test_missing_start_time():
     ]
     result = check_processing_time.get_time_from_attempts(attempts)
     assert result == 3.2
+
+
+def test_no_attempts():
+    with pytest.raises(ValueError, match='list of attempts is empty'):
+        check_processing_time.get_time_from_attempts([])
 
 
 def test_lambda_handler_with_normal_results():


### PR DESCRIPTION
Previously, errors in the `CHECK_PROCESSING_TIME` step function step would be written to the `processing_time_in_seconds` field and would be visible through the API. Now, errors should be stored in a separate field within the step function JSON object (so that they can be reviewed by the team internally if desired), while the processing time field retains its default value of `0`.