### PR TITLE
remove hyp3-tibet from deploy-enterprise.yml

### DIFF
--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -27,21 +27,6 @@ jobs:
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
             distribution_url: ''
 
-          - environment: hyp3-tibet
-            domain: hyp3-tibet.asf.alaska.edu
-            template_bucket: cf-templates-ejaipnrxq7xg-us-west-2
-            image_tag: latest
-            product_lifetime_in_days: 180
-            quota: 0
-            job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
-            instance_types: c5d.xlarge
-            default_max_vcpus: 1000
-            expanded_max_vcpus: 1000
-            required_surplus: 0
-            security_environment: ASF
-            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
-            distribution_url: ''
-
           - environment: hyp3-a19-jpl
             domain: hyp3-a19-jpl.asf.alaska.edu
             template_bucket: cf-templates-v4pvone059de-us-west-2


### PR DESCRIPTION
The compute environment in hyp3-tibet has been disabled as the processing campaign draws to a close. This removes hyp3-tibet from automated deployments, because I don't want deployments accidentally re-enabling processing.

I'm comfortable doing future vcpu changes or enabling/disabling manually via the console.