### PR TITLE
Update to JPL-public security environments

### DIFF
--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -53,7 +53,7 @@ jobs:
             default_max_vcpus: 1600
             expanded_max_vcpus: 1600
             required_surplus: 0
-            security_environment: JPL
+            security_environment: JPL-public
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
             distribution_url: ''
 
@@ -68,7 +68,7 @@ jobs:
             default_max_vcpus: 1600
             expanded_max_vcpus: 1600
             required_surplus: 0
-            security_environment: JPL
+            security_environment: JPL-public
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
             distribution_url: ''
 


### PR DESCRIPTION
Both `hyp3-tibet-jpl` and `hyp3-nisar-jpl` public bucket request to the JPL service desk have been resolved, and account level block public access has been removed for both of these accounts. 
![image](https://user-images.githubusercontent.com/7882693/177623775-783bd0e1-80a1-437c-b9b0-64f734ef48e6.png)

This updates the bucket policy attached to those deployments' content bucket to allow public read access. 
