### PR TITLE
Add enterprise streamflow deployment, make watermap deployment 30m only

### DIFF
--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -93,6 +93,21 @@ jobs:
             image_tag: latest
             product_lifetime_in_days: 14
             quota: 0
+            job_files: job_spec/RTC_GAMMA.yml job_spec/WATER_MAP.yml
+            instance_types: r5d.xlarge,r5dn.xlarge
+            default_max_vcpus: 640
+            expanded_max_vcpus: 640
+            required_surplus: 0
+            security_environment: ASF
+            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+            distribution_url: ''
+
+          - environment: hyp3-streamflow
+            domain: hyp3-streamflow.asf.alaska.edu
+            template_bucket: cf-templates-15gmiot9prm67-us-west-2
+            image_tag: latest
+            product_lifetime_in_days: 14
+            quota: 0
             job_files: job_spec/RTC_GAMMA_10M.yml job_spec/WATER_MAP_10M.yml
             instance_types: r5d.4xlarge,r5dn.4xlarge
             default_max_vcpus: 640


### PR DESCRIPTION
I've
* prepped the account for deployment
  * setup the CloudFormation templates bucket
  * deployed `hyp3-ci` to get the GH Action user, deployment role, and REST API access logging role
  * uploaded the SSL certificate
* setup the deploy environment here: https://github.com/ASFHyP3/hyp3/settings/environments/598446282/edit
* added this deployment to our onboarding doc
