### PR TITLE
scale based on total spending rather than ec2 spending

### DIFF
--- a/.github/actions/deploy-hyp3/action.yml
+++ b/.github/actions/deploy-hyp3/action.yml
@@ -50,8 +50,8 @@ inputs:
   EXPANDED_MAX_VCPUS:
     description: "Expanded maximum size for the AWS Batch compute environment to use when month-to-date budget sufficiently exceeds month-to-date spending"
     required: true
-  MONTHLY_COMPUTE_BUDGET:
-    description: "Total budget allocated for AWS Batch processing per month, in dollars. Ignored when DefaultMaxvCpus = ExpandedMaxvCpus."
+  MONTHLY_BUDGET:
+    description: "Total budget allocated per month, in dollars. Ignored when DefaultMaxvCpus = ExpandedMaxvCpus."
     required: true
   REQUIRED_SURPLUS:
     description: "Amount by which month-to-date budget must exceed month-to-date spending to increase fleet size, in dollars. Ignored when DefaultMaxvCpus = ExpandedMaxvCpus."
@@ -129,7 +129,7 @@ runs:
                 MonthlyJobQuotaPerUser='${{ inputs.MONTHLY_JOB_QUOTA_PER_USER }}' \
                 DefaultMaxvCpus='${{ inputs.DEFAULT_MAX_VCPUS }}' \
                 ExpandedMaxvCpus='${{ inputs.EXPANDED_MAX_VCPUS }}' \
-                MonthlyComputeBudget='${{ inputs.MONTHLY_COMPUTE_BUDGET }}' \
+                MonthlyBudget='${{ inputs.MONTHLY_BUDGET }}' \
                 RequiredSurplus='${{ inputs.REQUIRED_SURPLUS }}' \
                 AmiId='${{ inputs.AMI_ID }}' \
                 InstanceTypes='${{ inputs.INSTANCE_TYPES }}'

--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -23,9 +23,9 @@ jobs:
             deploy_ref: refs/heads/main
             job_files: job_spec/AUTORIFT.yml job_spec/INSAR_GAMMA.yml job_spec/RTC_GAMMA.yml
             instance_types: r5d.xlarge,r5dn.xlarge
-            default_max_vcpus: 600
-            expanded_max_vcpus: 1600
-            required_surplus: 1000
+            default_max_vcpus: 1000
+            expanded_max_vcpus: 2000
+            required_surplus: 2000
             security_environment: EDC
             ami_id: image_id_ecs_amz2
             distribution_url: 'https://d3gm2hf49xd6jj.cloudfront.net'
@@ -45,9 +45,9 @@ jobs:
               job_spec/INSAR_ISCE.yml
               job_spec/WATER_MAP.yml
             instance_types: r5d.xlarge,r5dn.xlarge
-            default_max_vcpus: 600
-            expanded_max_vcpus: 1600
-            required_surplus: 1000
+            default_max_vcpus: 1000
+            expanded_max_vcpus: 2000
+            required_surplus: 2000
             security_environment: EDC
             ami_id: image_id_ecs_amz2
             distribution_url: 'https://d1riv60tezqha9.cloudfront.net'

--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -89,7 +89,7 @@ jobs:
           JOB_FILES: ${{ matrix.job_files }}
           DEFAULT_MAX_VCPUS: ${{ matrix.default_max_vcpus }}
           EXPANDED_MAX_VCPUS: ${{ matrix.expanded_max_vcpus }}
-          MONTHLY_COMPUTE_BUDGET: ${{ secrets.MONTHLY_COMPUTE_BUDGET }}
+          MONTHLY_BUDGET: ${{ secrets.MONTHLY_BUDGET }}
           REQUIRED_SURPLUS: ${{ matrix.required_surplus }}
           PERMISSIONS_BOUNDARY_ARN: ${{ secrets.PERMISSIONS_BOUNDARY_ARN }}
           ORIGIN_ACCESS_IDENTITY_ID: ${{ secrets.ORIGIN_ACCESS_IDENTITY_ID }}

--- a/.github/workflows/deploy-enterprise-test.yml
+++ b/.github/workflows/deploy-enterprise-test.yml
@@ -69,7 +69,7 @@ jobs:
           JOB_FILES: ${{ matrix.job_files }}
           DEFAULT_MAX_VCPUS: ${{ matrix.default_max_vcpus }}
           EXPANDED_MAX_VCPUS: ${{ matrix.expanded_max_vcpus }}
