### PR TITLE
ignore openapi-spec-validator in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,6 @@ updates:
     ignore:
       - dependency-name: "moto"
       - dependency-name: "cryptography"
+      - dependency-name: "openapi-spec-validator"
     labels:
       - "bumpless"


### PR DESCRIPTION
ignoring dependabot updates for openapi-spec-validator pending the resolution of https://github.com/ASFHyP3/hyp3/issues/1193