### PR TITLE
Revert "Bump asf-search from 3.2.2 to 4.0.0"

### DIFF
--- a/requirements-apps-process-new-granules.txt
+++ b/requirements-apps-process-new-granules.txt
@@ -1,2 +1,2 @@
-asf-search==4.0.0
+asf-search==3.2.2
 ./lib/dynamo/


### PR DESCRIPTION
Reverts ASFHyP3/hyp3#1087

Deployment of the process-new-granules lambda function fails with "Unzipped size must be smaller than 262144000 bytes" after upgrading to asf-search 4.0.0. Refer to the "Deployment package (.zip file archive) size" service limit at https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html

The old requirements totaled 82 MB unzipped:
```
$ pip install asf_search==3.2.2 -t old/
...
Successfully installed asf_search-3.2.2 certifi-2022.6.15 charset-normalizer-2.1.0 idna-3.3 importlib-metadata-4.12.0 numpy-1.23.0 python-dateutil-2.8.2 pytz-2022.1 requests-2.28.1 shapely-1.8.2 six-1.16.0 urllib3-1.26.9 zipp-3.8.0

$ du -h old/ | tail -1
82M	old/
```

The new requirements total 505 MB unzipped:
```
$ pip install asf_search==4.0.0 -t new/
...
Successfully installed Fiona-1.8.21 PyYAML-6.0 WKTUtils-1.1.5 asf_search-4.0.0 attrs-21.4.0 certifi-2022.6.15 charset-normalizer-2.1.0 click-8.1.3 click-plugins-1.1.1 cligj-0.7.2 dateparser-1.1.1 defusedxml-0.7.1 geomet-0.3.0 geopandas-0.11.0 idna-3.3 importlib-metadata-4.12.0 joblib-1.1.0 kml2geojson-5.1.0 munch-2.5.0 numpy-1.23.0 packaging-21.3 pandas-1.4.3 pyparsing-3.0.9 pyproj-3.3.1 pyshp-2.3.0 python-dateutil-2.8.2 pytz-2022.1 pytz-deprecation-shim-0.1.0.post0 regex-2022.3.2 requests-2.28.1 scikit-learn-1.1.1 scipy-1.8.1 setuptools-62.6.0 shapely-1.8.2 six-1.16.0 sklearn-0.0 threadpoolctl-3.1.0 tzdata-2022.1 tzlocal-4.2 urllib3-1.26.9 zipp-3.8.0

$ du -h new/ | tail -1
505M	new/
```