-          MONTHLY_COMPUTE_BUDGET: ${{ secrets.MONTHLY_COMPUTE_BUDGET }}
+          MONTHLY_BUDGET: ${{ secrets.MONTHLY_BUDGET }}
           REQUIRED_SURPLUS: ${{ matrix.required_surplus }}
           PERMISSIONS_BOUNDARY_ARN: ${{ secrets.PERMISSIONS_BOUNDARY_ARN }}
           ORIGIN_ACCESS_IDENTITY_ID: ${{ secrets.ORIGIN_ACCESS_IDENTITY_ID }}

--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -138,7 +138,7 @@ jobs:
           JOB_FILES: ${{ matrix.job_files }}
           DEFAULT_MAX_VCPUS: ${{ matrix.default_max_vcpus }}
           EXPANDED_MAX_VCPUS: ${{ matrix.expanded_max_vcpus }}
-          MONTHLY_COMPUTE_BUDGET: ${{ secrets.MONTHLY_COMPUTE_BUDGET }}
+          MONTHLY_BUDGET: ${{ secrets.MONTHLY_BUDGET }}
           REQUIRED_SURPLUS: ${{ matrix.required_surplus }}
           PERMISSIONS_BOUNDARY_ARN: ${{ secrets.PERMISSIONS_BOUNDARY_ARN }}
           ORIGIN_ACCESS_IDENTITY_ID: ${{ secrets.ORIGIN_ACCESS_IDENTITY_ID }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [2.19.4]
+### Changed
+- `scale-cluster` now adjusts the compute environment size based on total month-to-date spending, rather than only EC2 
+  spending.
+
 ## [2.19.3]
 ### Fixed
 - Granted additional IAM permissions required by AWS Step Functions to manage AWS Batch jobs.

--- a/apps/main-cf.yml.j2
+++ b/apps/main-cf.yml.j2
@@ -66,8 +66,8 @@ Parameters:
     MinValue: 0
     Default: 60
 
-  MonthlyComputeBudget:
-    Description: Total budget allocated for AWS Batch processing per month, in dollars. Ignored when DefaultMaxvCpus = ExpandedMaxvCpus.
+  MonthlyBudget:
+    Description: Total budget allocated per month, in dollars. Ignored when DefaultMaxvCpus = ExpandedMaxvCpus.
     Type: Number
     MinValue: 0
     Default: 0
@@ -161,7 +161,7 @@ Resources:
         ComputeEnvironmentArn: !GetAtt Cluster.Outputs.ComputeEnvironmentArn
         DefaultMaxvCpus: !Ref DefaultMaxvCpus
         ExpandedMaxvCpus: !Ref ExpandedMaxvCpus
-        MonthlyComputeBudget: !Ref MonthlyComputeBudget
+        MonthlyBudget: !Ref MonthlyBudget
         RequiredSurplus: !Ref RequiredSurplus
         {% if security_environment == 'EDC' %}
         PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn

--- a/apps/scale-cluster/scale-cluster-cf.yml.j2
+++ b/apps/scale-cluster/scale-cluster-cf.yml.j2
@@ -13,7 +13,7 @@ Parameters:
     Type: Number
     MinValue: 0
 
-  MonthlyComputeBudget:
+  MonthlyBudget:
     Type: Number
     MinValue: 0
 
@@ -91,7 +91,7 @@ Resources:
       Environment:
         Variables:
           COMPUTE_ENVIRONMENT_ARN: !Ref ComputeEnvironmentArn
-          MONTHLY_COMPUTE_BUDGET: !Ref MonthlyComputeBudget
+          MONTHLY_BUDGET: !Ref MonthlyBudget
           DEFAULT_MAX_VCPUS: !Ref DefaultMaxvCpus
           EXPANDED_MAX_VCPUS: !Ref ExpandedMaxvCpus
           REQUIRED_SURPLUS: !Ref RequiredSurplus

--- a/apps/scale-cluster/src/scale_cluster.py
+++ b/apps/scale-cluster/src/scale_cluster.py
@@ -18,18 +18,11 @@ def get_time_period(today: date):
     }
 
 
-def get_month_to_date_compute_spending():
+def get_month_to_date_spending():
     time_period = get_time_period(date.today())
     granularity = 'MONTHLY'
-    _filter = {
-        'Dimensions': {
-            'Key': 'SERVICE',
-            'Values': ['Amazon Elastic Compute Cloud - Compute', 'EC2 - Other']
-        }
-    }
     metrics = ['UnblendedCost']
