### PR TITLE
Add RIVER_WIDTH job type and support for job types with multiple tasks

### DIFF
--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -44,7 +44,6 @@ jobs:
               job_spec/RTC_GAMMA.yml
               job_spec/INSAR_ISCE.yml
               job_spec/WATER_MAP.yml
-              job_spec/RIVER_WIDTH.yml
             instance_types: r5d.xlarge,r5dn.xlarge
             default_max_vcpus: 1000
             expanded_max_vcpus: 2000

--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -44,6 +44,7 @@ jobs:
               job_spec/RTC_GAMMA.yml
               job_spec/INSAR_ISCE.yml
               job_spec/WATER_MAP.yml
+              job_spec/RIVER_WIDTH.yml
             instance_types: r5d.xlarge,r5dn.xlarge
             default_max_vcpus: 1000
             expanded_max_vcpus: 2000

--- a/.github/workflows/deploy-enterprise-test.yml
+++ b/.github/workflows/deploy-enterprise-test.yml
@@ -25,6 +25,7 @@ jobs:
               job_spec/RTC_GAMMA.yml
               job_spec/INSAR_ISCE.yml
               job_spec/WATER_MAP.yml
+              job_spec/RIVER_WIDTH.yml
             instance_types: r5d.xlarge,r5dn.xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640

--- a/.github/workflows/deploy-enterprise-test.yml
+++ b/.github/workflows/deploy-enterprise-test.yml
@@ -26,7 +26,7 @@ jobs:
               job_spec/INSAR_ISCE.yml
               job_spec/WATER_MAP.yml
               job_spec/RIVER_WIDTH.yml
-            instance_types: r5d.xlarge,r5dn.xlarge
+            instance_types: r5d.xlarge,r5dn.xlarge,r5d.4xlarge,r5dn.4xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640
             required_surplus: 0

--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -108,7 +108,7 @@ jobs:
             image_tag: latest
             product_lifetime_in_days: 14
             quota: 0
-            job_files: job_spec/RTC_GAMMA_10M.yml job_spec/WATER_MAP_10M.yml
+            job_files: job_spec/RTC_GAMMA_10M.yml job_spec/WATER_MAP_10M.yml job_spec/RIVER_WIDTH.yml
             instance_types: r5d.4xlarge,r5dn.4xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.20.0]
+### Added
+- New `RIVER_WIDTH` job type.
+### Changed
+- Job specifications can now specify multiple tasks.
+
 ## [2.19.7]
 ### Changed
 - `WATER_MAP` and `WATER_MAP_10M` now can run up to 10 hours before timing out.

--- a/apps/get-files/src/get_files.py
+++ b/apps/get-files/src/get_files.py
@@ -36,7 +36,7 @@ def get_object_file_type(bucket, key):
 
 
 def visible_product(product_path: Union[str, Path]) -> bool:
-    return Path(product_path).suffix in ('.zip', '.nc')
+    return Path(product_path).suffix in ('.zip', '.nc', '.geojson')
 
 
 def get_products(files):

--- a/apps/render_cf.py
+++ b/apps/render_cf.py
@@ -45,6 +45,11 @@ def main():
     job_types = {}
     for file in args.job_spec_files:
         job_types.update(yaml.safe_load(file.read_text()))
+
+    for job_type, job_spec in job_types.items():
+        for task in job_spec['tasks']:
+            task['name'] = job_type + '_' + task['name'] if task['name'] else job_type
+
     render_templates(job_types, args.security_environment, args.api_name)
 
 

--- a/apps/step-function.json.j2
+++ b/apps/step-function.json.j2
@@ -92,7 +92,7 @@
         {
           "Variable": "$.job_type",
           "StringEquals": "{{ job_type }}",
-          "Next": "{{ job_type + '_' + job_spec['tasks'][0]['name'] }}"
+          "Next": "{{ job_spec['tasks'][0]['name'] }}"
         }{% if not loop.last %},{% endif %}
         {% endfor %}
       ],
@@ -100,11 +100,11 @@
     },
     {% for job_type, job_spec in job_types.items() %}
     {% for task in job_spec['tasks'] %}
