### PR TITLE
Temporarily pin AVO hyp3-gamma image tag

### DIFF
--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -75,7 +75,7 @@ jobs:
           - environment: hyp3-avo
             domain: hyp3-avo.asf.alaska.edu
             template_bucket: cf-templates-1x4a21iq1cba7-us-west-2
-            image_tag: latest
+            image_tag: 5.4.2.dev2_ga6225f8
             product_lifetime_in_days: 365000
             quota: 0
             job_files: job_spec/INSAR_GAMMA.yml


### PR DESCRIPTION
AVO processing identified some issues with InSAR GAMMA products where an un-physical subsidence was observed due to GAMMA keying in on a "signal" over the water. Our current water mask is buffered such that these narrow water bodies aren't masked out.

This pins the hyp3-gamma container image to the `5.4.2.dev2_ga6225f8` tags, which was produced via ASFHyP3/hyp3-gamma#379 and uses a stricter water mask that is not buffered away from the coast line.

IMPORTANTLY, this should be a temporary change until we integrate a better water-masking workflow that's suitable to general HyP3 (see ASFHyP3/hyp3-gamma#379 for more details).