### PR TITLE
upgrade moto to v4.0.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    ignore:
-      - dependency-name: "moto"
     labels:
       - "bumpless"

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -6,7 +6,7 @@
 -r requirements-apps-update-db.txt
 boto3==1.24.68
 jinja2==3.1.2
-moto==1.3.14
+moto[dynamodb]==4.0.2
 pytest==7.1.3
 PyYAML==6.0
 responses==0.21.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import yaml
 from moto import mock_dynamodb
 
 
-
 @pytest.fixture
 def table_properties():
     class TableProperties:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,9 +2,8 @@ from os import environ, path
 
 import pytest
 import yaml
-from moto import mock_dynamodb2
+from moto import mock_dynamodb
 
-from dynamo import DYNAMODB_RESOURCE
 
 
 @pytest.fixture
@@ -25,9 +24,12 @@ def get_table_properties_from_template(resource_name):
     return table_properties
 
 
+@mock_dynamodb
 @pytest.fixture
 def tables(table_properties):
-    with mock_dynamodb2():
+    with mock_dynamodb():
+        from dynamo import DYNAMODB_RESOURCE
+
         class Tables:
             jobs_table = DYNAMODB_RESOURCE.create_table(
                 TableName=environ['JOBS_TABLE_NAME'],
@@ -39,7 +41,7 @@ def tables(table_properties):
             )
             subscriptions_table = DYNAMODB_RESOURCE.create_table(
                 TableName=environ['SUBSCRIPTIONS_TABLE_NAME'],
-                **table_properties.subscriptions_table
+                **table_properties.subscriptions_table,
             )
         tables = Tables()
         yield tables


### PR DESCRIPTION
I haven't quite figured out *why* this particular configuration works, but it works. So far it only works if I include both the `@mock_dynamodb` decorator *and* the `with mock_dynamodb()` context manager.

See "pesky imports" at http://docs.getmoto.org/en/latest/docs/getting_started.html#what-about-those-pesky-imports