### PR TITLE
add additional iam permissions to step function role

### DIFF
--- a/apps/workflow-cf.yml.j2
+++ b/apps/workflow-cf.yml.j2
@@ -128,6 +128,12 @@ Resources:
               - !Ref {{ snake_to_pascal_case(job_type) }}
               {% endfor %}
           - Effect: Allow
+            Action: batch:DescribeJobs
+            Resource: "*"
+          - Effect: Allow
+            Action: batch:TerminateJob
+            Resource: !Sub "arn:aws:batch:${AWS::Region}:${AWS::AccountId}:job/*"
+          - Effect: Allow
             Action:
               - events:PutTargets
               - events:PutRule


### PR DESCRIPTION
The IAM permissions needed by Step Functions to manage Batch jobs are documented at https://docs.aws.amazon.com/step-functions/latest/dg/batch-iam.html

The details of all the `batch:*` IAM actions and their supported Resource values are at https://docs.aws.amazon.com/service-authorization/latest/reference/list_awsbatch.html

These permissions weren't strictly required for our step functions to submit Batch jobs and advance when those jobs completed successfully. However, when under load with many running Step Function executions with many RUNNABLE Batch jobs, the EDC platform team reported seeing many `AccessDenied` errors logged for `batch:DescribeJobs` calls (all those running step functions checking in on the status of the jobs they submitted).