### PR TITLE
Revert "Use default service-linked role for AWS Batch Compute Environment"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.18.1]
 ### Changed
 - Increased `MemorySize` for `process-new-granules` function to improve performance when evaluating subscriptions.
-- Decoupled Batch Compute Environment from customer-managed service role in favor of the default AWS-managed
-  service-linked role.
 
 ## [2.18.0]
 ### Removed

--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -29,7 +29,7 @@ Parameters:
 Outputs:
 
   ComputeEnvironmentArn:
-    Value: !Ref BatchComputeEnvironment
+    Value: !Ref ComputeEnvironment
 
   JobQueueArn:
     Value: !Ref BatchJobQueue
@@ -67,9 +67,10 @@ Resources:
 
             --==BOUNDARY==--
 
-  BatchComputeEnvironment:
+  ComputeEnvironment:
     Type: AWS::Batch::ComputeEnvironment
     Properties:
+      ServiceRole: !GetAtt BatchServiceRole.Arn
       Type: MANAGED
       ComputeResources:
         Type: SPOT
@@ -96,7 +97,7 @@ Resources:
     Properties:
       Priority: 1
       ComputeEnvironmentOrder:
-        - ComputeEnvironment: !Ref BatchComputeEnvironment
+        - ComputeEnvironment: !Ref ComputeEnvironment
           Order: 1
       SchedulingPolicyArn: !Ref SchedulingPolicy
 
@@ -137,6 +138,26 @@ Resources:
           - Effect: Allow
             Action: s3:PutObjectTagging
             Resource: !Sub "arn:aws:s3:::${ContentBucket}/*"
+
+  BatchServiceRole:
+    Type: {{ 'Custom::JplRole' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::Role' }}
+    Properties:
+      {% if security_environment in ('JPL', 'JPL-public') %}
+      ServiceToken: !ImportValue Custom::JplRole::ServiceToken
+      Path: /account-managed/hyp3/
+      {% endif %}
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Action: sts:AssumeRole
+          Principal:
+            Service: batch.amazonaws.com
+          Effect: Allow
+      {% if security_environment == 'EDC' %}
+      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
+      {% endif %}
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole
 
   InstanceRole:
     Type: {{ 'Custom::JplRole' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::Role' }}


### PR DESCRIPTION
Reverts ASFHyP3/hyp3#1051

Rolling back this change pending resolution of https://bugs.earthdata.nasa.gov/servicedesk/customer/portal/7/NASD-3095 allowing creation of the AWS Batch service-linked role in Earthdata Cloud environments.