-    "{{ job_type + '_' + task['name'] }}": {
+    "{{ task['name'] }}": {
       "Type": "Task",
       "Resource": "arn:aws:states:::batch:submitJob.sync",
       "Parameters": {
-        "JobDefinition": "{{ '${'+ snake_to_pascal_case(job_type + '_' + task['name']) + '}' }}",
+        "JobDefinition": "{{ '${'+ snake_to_pascal_case(task['name']) + '}' }}",
         "JobName.$": "$.job_id",
         "JobQueue": "${JobQueueArn}",
         "ShareIdentifier": "default",
@@ -116,7 +116,7 @@
         }
       },
       "ResultPath": "$.results.processing_results",
-      "Next": "{% if not loop.last %}{{ job_type + '_' + loop.nextitem['name'] }}{% else %}GET_FILES{% endif %}",
+      "Next": "{% if not loop.last %}{{ loop.nextitem['name'] }}{% else %}GET_FILES{% endif %}",
       "Retry": [
         {
           "ErrorEquals": [

--- a/apps/step-function.json.j2
+++ b/apps/step-function.json.j2
@@ -92,18 +92,19 @@
         {
           "Variable": "$.job_type",
           "StringEquals": "{{ job_type }}",
-          "Next": "{{ job_type }}"
+          "Next": "{{ job_type + '_' + job_spec['tasks'][0]['name'] }}"
         }{% if not loop.last %},{% endif %}
         {% endfor %}
       ],
       "Default": "JOB_FAILED"
     },
     {% for job_type, job_spec in job_types.items() %}
-    "{{ job_type }}": {
+    {% for task in job_spec['tasks'] %}
+    "{{ job_type + '_' + task['name'] }}": {
       "Type": "Task",
       "Resource": "arn:aws:states:::batch:submitJob.sync",
       "Parameters": {
-        "JobDefinition": "{{ '${'+ snake_to_pascal_case(job_type) + '}' }}",
+        "JobDefinition": "{{ '${'+ snake_to_pascal_case(job_type + '_' + task['name']) + '}' }}",
         "JobName.$": "$.job_id",
         "JobQueue": "${JobQueueArn}",
         "ShareIdentifier": "default",
@@ -115,7 +116,7 @@
         }
       },
       "ResultPath": "$.results.processing_results",
-      "Next": "GET_FILES",
+      "Next": "{% if not loop.last %}{{ job_type + '_' + loop.nextitem['name'] }}{% else %}GET_FILES{% endif %}",
       "Retry": [
         {
           "ErrorEquals": [
@@ -141,6 +142,7 @@
         }
       ]
     },
+    {% endfor %}
     {% endfor %}
     "UPLOAD_LOG":{
       "Type": "Task",

--- a/apps/workflow-cf.yml.j2
+++ b/apps/workflow-cf.yml.j2
@@ -40,8 +40,9 @@ Outputs:
     Value: !Ref StepFunction
 
 Resources:
-  {% for job_type, job_spec in  job_types.items() %}
-  {{ snake_to_pascal_case(job_type) }}:
+  {% for job_type, job_spec in job_types.items() %}
+  {% for task in job_spec['tasks'] %}
+  {{ snake_to_pascal_case(job_type + '_' + task['name']) }}:
     Type: AWS::Batch::JobDefinition
     Properties:
       Type: container
@@ -50,20 +51,20 @@ Resources:
         {{ k }}: {{ v.get('default') or v['api_schema'].get('default') }}
         {% endfor %}
       ContainerProperties:
-        Image: {% if 'image_tag' in job_spec -%}
-            "{{ job_spec['image'] }}:{{ job_spec['image_tag'] }}"
+        Image: {% if 'image_tag' in task -%}
+            "{{ task['image'] }}:{{ task['image_tag'] }}"
           {% else -%}
-            !Sub "{{ job_spec['image'] }}:${ImageTag}"
+            !Sub "{{ task['image'] }}:${ImageTag}"
           {% endif %}
         JobRoleArn: !Ref TaskRoleArn
         ExecutionRoleArn: !GetAtt ExecutionRole.Arn
         ResourceRequirements:
           - Type: VCPU
-            Value: "{{ job_spec['vcpu'] }}"
+            Value: "{{ task['vcpu'] }}"
           - Type: MEMORY
-            Value: "{{ job_spec['memory'] }}"
+            Value: "{{ task['memory'] }}"
         Command:
-          {% for command in job_spec['command'] %}
+          {% for command in task['command'] %}
           - {{ command }}
           {% endfor %}
         Secrets:
@@ -72,7 +73,8 @@ Resources:
           - Name: EARTHDATA_PASSWORD
             ValueFrom: !Sub "${SecretArn}:password::"
       Timeout:
-        AttemptDurationSeconds: {{ job_spec['timeout'] }}
+        AttemptDurationSeconds: {{ task['timeout'] }}
+  {% endfor %}
   {% endfor %}
 
   StepFunction:
@@ -82,8 +84,10 @@ Resources:
       DefinitionS3Location: step-function.json
       DefinitionSubstitutions:
         JobQueueArn: !Ref JobQueueArn
-        {% for job_type in job_types %}
-        {{ snake_to_pascal_case(job_type) }}: !Ref {{ snake_to_pascal_case(job_type) }}
+        {% for job_type, job_spec in job_types.items() %}
+        {% for task in job_spec['tasks'] %}
+        {{ snake_to_pascal_case(job_type + '_' + task['name']) }}: !Ref {{ snake_to_pascal_case(job_type + '_' + task['name']) }}
+        {% endfor %}
         {% endfor %}
         UpdateDBLambdaArn: !GetAtt UpdateDB.Outputs.LambdaArn
         GetFilesLambdaArn: !GetAtt GetFiles.Outputs.LambdaArn
@@ -124,8 +128,10 @@ Resources:
             Action: batch:SubmitJob
             Resource:
               - !Ref JobQueueArn
-              {% for job_type in job_types %}
-              - !Ref {{ snake_to_pascal_case(job_type) }}
+              {% for job_type, job_spec in job_types.items() %}
+              {% for task in job_spec['tasks'] %}
+              - !Ref {{ snake_to_pascal_case(job_type + '_' + task['name']) }}
+              {% endfor %}
               {% endfor %}
           - Effect: Allow
             Action: batch:DescribeJobs

--- a/apps/workflow-cf.yml.j2
+++ b/apps/workflow-cf.yml.j2
@@ -42,7 +42,7 @@ Outputs:
 Resources:
   {% for job_type, job_spec in job_types.items() %}
   {% for task in job_spec['tasks'] %}
-  {{ snake_to_pascal_case(job_type + '_' + task['name']) }}:
+  {{ snake_to_pascal_case(task['name']) }}:
     Type: AWS::Batch::JobDefinition
     Properties:
       Type: container
@@ -86,7 +86,7 @@ Resources:
         JobQueueArn: !Ref JobQueueArn
         {% for job_type, job_spec in job_types.items() %}
         {% for task in job_spec['tasks'] %}
-        {{ snake_to_pascal_case(job_type + '_' + task['name']) }}: !Ref {{ snake_to_pascal_case(job_type + '_' + task['name']) }}
+        {{ snake_to_pascal_case(task['name']) }}: !Ref {{ snake_to_pascal_case(task['name']) }}
         {% endfor %}
         {% endfor %}
         UpdateDBLambdaArn: !GetAtt UpdateDB.Outputs.LambdaArn
@@ -130,7 +130,7 @@ Resources:
               - !Ref JobQueueArn
               {% for job_type, job_spec in job_types.items() %}
               {% for task in job_spec['tasks'] %}
-              - !Ref {{ snake_to_pascal_case(job_type + '_' + task['name']) }}
+              - !Ref {{ snake_to_pascal_case(task['name']) }}
               {% endfor %}
               {% endfor %}
           - Effect: Allow

--- a/job_spec/AUTORIFT.yml
+++ b/job_spec/AUTORIFT.yml
@@ -1,5 +1,4 @@
 AUTORIFT:
-  image: ghcr.io/asfhyp3/hyp3-autorift
   required_parameters:
     - granules
   parameters:
@@ -40,17 +39,20 @@ AUTORIFT:
               example: LC08_L1GT_118112_20210107_20210107_02_RT
     bucket_prefix:
       default:  '""'
-  command:
-    - --bucket
-    - '!Ref Bucket'
-    - --bucket-prefix
-    - Ref::bucket_prefix
-    - --parameter-file
-    - '/vsicurl/http://its-live-data.s3.amazonaws.com/autorift_parameters/v001/autorift_landice_0120m.shp'
-    - --naming-scheme
-    - ITS_LIVE_OD
-    - Ref::granules
   validators: []
-  timeout: 10800
-  vcpu: 1
-  memory: 31600
+  tasks:
+    - name: ''
+      image: ghcr.io/asfhyp3/hyp3-autorift
+      command:
+        - --bucket
+        - '!Ref Bucket'
+        - --bucket-prefix
+        - Ref::bucket_prefix
+        - --parameter-file
+        - '/vsicurl/http://its-live-data.s3.amazonaws.com/autorift_parameters/v001/autorift_landice_0120m.shp'
+        - --naming-scheme
+        - ITS_LIVE_OD
+        - Ref::granules
+      timeout: 10800
+      vcpu: 1
+      memory: 31600

--- a/job_spec/AUTORIFT_ITS_LIVE.yml
+++ b/job_spec/AUTORIFT_ITS_LIVE.yml
@@ -1,5 +1,4 @@
 AUTORIFT:
-  image: ghcr.io/asfhyp3/hyp3-autorift
   required_parameters:
     - granules
   parameters:
@@ -40,17 +39,20 @@ AUTORIFT:
               example: LC08_L1GT_118112_20210107_20210107_02_RT
     bucket_prefix:
       default:  '""'
-  command:
-    - --bucket
-    - '!Ref Bucket'
-    - --bucket-prefix
-    - Ref::bucket_prefix
-    - --parameter-file
-    - '/vsicurl/http://its-live-data.s3.amazonaws.com/autorift_parameters/v001/autorift_landice_0120m.shp'
-    - --naming-scheme
-    - ITS_LIVE_PROD
-    - Ref::granules
   validators: []
-  timeout: 10800
-  vcpu: 1
-  memory: 31600
+  tasks:
+    - name: ''
+      image: ghcr.io/asfhyp3/hyp3-autorift
+      command:
+        - --bucket
+        - '!Ref Bucket'
+        - --bucket-prefix
+        - Ref::bucket_prefix
+        - --parameter-file
+        - '/vsicurl/http://its-live-data.s3.amazonaws.com/autorift_parameters/v001/autorift_landice_0120m.shp'
+        - --naming-scheme
+        - ITS_LIVE_PROD
+        - Ref::granules
+      timeout: 10800
+      vcpu: 1
+      memory: 31600

--- a/job_spec/INSAR_GAMMA.yml
+++ b/job_spec/INSAR_GAMMA.yml
@@ -1,5 +1,4 @@
 INSAR_GAMMA:
-  image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma
   required_parameters:
     - granules
   parameters:
@@ -64,32 +63,35 @@ INSAR_GAMMA:
         enum:
           - 20x4
           - 10x2
-  command:
-    - ++process
-    - insar
-    - --bucket
-    - '!Ref Bucket'
-    - --bucket-prefix
-    - Ref::bucket_prefix
-    - --include-look-vectors
-    - Ref::include_look_vectors
-    - --include-los-displacement
-    - Ref::include_los_displacement
-    - --include-displacement-maps
-    - Ref::include_displacement_maps
-    - --include-inc-map
-    - Ref::include_inc_map
-    - --include-dem
-    - Ref::include_dem
-    - --include-wrapped-phase
-    - Ref::include_wrapped_phase
-    - --apply-water-mask
-    - Ref::apply_water_mask
-    - --looks
-    - Ref::looks
-    - Ref::granules
   validators:
     - check_dem_coverage
-  timeout: 10800
-  vcpu: 1
-  memory: 31600
+  tasks:
+    - name: ''
+      image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma
+      command:
+        - ++process
+        - insar
+        - --bucket
+        - '!Ref Bucket'
+        - --bucket-prefix
+        - Ref::bucket_prefix
+        - --include-look-vectors
+        - Ref::include_look_vectors
+        - --include-los-displacement
+        - Ref::include_los_displacement
+        - --include-displacement-maps
+        - Ref::include_displacement_maps
+        - --include-inc-map
+        - Ref::include_inc_map
+        - --include-dem
+        - Ref::include_dem
+        - --include-wrapped-phase
+        - Ref::include_wrapped_phase
+        - --apply-water-mask
+        - Ref::apply_water_mask
+        - --looks
+        - Ref::looks
+        - Ref::granules
+      timeout: 10800
+      vcpu: 1
+      memory: 31600

--- a/job_spec/INSAR_ISCE.yml
+++ b/job_spec/INSAR_ISCE.yml
@@ -1,5 +1,4 @@
 INSAR_ISCE:
-  image: ghcr.io/access-cloud-based-insar/dockerizedtopsapp
   required_parameters:
     - granules
     - secondary_granules
@@ -30,16 +29,19 @@ INSAR_ISCE:
           example: S1B_IW_SLC__1SDV_20210711T014947_20210711T015013_027740_034F80_D404
     bucket_prefix:
       default:  '""'
-  command:
-    - --bucket
-    - '!Ref Bucket'
-    - --bucket-prefix
-    - Ref::bucket_prefix
-    - --reference-scenes
-    - Ref::granules
-    - --secondary-scenes
-    - Ref::secondary_granules
   validators: []
-  timeout: 10800
-  vcpu: 1
-  memory: 7500
+  tasks:
+    - name: ''
+      image: ghcr.io/access-cloud-based-insar/dockerizedtopsapp
+      command:
+        - --bucket
+        - '!Ref Bucket'
+        - --bucket-prefix
+        - Ref::bucket_prefix
+        - --reference-scenes
+        - Ref::granules
+        - --secondary-scenes
+        - Ref::secondary_granules
+      timeout: 10800
+      vcpu: 1
+      memory: 7500

--- a/job_spec/INSAR_ISCE_TEST.yml
+++ b/job_spec/INSAR_ISCE_TEST.yml
@@ -1,5 +1,4 @@
 INSAR_ISCE_TEST:
-  image: ghcr.io/access-cloud-based-insar/dockerizedtopsapp
   image_tag: test
   required_parameters:
     - granules
@@ -31,16 +30,19 @@ INSAR_ISCE_TEST:
           example: S1B_IW_SLC__1SDV_20210711T014947_20210711T015013_027740_034F80_D404
     bucket_prefix:
       default:  '""'
-  command:
-    - --bucket
-    - '!Ref Bucket'
-    - --bucket-prefix
-    - Ref::bucket_prefix
-    - --reference-scenes
-    - Ref::granules
-    - --secondary-scenes
-    - Ref::secondary_granules
   validators: []
-  timeout: 10800
-  vcpu: 1
-  memory: 7500
+  tasks:
+    - name: ''
+      image: ghcr.io/access-cloud-based-insar/dockerizedtopsapp
+      command:
+        - --bucket
+        - '!Ref Bucket'
+        - --bucket-prefix
+        - Ref::bucket_prefix
+        - --reference-scenes
+        - Ref::granules
+        - --secondary-scenes
+        - Ref::secondary_granules
+      timeout: 10800
+      vcpu: 1
+      memory: 7500

--- a/job_spec/INSAR_ISCE_TEST.yml
+++ b/job_spec/INSAR_ISCE_TEST.yml
@@ -1,5 +1,4 @@
 INSAR_ISCE_TEST:
-  image_tag: test
   required_parameters:
     - granules
     - secondary_granules
@@ -34,6 +33,7 @@ INSAR_ISCE_TEST:
   tasks:
     - name: ''
       image: ghcr.io/access-cloud-based-insar/dockerizedtopsapp
+      image_tag: test
       command:
         - --bucket
         - '!Ref Bucket'

--- a/job_spec/RIVER_WIDTH.yml
+++ b/job_spec/RIVER_WIDTH.yml
@@ -27,7 +27,7 @@ RIVER_WIDTH:
   validators:
     - check_dem_coverage
   tasks:
-    - name: water_map
+    - name: WATER_MAP
       image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma
       command:
         - ++process
@@ -42,7 +42,7 @@ RIVER_WIDTH:
       timeout: 36000
       vcpu: 1
       memory: 126000
-    - name: river_width
+    - name: RIVER_WIDTH
       image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/asfhyp3/riverwidthsar
       command:
         - --bucket

--- a/job_spec/RIVER_WIDTH.yml
+++ b/job_spec/RIVER_WIDTH.yml
@@ -1,0 +1,54 @@
+RIVER_WIDTH:
+  required_parameters:
+    - granules
+  parameters:
+    granules:
+      default: '""'
+      api_schema:
+        type: array
+        minItems: 1
+        maxItems: 1
+        items:
+          anyOf:
+            - description: The name of the IW VV+VH Sentinel-1 GRDH granule to process
+              type: string
+              pattern: "^S1[AB]_IW_GRDH_1SDV"
+              minLength: 67
+              maxLength: 67
+              example: S1A_IW_GRDH_1SDV_20210413T235641_20210413T235706_037439_0469D0_3F2B
+            - description: The name of the IW VV+VH Sentinel-1 SLC granule to process
+              type: string
+              pattern: "^S1[AB]_IW_SLC__1SDV"
+              minLength: 67
+              maxLength: 67
+              example: S1A_IW_SLC__1SDV_20211110T234815_20211110T234842_040516_04CE0A_E717
+    bucket_prefix:
+      default:  '""'
+  validators:
+    - check_dem_coverage
+  tasks:
+    - name: water_map
+      image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma
+      command:
+        - ++process
+        - water_map
+        - --bucket
+        - '!Ref Bucket'
+        - --bucket-prefix
+        - Ref::bucket_prefix
+        - --resolution
+        - 10.0
+        - Ref::granules
+      timeout: 36000
+      vcpu: 1
+      memory: 126000
+    - name: river_width
+      image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/asfhyp3/riverwidthsar
+      command:
+        - --bucket
+        - '!Ref Bucket'
+        - --bucket-prefix
+        - Ref::bucket_prefix
+      timeout: 1800
+      vcpu: 1
+      memory: 31600

--- a/job_spec/RIVER_WIDTH.yml
+++ b/job_spec/RIVER_WIDTH.yml
@@ -42,7 +42,7 @@ RIVER_WIDTH:
       timeout: 36000
       vcpu: 1
       memory: 126000
-    - name: RIVER_WIDTH
+    - name: ''
       image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/asfhyp3/riverwidthsar
       command:
         - --bucket

--- a/job_spec/RTC_GAMMA.yml
+++ b/job_spec/RTC_GAMMA.yml
@@ -1,5 +1,4 @@
 RTC_GAMMA:
-  image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma
   required_parameters:
     - granules
   parameters:
@@ -88,36 +87,39 @@ RTC_GAMMA:
         description: Include a false-color RGB decomposition in the product package for dual-pol granules (ignored for single-pol granules)
         default: false
         type: boolean
-  command:
-    - ++process
-    - rtc
-    - --bucket
-    - '!Ref Bucket'
-    - --bucket-prefix
-    - Ref::bucket_prefix
-    - --resolution
-    - Ref::resolution
-    - --dem-name
-    - Ref::dem_name
-    - --radiometry
-    - Ref::radiometry
-    - --scale
-    - Ref::scale
-    - --speckle-filter
-    - Ref::speckle_filter
-    - --dem-matching
-    - Ref::dem_matching
-    - --include-dem
-    - Ref::include_dem
-    - --include-inc-map
-    - Ref::include_inc_map
-    - --include-scattering-area
-    - Ref::include_scattering_area
-    - --include-rgb
-    - Ref::include_rgb
-    - Ref::granules
   validators:
     - check_dem_coverage
-  timeout: 5400
-  vcpu: 1
-  memory: 31600
+  tasks:
+    - name: ''
+      image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma
+      command:
+        - ++process
+        - rtc
+        - --bucket
+        - '!Ref Bucket'
+        - --bucket-prefix
+        - Ref::bucket_prefix
+        - --resolution
+        - Ref::resolution
+        - --dem-name
+        - Ref::dem_name
+        - --radiometry
+        - Ref::radiometry
+        - --scale
+        - Ref::scale
+        - --speckle-filter
+        - Ref::speckle_filter
+        - --dem-matching
+        - Ref::dem_matching
+        - --include-dem
+        - Ref::include_dem
+        - --include-inc-map
+        - Ref::include_inc_map
+        - --include-scattering-area
+        - Ref::include_scattering_area
+        - --include-rgb
+        - Ref::include_rgb
+        - Ref::granules
+      timeout: 5400
+      vcpu: 1
+      memory: 31600

--- a/job_spec/RTC_GAMMA_10M.yml
+++ b/job_spec/RTC_GAMMA_10M.yml
@@ -1,5 +1,4 @@
 RTC_GAMMA:
-  image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma
   required_parameters:
     - granules
   parameters:
@@ -89,36 +88,39 @@ RTC_GAMMA:
         description: Include a false-color RGB decomposition in the product package for dual-pol granules (ignored for single-pol granules)
         default: false
         type: boolean
-  command:
-    - ++process
-    - rtc
-    - --bucket
-    - '!Ref Bucket'
-    - --bucket-prefix
-    - Ref::bucket_prefix
-    - --resolution
-    - Ref::resolution
-    - --dem-name
-    - Ref::dem_name
-    - --radiometry
-    - Ref::radiometry
-    - --scale
-    - Ref::scale
-    - --speckle-filter
-    - Ref::speckle_filter
-    - --dem-matching
-    - Ref::dem_matching
-    - --include-dem
-    - Ref::include_dem
-    - --include-inc-map
-    - Ref::include_inc_map
-    - --include-scattering-area
-    - Ref::include_scattering_area
-    - --include-rgb
-    - Ref::include_rgb
-    - Ref::granules
   validators:
     - check_dem_coverage
-  timeout: 10800
-  vcpu: 1
-  memory: 126000
+  tasks:
+    - name: ''
+      image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma
+      command:
+        - ++process
+        - rtc
+        - --bucket
+        - '!Ref Bucket'
+        - --bucket-prefix
+        - Ref::bucket_prefix
+        - --resolution
+        - Ref::resolution
+        - --dem-name
+        - Ref::dem_name
+        - --radiometry
+        - Ref::radiometry
+        - --scale
+        - Ref::scale
+        - --speckle-filter
+        - Ref::speckle_filter
+        - --dem-matching
+        - Ref::dem_matching
+        - --include-dem
+        - Ref::include_dem
+        - --include-inc-map
+        - Ref::include_inc_map
+        - --include-scattering-area
+        - Ref::include_scattering_area
+        - --include-rgb
+        - Ref::include_rgb
+        - Ref::granules
+      timeout: 10800
+      vcpu: 1
+      memory: 126000

--- a/job_spec/WATER_MAP.yml
+++ b/job_spec/WATER_MAP.yml
@@ -1,5 +1,4 @@
 WATER_MAP:
-  image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma
   required_parameters:
     - granules
   parameters:
@@ -92,42 +91,45 @@ WATER_MAP:
         description: Maximum bound used for iterative method. Ignored when include_flood_depth is false.
         default: 15
         type: integer
-  command:
-    - ++process
-    - water_map
-    - --bucket
-    - '!Ref Bucket'
-    - --bucket-prefix
-    - Ref::bucket_prefix
-    - --resolution
-    - Ref::resolution
-    - --speckle-filter
-    - Ref::speckle_filter
-    - --max-vv-threshold
-    - Ref::max_vv_threshold
-    - --max-vh-threshold
-    - Ref::max_vh_threshold
-    - --hand-threshold
-    - Ref::hand_threshold
-    - --hand-fraction
-    - Ref::hand_fraction
-    - --membership-threshold
-    - Ref::membership_threshold
-    - --include-flood-depth
-    - Ref::include_flood_depth
-    - --estimator
-    - Ref::flood_depth_estimator
-    - --water-level-sigma
-    - Ref::water_level_sigma
-    - --known-water-threshold
-    - Ref::known_water_threshold
-    - --iterative-min
-    - Ref::iterative_min
-    - --iterative-max
-    - Ref::iterative_max
-    - Ref::granules
   validators:
     - check_dem_coverage
-  timeout: 36000
-  vcpu: 1
-  memory: 31600
+  tasks:
+    - name: ''
+      image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma
+      command:
+        - ++process
+        - water_map
+        - --bucket
+        - '!Ref Bucket'
+        - --bucket-prefix
+        - Ref::bucket_prefix
+        - --resolution
+        - Ref::resolution
+        - --speckle-filter
+        - Ref::speckle_filter
+        - --max-vv-threshold
+        - Ref::max_vv_threshold
+        - --max-vh-threshold
+        - Ref::max_vh_threshold
+        - --hand-threshold
+        - Ref::hand_threshold
+        - --hand-fraction
+        - Ref::hand_fraction
+        - --membership-threshold
+        - Ref::membership_threshold
+        - --include-flood-depth
+        - Ref::include_flood_depth
+        - --estimator
+        - Ref::flood_depth_estimator
+        - --water-level-sigma
+        - Ref::water_level_sigma
+        - --known-water-threshold
+        - Ref::known_water_threshold
+        - --iterative-min
+        - Ref::iterative_min
+        - --iterative-max
+        - Ref::iterative_max
+        - Ref::granules
+      timeout: 36000
+      vcpu: 1
+      memory: 31600

--- a/job_spec/WATER_MAP_10M.yml
+++ b/job_spec/WATER_MAP_10M.yml
@@ -1,5 +1,4 @@
 WATER_MAP:
-  image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma
   required_parameters:
     - granules
   parameters:
@@ -93,42 +92,45 @@ WATER_MAP:
         description: Maximum bound used for iterative method. Ignored when include_flood_depth is false.
         default: 15
         type: integer
-  command:
-    - ++process
-    - water_map
-    - --bucket
-    - '!Ref Bucket'
-    - --bucket-prefix
-    - Ref::bucket_prefix
-    - --resolution
-    - Ref::resolution
-    - --speckle-filter
-    - Ref::speckle_filter
-    - --max-vv-threshold
-    - Ref::max_vv_threshold
-    - --max-vh-threshold
-    - Ref::max_vh_threshold
-    - --hand-threshold
-    - Ref::hand_threshold
-    - --hand-fraction
-    - Ref::hand_fraction
-    - --membership-threshold
-    - Ref::membership_threshold
-    - --include-flood-depth
-    - Ref::include_flood_depth
-    - --estimator
-    - Ref::flood_depth_estimator
-    - --water-level-sigma
-    - Ref::water_level_sigma
-    - --known-water-threshold
-    - Ref::known_water_threshold
-    - --iterative-min
-    - Ref::iterative_min
-    - --iterative-max
-    - Ref::iterative_max
-    - Ref::granules
   validators:
     - check_dem_coverage
-  timeout: 36000
-  vcpu: 1
-  memory: 126000
+  tasks:
+    - name: ''
+      image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma
+      command:
+        - ++process
+        - water_map
+        - --bucket
+        - '!Ref Bucket'
+        - --bucket-prefix
+        - Ref::bucket_prefix
+        - --resolution
+        - Ref::resolution
+        - --speckle-filter
+        - Ref::speckle_filter
+        - --max-vv-threshold
+        - Ref::max_vv_threshold
+        - --max-vh-threshold
+        - Ref::max_vh_threshold
+        - --hand-threshold
+        - Ref::hand_threshold
+        - --hand-fraction
+        - Ref::hand_fraction
+        - --membership-threshold
+        - Ref::membership_threshold
+        - --include-flood-depth
+        - Ref::include_flood_depth
+        - --estimator
+        - Ref::flood_depth_estimator
+        - --water-level-sigma
+        - Ref::water_level_sigma
+        - --known-water-threshold
+        - Ref::known_water_threshold
+        - --iterative-min
+        - Ref::iterative_min
+        - --iterative-max
+        - Ref::iterative_max
+        - Ref::granules
+      timeout: 36000
+      vcpu: 1
+      memory: 126000


### PR DESCRIPTION
# TODO

UPLOAD_LOG will only upload the log of the failed task, not preceding tasks. I think that's alright to leave as-is.

CHECK_PROCESSING_TIME will only log the processing time of the final task, not the sum of the processing times for all tasks

HANDLE_BATCH_EVENT will fire when each tasks starts. It may only need to fire when the first task starts, but I don't think having it fire multiple times does any harm. As-is, a job will show as RUNNING even if stalled in between two tasks. Both tasks will have the same priority, so getting stalled is unlikely, unless new jobs are submitted by other users between the first task running and the second task running.