### PR TITLE
Add github action for Snyk scanning

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -78,7 +78,7 @@ jobs:
       - run: |
           python -m pip install --upgrade pip
           make install
-          make render
+          make render security_environment=EDC
       - name: Run Snyk to check for vulnerabilities
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -71,6 +71,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.9
+      - run: |
+          python -m pip install --upgrade pip
+          make install
+          make render
       - name: Run Snyk to check for vulnerabilities
         uses: snyk/actions/python@master
         env:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -83,7 +83,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: |
-          snyk test --package-manager=pip --file=requirements*.txt
+          snyk test --package-manager=pip --file=requirements-all.txt
           snyk iac test
 
   call-secrets-analysis-workflow:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -83,8 +83,8 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: |
-          snyk test --package-manager=pip --file=requirements-all.txt
-          snyk iac test
+          snyk test --package-manager=pip --file=requirements-all.txt --severity-threshold=high
+          snyk iac test --severity-threshold=high
 
   call-secrets-analysis-workflow:
     uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@main

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -83,7 +83,7 @@ jobs:
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         run: |
-          snyk test
+          snyk test --package-manager=pip --file=requirements*.txt
           snyk iac test
 
   call-secrets-analysis-workflow:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -67,5 +67,14 @@ jobs:
           sed -i 's/"Resource": "${.*}"/"Resource": "foo:bar"/' apps/step-function.json
           statelint apps/step-function.json
 
+  snyk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/python@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
   call-secrets-analysis-workflow:
     uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@main

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -79,7 +79,7 @@ jobs:
           make install
           make render
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python@master
+        uses: snyk/actions/python-3.8@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -70,7 +70,7 @@ jobs:
   snyk:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - uses: snyk/actions/setup@master
       - uses: actions/setup-python@v1
         with:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -71,6 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - uses: snyk/actions/setup@master
       - uses: actions/setup-python@v1
         with:
           python-version: 3.9
@@ -79,9 +80,11 @@ jobs:
           make install
           make render
       - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.8@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        run: |
+          snyk test
+          snyk iac test
 
   call-secrets-analysis-workflow:
     uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@main

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,7 @@
+version: v1.19.0
+ignore:
+  SNYK-CC-TF-99:
+    - 'apps/api/api-cf.yml > [DocId: 0] > Resources[RestApi] > Properties > Body > * > x-amazon-apigateway-any-method[x-amazon-apigateway-auth] > type':
+        created: 2022-05-25T00:00:00.000Z
+        reason: Rest API is configured as a private API only accepting traffic from the application VPC in Earthdata
+                Cloud deployments. Authentication and authorization are implemented in the Python app served by the API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.17.4]
 ### Added
 - GitHub action to scan Python dependencies and rendered CloudFormation templates for known security vulnerabilities
-  using Snyk
+  using Snyk.
 
 ## [2.17.3]
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.17.4]
+### Added
+- GitHub action to scan Python dependencies and rendered CloudFormation templates for known security vulnerabilities
+  using Snyk
+
 ## [2.17.3]
 ### Fixed
-AUTORIFT jobs can now be submitted for Sentinel-2 scenes with 25-character Earth Search names. Fixes [#1022](https://github.com/ASFHyP3/hyp3/issues/1022).
+- AUTORIFT jobs can now be submitted for Sentinel-2 scenes with 25-character Earth Search names. Fixes [#1022](https://github.com/ASFHyP3/hyp3/issues/1022).
 
 ## [2.17.2]
 ### Fixed


### PR DESCRIPTION
This doesn't implement any scheduled scanning, or reporting via the Snyk web interface, but it satisfies the need of preventing code with known high/critical vulnerabilities from being deployed.

Repository is configured with my personal SNYK_TOKEN; I hope we'll be able to provision a [service account](https://docs.snyk.io/features/user-and-group-management/managing-groups-and-organizations/service-accounts) for our Snyk organization, but I'm content to move forward as-is.

Reference for Snyk CLI commands: https://docs.snyk.io/snyk-cli/cli-reference

Reference for the .snyk policy file: https://docs.snyk.io/products/snyk-infrastructure-as-code/snyk-cli-for-infrastructure-as-code/iac-ignores-using-the-.snyk-policy-file

