### PR TITLE
Specify pip platform and upgrade cryptography

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ export PYTHONPATH = ${API}:${CHECK_PROCESSING_TIME}:${GET_FILES}:${HANDLE_BATCH_
 
 
 build: render
-	python -m pip install --platform manylinux2014_x86_64 --upgrade -r requirements-apps-api.txt -t ${API}; \
-	python -m pip install --platform manylinux2014_x86_64 --upgrade -r requirements-apps-handle-batch-event.txt -t ${HANDLE_BATCH_EVENT}; \
-	python -m pip install --platform manylinux2014_x86_64 --upgrade -r requirements-apps-process-new-granules.txt -t ${PROCESS_NEW_GRANULES}; \
-	python -m pip install --platform manylinux2014_x86_64 --upgrade -r requirements-apps-scale-cluster.txt -t ${SCALE_CLUSTER}; \
-	python -m pip install --platform manylinux2014_x86_64 --upgrade -r requirements-apps-start-execution.txt -t ${START_EXECUTION}; \
-	python -m pip install --platform manylinux2014_x86_64 --upgrade -r requirements-apps-update-db.txt -t ${UPDATE_DB}
+	python -m pip install --platform manylinux2014_x86_64 --only-binary=:all: --upgrade -r requirements-apps-api.txt -t ${API}; \
+	python -m pip install --platform manylinux2014_x86_64 --only-binary=:all: --upgrade -r requirements-apps-handle-batch-event.txt -t ${HANDLE_BATCH_EVENT}; \
+	python -m pip install --platform manylinux2014_x86_64 --only-binary=:all: --upgrade -r requirements-apps-process-new-granules.txt -t ${PROCESS_NEW_GRANULES}; \
+	python -m pip install --platform manylinux2014_x86_64 --only-binary=:all: --upgrade -r requirements-apps-scale-cluster.txt -t ${SCALE_CLUSTER}; \
+	python -m pip install --platform manylinux2014_x86_64 --only-binary=:all: --upgrade -r requirements-apps-start-execution.txt -t ${START_EXECUTION}; \
+	python -m pip install --platform manylinux2014_x86_64 --only-binary=:all: --upgrade -r requirements-apps-update-db.txt -t ${UPDATE_DB}
 
 tests: render
 	export $$(xargs < tests/cfg.env); \
@@ -28,7 +28,7 @@ run: render
 	python apps/api/src/hyp3_api/__main__.py
 
 install:
-	python -m pip install --platform manylinux2014_x86_64 -r requirements-all.txt
+	python -m pip install --platform manylinux2014_x86_64 --only-binary=:all: -r requirements-all.txt
 
 files ?= job_spec/*.yml
 security_environment ?= ASF

--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ export PYTHONPATH = ${API}:${CHECK_PROCESSING_TIME}:${GET_FILES}:${HANDLE_BATCH_
 
 
 build: render
-	python -m pip install --upgrade -r requirements-apps-api.txt -t ${API}; \
-	python -m pip install --upgrade -r requirements-apps-handle-batch-event.txt -t ${HANDLE_BATCH_EVENT}; \
-	python -m pip install --upgrade -r requirements-apps-process-new-granules.txt -t ${PROCESS_NEW_GRANULES}; \
-	python -m pip install --upgrade -r requirements-apps-scale-cluster.txt -t ${SCALE_CLUSTER}; \
-	python -m pip install --upgrade -r requirements-apps-start-execution.txt -t ${START_EXECUTION}; \
-	python -m pip install --upgrade -r requirements-apps-update-db.txt -t ${UPDATE_DB}
+	python -m pip install --platform manylinux2014_x86_64 --upgrade -r requirements-apps-api.txt -t ${API}; \
+	python -m pip install --platform manylinux2014_x86_64 --upgrade -r requirements-apps-handle-batch-event.txt -t ${HANDLE_BATCH_EVENT}; \
+	python -m pip install --platform manylinux2014_x86_64 --upgrade -r requirements-apps-process-new-granules.txt -t ${PROCESS_NEW_GRANULES}; \
+	python -m pip install --platform manylinux2014_x86_64 --upgrade -r requirements-apps-scale-cluster.txt -t ${SCALE_CLUSTER}; \
+	python -m pip install --platform manylinux2014_x86_64 --upgrade -r requirements-apps-start-execution.txt -t ${START_EXECUTION}; \
+	python -m pip install --platform manylinux2014_x86_64 --upgrade -r requirements-apps-update-db.txt -t ${UPDATE_DB}
 
 tests: render
 	export $$(xargs < tests/cfg.env); \
@@ -28,7 +28,7 @@ run: render
 	python apps/api/src/hyp3_api/__main__.py
 
 install:
-	python -m pip install -r requirements-all.txt
+	python -m pip install --platform manylinux2014_x86_64 -r requirements-all.txt
 
 files ?= job_spec/*.yml
 security_environment ?= ASF

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ run: render
 	python apps/api/src/hyp3_api/__main__.py
 
 install:
-	python -m pip install --platform manylinux2014_x86_64 --only-binary=:all: -r requirements-all.txt
+	python -m pip install -r requirements-all.txt
 
 files ?= job_spec/*.yml
 security_environment ?= ASF

--- a/requirements-apps-api.txt
+++ b/requirements-apps-api.txt
@@ -1,4 +1,4 @@
-cryptography<38
+cryptography==38.0.1
 flask==2.1.0
 Flask-Cors==3.0.10
 openapi-core==0.14.5


### PR DESCRIPTION
We had pinned `cryptography` to <38 in https://github.com/ASFHyP3/hyp3/pull/1183 because the hyp3 API lambda logs were showing:

```
[ERROR] Runtime.ImportModuleError: Unable to import module 'hyp3_api.lambda_handler': /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /var/task/cryptography/hazmat/bindings/_rust.abi3.so)
```

This is likely because [cryptography now ships the `manylinux_2_28` wheel](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#3800---2022-09-06) while Amazon Linux 2 is compatible with the `manylinux2014` wheel. Some brief Googling indicates that Amazon Linux 2 is likely based on one of the distros listed [here](https://github.com/pypa/manylinux) as being compatible with `manylinux2014`, and also that Amazon Linux 2 uses a version of `glibc` earlier than `2.28`.

Also see https://aws.amazon.com/premiumsupport/knowledge-center/lambda-python-package-compatible/