### PR TITLE
pin cryptography to 37.0.4 and ignore future dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,5 +11,6 @@ updates:
       interval: "daily"
     ignore:
       - dependency-name: "moto"
+      - dependency-name: "cryptography"
     labels:
       - "bumpless"

--- a/requirements-apps-api.txt
+++ b/requirements-apps-api.txt
@@ -1,4 +1,4 @@
-cryptography<39
+cryptography==37.0.4
 flask==2.1.0
 Flask-Cors==3.0.10
 openapi-core==0.14.5


### PR DESCRIPTION
We'd forgotten to update dependabot to ignore future `cryptography` versions, so it opened a PR for the new 39.0.0 release (https://github.com/ASFHyP3/hyp3/pull/1188) that re-introduced the issue described in https://github.com/ASFHyP3/hyp3/issues/1190