### PR TITLE
change security environment for hyp3-a19-jpl from JPL to JPL-public

### DIFF
--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -68,7 +68,7 @@ jobs:
             default_max_vcpus: 1600
             expanded_max_vcpus: 1600
             required_surplus: 0
-            security_environment: JPL
+            security_environment: JPL-public
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
             distribution_url: ''
 

--- a/apps/main-cf.yml.j2
+++ b/apps/main-cf.yml.j2
@@ -276,8 +276,8 @@ Resources:
       PublicAccessBlockConfiguration:
         BlockPublicAcls: True
         IgnorePublicAcls: True
-        BlockPublicPolicy: {{ 'True' if security_environment == 'EDC' else 'False' }}
-        RestrictPublicBuckets: {{ 'True' if security_environment == 'EDC' else 'False' }}
+        BlockPublicPolicy: {{ 'True' if security_environment in ('EDC', 'JPL') else 'False' }}
+        RestrictPublicBuckets: {{ 'True' if security_environment in ('EDC', 'JPL') else 'False' }}
       LifecycleConfiguration:
         Rules:
           - Status: Enabled


### PR DESCRIPTION
The only impact to the rendered template should be to include the public bucket policy at https://github.com/ASFHyP3/hyp3/blob/develop/apps/main-cf.yml.j2#L307

Note that this leaves the `JPL` security environment option unused by any deployments at the moment. Do we anticipate needing it in the future? Should we consider consolidating `JPL` and `JPL-public`?

@jhkennedy have you validated our ability to create a public bucket policy in the a19-jpl account?