### PR TITLE
Increase memory for process-new-granules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [2.18.1]
+### Changed
+- Increased `MemorySize` for `process-new-granules` function to improve performance when evaluating subscriptions.
+
 ## [2.18.0]
 ### Removed
 - `BannedCidrBlocks` stack parameter to specify CIDR ranges that will receive HTTP 403 Forbidden responses from the API

--- a/apps/process-new-granules/process-new-granules-cf.yml.j2
+++ b/apps/process-new-granules/process-new-granules-cf.yml.j2
@@ -99,7 +99,7 @@ Resources:
           MONTHLY_JOB_QUOTA_PER_USER: !Ref MonthlyJobQuotaPerUser
       Code: src/
       Handler: process_new_granules.lambda_handler
-      MemorySize: 128
+      MemorySize: 1024
       Role: !GetAtt Role.Arn
       Runtime: python3.9
       Timeout: 900


### PR DESCRIPTION
The `process-new-granules` function that's scheduled to run every ~15 minutes has started to fail due to running out of memory on occasion:
![Screenshot from 2022-06-06 09-17-21](https://user-images.githubusercontent.com/17994518/172212637-921f87cd-722b-41c7-939e-74cbaee774d6.png)

We've also seen run times consistently hitting the 15 minute timeout each time the function runs. Increasing the memory available to the lambda function will also increase the CPU and network available to the function somewhat. See https://docs.aws.amazon.com/lambda/latest/operatorguide/computing-power.html for more details. Here is average runtime per day (900,000ms = 15 minutes):
![Screenshot from 2022-06-06 09-19-10](https://user-images.githubusercontent.com/17994518/172212843-599189d7-7fcd-4761-b690-da74702f57d0.png)
