### PR TITLE
use openapi-spec-validator during make openapi-validate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ flake8:
 	flake8 --ignore=E731 --max-line-length=120 --import-order-style=pycharm --statistics --application-import-names hyp3_api,get_files,handle_batch_event,check_processing_time,start_execution,update_db,upload_log,dynamo,process_new_granules,scale_cluster apps tests lib
 
 openapi-validate: render
-	prance validate --backend=openapi-spec-validator apps/api/src/hyp3_api/api-spec/openapi-spec.yml
+	openapi-spec-validator apps/api/src/hyp3_api/api-spec/openapi-spec.yml
 
 cfn-lint: render
 	cfn-lint --info --ignore-checks W3002 E3008 --template `find . -name *-cf.yml`

--- a/apps/api/src/hyp3_api/api-spec/openapi-spec.yml.j2
+++ b/apps/api/src/hyp3_api/api-spec/openapi-spec.yml.j2
@@ -462,7 +462,7 @@ components:
       description: Date and time object formatted according to ISO 8601
       type: string
       format: date-time
-      example: 2020-06-04T18:00:03+00:00
+      example: "2020-06-04T18:00:03+00:00"
 
     intersectsWith:
       description: Area-of-interest as a WKT string.

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -15,6 +15,4 @@ flake8-import-order==0.18.1
 flake8-blind-except==0.2.1
 flake8-builtins==1.5.3
 openapi-spec-validator==0.4.0
-click==8.1.3
-prance==0.21.8.0
 cfn-lint==0.64.1


### PR DESCRIPTION
`prance` is still a dependency in `requirements-api.txt`, but we can use `openapi-spec-validator` directly in `make openapi-validate` to remove `prance` and `click` as development dependencies in `requirements-all.txt`

Datetime string in the openapi spec had to be quoted to avoid a `Object of type datetime is not JSON serializable` error described at https://github.com/p1c2u/openapi-spec-validator/issues/158