### PR TITLE
Use default service-linked role for AWS Batch Compute Environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.18.1]
 ### Changed
 - Increased `MemorySize` for `process-new-granules` function to improve performance when evaluating subscriptions.
-- Decoupled Batch Compute Environment from customer-managed service role in favor of AWS-managed service-linked role.
+- Decoupled Batch Compute Environment from customer-managed service role in favor of the default AWS-managed
+  service-linked role.
 
 ## [2.18.0]
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.18.1]
 ### Changed
 - Increased `MemorySize` for `process-new-granules` function to improve performance when evaluating subscriptions.
+- Decoupled Batch Compute Environment from customer-managed service role in favor of AWS-managed service-linked role.
 
 ## [2.18.0]
 ### Removed

--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -29,7 +29,7 @@ Parameters:
 Outputs:
 
   ComputeEnvironmentArn:
-    Value: !Ref ComputeEnvironment
+    Value: !Ref BatchComputeEnvironment
 
   JobQueueArn:
     Value: !Ref BatchJobQueue
@@ -67,7 +67,7 @@ Resources:
 
             --==BOUNDARY==--
 
-  ComputeEnvironment:
+  BatchComputeEnvironment:
     Type: AWS::Batch::ComputeEnvironment
     Properties:
       Type: MANAGED
@@ -96,7 +96,7 @@ Resources:
     Properties:
       Priority: 1
       ComputeEnvironmentOrder:
-        - ComputeEnvironment: !Ref ComputeEnvironment
+        - ComputeEnvironment: !Ref BatchComputeEnvironment
           Order: 1
       SchedulingPolicyArn: !Ref SchedulingPolicy
 
@@ -137,26 +137,6 @@ Resources:
           - Effect: Allow
             Action: s3:PutObjectTagging
             Resource: !Sub "arn:aws:s3:::${ContentBucket}/*"
-
-  BatchServiceRole:
-    Type: {{ 'Custom::JplRole' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::Role' }}
-    Properties:
-      {% if security_environment in ('JPL', 'JPL-public') %}
-      ServiceToken: !ImportValue Custom::JplRole::ServiceToken
-      Path: /account-managed/hyp3/
-      {% endif %}
-      AssumeRolePolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          Action: sts:AssumeRole
-          Principal:
-            Service: batch.amazonaws.com
-          Effect: Allow
-      {% if security_environment == 'EDC' %}
-      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
-      {% endif %}
-      ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole
 
   InstanceRole:
     Type: {{ 'Custom::JplRole' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::Role' }}

--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -70,7 +70,6 @@ Resources:
   ComputeEnvironment:
     Type: AWS::Batch::ComputeEnvironment
     Properties:
-      ServiceRole: !GetAtt BatchServiceRole.Arn
       Type: MANAGED
       ComputeResources:
         Type: SPOT


### PR DESCRIPTION
When HyP3 was initially developed, we had to provision an IAM role for the `ServiceRole` attribute of the AWS Batch Compute environment.

In Apr 2021, AWS Batch [introduced support](https://aws.amazon.com/about-aws/whats-new/2021/04/aws-batch-simplifies-permissions-introducing-service-linked-roles/) for Service-Linked roles. If no customer-managed `ServiceRole` is specified for a compute environment, the service-linked role is automatically created (if necessary) and assigned, which automatically grants the necessary permissions by default.

https://docs.aws.amazon.com/batch/latest/userguide/using-service-linked-roles.html
https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-batch-computeenvironment.html#cfn-batch-computeenvironment-servicerole

Removing the `ServiceRole` attribute *isn't enough* to update the Service Role on existing Compute Environments. I've updated the logical resource ID for the compute environment to force a new one to be created (with the default service-linked role attached) as part of this deployment.

This ultimately addresses a "Following fields ... subnets ... can be updated only for Non-fargate Compute Environment having a Batch Service Linked Role" error when attempting to add additional subnets for an existing HyP3 deployment.