-    response = COST_EXPLORER.get_cost_and_usage(TimePeriod=time_period, Granularity=granularity, Filter=_filter,
-                                                Metrics=metrics)
+    response = COST_EXPLORER.get_cost_and_usage(TimePeriod=time_period, Granularity=granularity, Metrics=metrics)
     return float(response['ResultsByTime'][0]['Total']['UnblendedCost']['Amount'])
 
 
@@ -47,14 +40,14 @@ def set_max_vcpus(compute_environment_arn: str, max_vcpus: int, desired_vcpus: i
     )
 
 
-def get_max_vcpus(today, monthly_compute_budget, month_to_date_compute_spending, default_max_vcpus, expanded_max_vcpus,
+def get_max_vcpus(today, monthly_budget, month_to_date_spending, default_max_vcpus, expanded_max_vcpus,
                   required_surplus):
     days_in_month = calendar.monthrange(today.year, today.month)[1]
-    month_to_date_compute_budget = monthly_compute_budget * today.day / days_in_month
-    available_surplus = month_to_date_compute_budget - month_to_date_compute_spending
+    month_to_date_budget = monthly_budget * today.day / days_in_month
+    available_surplus = month_to_date_budget - month_to_date_spending
 
-    print(f'Month-to-date compute budget: ${month_to_date_compute_budget:,.2f}')
-    print(f'Month-to-date compute spending: ${month_to_date_compute_spending:,.2f}')
+    print(f'Month-to-date budget: ${month_to_date_budget:,.2f}')
+    print(f'Month-to-date spending: ${month_to_date_spending:,.2f}')
     print(f'Available surplus: ${available_surplus:,.2f}')
     print(f'Required surplus: ${required_surplus:,.2f}')
 
@@ -67,8 +60,8 @@ def get_max_vcpus(today, monthly_compute_budget, month_to_date_compute_spending,
 
 def lambda_handler(event, context):
     max_vcpus = get_max_vcpus(today=date.today(),
-                              monthly_compute_budget=int(environ['MONTHLY_COMPUTE_BUDGET']),
-                              month_to_date_compute_spending=get_month_to_date_compute_spending(),
+                              monthly_budget=int(environ['MONTHLY_BUDGET']),
+                              month_to_date_spending=get_month_to_date_spending(),
                               default_max_vcpus=int(environ['DEFAULT_MAX_VCPUS']),
                               expanded_max_vcpus=int(environ['EXPANDED_MAX_VCPUS']),
                               required_surplus=int(environ['REQUIRED_SURPLUS']))

--- a/apps/scale-cluster/src/scale_cluster.py
+++ b/apps/scale-cluster/src/scale_cluster.py
@@ -18,8 +18,8 @@ def get_time_period(today: date):
     }
 
 
-def get_month_to_date_spending():
-    time_period = get_time_period(date.today())
+def get_month_to_date_spending(today: date):
+    time_period = get_time_period(today)
     granularity = 'MONTHLY'
     metrics = ['UnblendedCost']
     response = COST_EXPLORER.get_cost_and_usage(TimePeriod=time_period, Granularity=granularity, Metrics=metrics)
@@ -61,7 +61,7 @@ def get_max_vcpus(today, monthly_budget, month_to_date_spending, default_max_vcp
 def lambda_handler(event, context):
     max_vcpus = get_max_vcpus(today=date.today(),
                               monthly_budget=int(environ['MONTHLY_BUDGET']),
-                              month_to_date_spending=get_month_to_date_spending(),
+                              month_to_date_spending=get_month_to_date_spending(date.today()),
                               default_max_vcpus=int(environ['DEFAULT_MAX_VCPUS']),
                               expanded_max_vcpus=int(environ['EXPANDED_MAX_VCPUS']),
                               required_surplus=int(environ['REQUIRED_SURPLUS']))

--- a/tests/test_scale_cluster.py
+++ b/tests/test_scale_cluster.py
@@ -29,56 +29,56 @@ def test_get_time_period():
 
 def test_get_max_vcpus():
     vcpus = scale_cluster.get_max_vcpus(today=date(2020, 1, 1),
-                                        monthly_compute_budget=1000,
-                                        month_to_date_compute_spending=0,
+                                        monthly_budget=1000,
+                                        month_to_date_spending=0,
                                         default_max_vcpus=1,
                                         expanded_max_vcpus=2,
                                         required_surplus=1000)
     assert vcpus == 1
 
     vcpus = scale_cluster.get_max_vcpus(today=date(2020, 1, 31),
-                                        monthly_compute_budget=1000,
-                                        month_to_date_compute_spending=0,
+                                        monthly_budget=1000,
+                                        month_to_date_spending=0,
                                         default_max_vcpus=3,
                                         expanded_max_vcpus=4,
                                         required_surplus=1000)
     assert vcpus == 4
 
     vcpus = scale_cluster.get_max_vcpus(today=date(2020, 1, 31),
-                                        monthly_compute_budget=1000,
-                                        month_to_date_compute_spending=999.99,
+                                        monthly_budget=1000,
+                                        month_to_date_spending=999.99,
                                         default_max_vcpus=1,
                                         expanded_max_vcpus=2,
                                         required_surplus=1000)
     assert vcpus == 1
 
     vcpus = scale_cluster.get_max_vcpus(today=date(2020, 1, 31),
-                                        monthly_compute_budget=0,
-                                        month_to_date_compute_spending=0,
+                                        monthly_budget=0,
+                                        month_to_date_spending=0,
                                         default_max_vcpus=1,
                                         expanded_max_vcpus=2,
                                         required_surplus=1)
     assert vcpus == 1
 
     vcpus = scale_cluster.get_max_vcpus(today=date(2020, 2, 20),
-                                        monthly_compute_budget=29000,
-                                        month_to_date_compute_spending=19001,
+                                        monthly_budget=29000,
+                                        month_to_date_spending=19001,
                                         default_max_vcpus=1,
                                         expanded_max_vcpus=2,
                                         required_surplus=1000)
     assert vcpus == 1
 
     vcpus = scale_cluster.get_max_vcpus(today=date(2020, 2, 20),
-                                        monthly_compute_budget=29000,
-                                        month_to_date_compute_spending=19000,
+                                        monthly_budget=29000,
+                                        month_to_date_spending=19000,
                                         default_max_vcpus=1,
                                         expanded_max_vcpus=2,
                                         required_surplus=1000)
     assert vcpus == 2
 
     vcpus = scale_cluster.get_max_vcpus(today=date(2020, 2, 20),
-                                        monthly_compute_budget=29000,
-                                        month_to_date_compute_spending=19000,
+                                        monthly_budget=29000,
+                                        month_to_date_spending=19000,
                                         default_max_vcpus=1,
                                         expanded_max_vcpus=2,
                                         required_surplus=1001)

--- a/tests/test_scale_cluster.py
+++ b/tests/test_scale_cluster.py
@@ -13,6 +13,13 @@ def batch_stubber():
         stubber.assert_no_pending_responses()
 
 
+@pytest.fixture
+def cost_explorer_stubber():
+    with Stubber(scale_cluster.COST_EXPLORER) as stubber:
+        yield stubber
+        stubber.assert_no_pending_responses()
+
+
 def test_get_time_period():
     result = scale_cluster.get_time_period(date(year=2020, month=1, day=1))
     assert result == {'Start': '2020-01-01', 'End': '2020-02-01'}
@@ -114,3 +121,29 @@ def test_set_max_vcpus(batch_stubber):
                                service_response={})
 
     scale_cluster.set_max_vcpus(compute_environment_arn='foo', max_vcpus=10, desired_vcpus=5)
+
+
+def test_get_month_to_date_spending(cost_explorer_stubber):
+    expected_params = {
+        'Metrics': ['UnblendedCost'],
+        'Granularity': 'MONTHLY',
+        'TimePeriod': {
+            'Start': '2022-07-01',
+            'End': '2022-08-01',
+        },
+    }
+    mock_service_response = {
+        'ResultsByTime': [
+            {
+                'Total': {
+                    'UnblendedCost': {
+                        'Amount': '100.2',
+                    },
+                },
+            },
+        ],
+    }
+    cost_explorer_stubber.add_response(method='get_cost_and_usage', expected_params=expected_params,
+                                       service_response=mock_service_response)
+
+    assert scale_cluster.get_month_to_date_spending(date(2022, 7, 15)) == 100.2


### PR DESCRIPTION
Will need to re-create the MONTHLY_COMPUTE_BUDGET repository secret as MONTHLY_BUDGET. Might be a nice time to turn that into an environment secret; I think it's only used by `hyp3-edc-uat` and `hyp3-edc-prod` (the only environments where default_max_vcpus != expanded_max_vcpus).