### PR TITLE
drop hyp3 evironment from deploy-daac.yml

### DIFF
--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -13,22 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - environment: hyp3
-            domain: hyp3-api.asf.alaska.edu
-            template_bucket: cf-templates-aubvn3i9olmk-us-west-2
-            image_tag: latest
-            product_lifetime_in_days: 14
-            quota: 1000
-            deploy_ref: refs/heads/main
-            job_files: job_spec/AUTORIFT.yml job_spec/INSAR_GAMMA.yml job_spec/RTC_GAMMA.yml
-            instance_types: r5d.xlarge,r5dn.xlarge
-            default_max_vcpus: 600
-            expanded_max_vcpus: 1600
-            required_surplus: 1000
-            security_environment: ASF
-            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
-            distribution_url: ''
-
           - environment: hyp3-edc-prod
             domain: ''
             template_bucket: cf-templates-118mtzosmrltk-us-west-2


### PR DESCRIPTION
to be merged after the DNS cutover of https://hyp3-api.asf.alaska.edu to the hyp3-edc-prod deployment