### PR TITLE
upgrade to latest generation r6id/c6id instance types

### DIFF
--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -22,7 +22,7 @@ jobs:
             quota: 1000
             deploy_ref: refs/heads/main
             job_files: job_spec/AUTORIFT.yml job_spec/INSAR_GAMMA.yml job_spec/RTC_GAMMA.yml
-            instance_types: r6id.xlarge
+            instance_types: r6id.xlarge,r5dn.xlarge
             default_max_vcpus: 1000
             expanded_max_vcpus: 2000
             required_surplus: 2000
@@ -44,7 +44,7 @@ jobs:
               job_spec/RTC_GAMMA.yml
               job_spec/INSAR_ISCE.yml
               job_spec/WATER_MAP.yml
-            instance_types: r6id.xlarge
+            instance_types: r6id.xlarge,r5dn.xlarge
             default_max_vcpus: 1000
             expanded_max_vcpus: 2000
             required_surplus: 2000

--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -22,7 +22,7 @@ jobs:
             quota: 1000
             deploy_ref: refs/heads/main
             job_files: job_spec/AUTORIFT.yml job_spec/INSAR_GAMMA.yml job_spec/RTC_GAMMA.yml
-            instance_types: r5d.xlarge,r5dn.xlarge
+            instance_types: r6id.xlarge
             default_max_vcpus: 1000
             expanded_max_vcpus: 2000
             required_surplus: 2000
@@ -44,7 +44,7 @@ jobs:
               job_spec/RTC_GAMMA.yml
               job_spec/INSAR_ISCE.yml
               job_spec/WATER_MAP.yml
-            instance_types: r5d.xlarge,r5dn.xlarge
+            instance_types: r6id.xlarge
             default_max_vcpus: 1000
             expanded_max_vcpus: 2000
             required_surplus: 2000

--- a/.github/workflows/deploy-enterprise-test.yml
+++ b/.github/workflows/deploy-enterprise-test.yml
@@ -26,7 +26,7 @@ jobs:
               job_spec/INSAR_ISCE.yml
               job_spec/WATER_MAP.yml
               job_spec/RIVER_WIDTH.yml
-            instance_types: r5d.xlarge,r5dn.xlarge,r5d.4xlarge,r5dn.4xlarge
+            instance_types: r6id.xlarge,r6id.4xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640
             required_surplus: 0

--- a/.github/workflows/deploy-enterprise-test.yml
+++ b/.github/workflows/deploy-enterprise-test.yml
@@ -26,7 +26,7 @@ jobs:
               job_spec/INSAR_ISCE.yml
               job_spec/WATER_MAP.yml
               job_spec/RIVER_WIDTH.yml
-            instance_types: r6id.xlarge,r6id.4xlarge
+            instance_types: r6id.xlarge,r6id.4xlarge,r5dn.xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640
             required_surplus: 0

--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -19,7 +19,7 @@ jobs:
             product_lifetime_in_days: 180
             quota: 0
             job_files: job_spec/AUTORIFT_ITS_LIVE.yml
-            instance_types: r5d.xlarge,r5dn.xlarge
+            instance_types: r6id.xlarge
             default_max_vcpus: 10000
             expanded_max_vcpus: 10000
             required_surplus: 0
@@ -34,7 +34,7 @@ jobs:
             product_lifetime_in_days: 180
             quota: 0
             job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
-            instance_types: c5d.xlarge
+            instance_types: c6id.xlarge
             default_max_vcpus: 1600
             expanded_max_vcpus: 1600
             required_surplus: 0
@@ -49,7 +49,7 @@ jobs:
             product_lifetime_in_days: 180
             quota: 0
             job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
-            instance_types: c5d.xlarge
+            instance_types: c6id.xlarge
             default_max_vcpus: 1600
             expanded_max_vcpus: 1600
             required_surplus: 0
@@ -64,7 +64,7 @@ jobs:
             product_lifetime_in_days: 180
             quota: 0
             job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
-            instance_types: c5d.xlarge
+            instance_types: c6id.xlarge
             default_max_vcpus: 1600
             expanded_max_vcpus: 1600
             required_surplus: 0
@@ -79,7 +79,7 @@ jobs:
             product_lifetime_in_days: 365000
             quota: 0
             job_files: job_spec/INSAR_GAMMA.yml
-            instance_types: r5d.xlarge,r5dn.xlarge
+            instance_types: r6id.xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640
             required_surplus: 0
@@ -94,7 +94,7 @@ jobs:
             product_lifetime_in_days: 14
             quota: 0
             job_files: job_spec/RTC_GAMMA.yml job_spec/WATER_MAP.yml
-            instance_types: r5d.xlarge,r5dn.xlarge
+            instance_types: r6id.xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640
             required_surplus: 0
@@ -109,7 +109,7 @@ jobs:
             product_lifetime_in_days: 14
             quota: 0
             job_files: job_spec/RTC_GAMMA_10M.yml job_spec/WATER_MAP_10M.yml job_spec/RIVER_WIDTH.yml
-            instance_types: r5d.4xlarge,r5dn.4xlarge
+            instance_types: r6id.4xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640
             required_surplus: 0

--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -19,7 +19,7 @@ jobs:
             product_lifetime_in_days: 180
             quota: 0
             job_files: job_spec/AUTORIFT_ITS_LIVE.yml
-            instance_types: r6id.xlarge
+            instance_types: r6id.xlarge,r5dn.xlarge
             default_max_vcpus: 10000
             expanded_max_vcpus: 10000
             required_surplus: 0
@@ -79,7 +79,7 @@ jobs:
             product_lifetime_in_days: 365000
             quota: 0
             job_files: job_spec/INSAR_GAMMA.yml
-            instance_types: r6id.xlarge
+            instance_types: r6id.xlarge,r5dn.xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640
             required_surplus: 0
@@ -94,7 +94,7 @@ jobs:
             product_lifetime_in_days: 14
             quota: 0
             job_files: job_spec/RTC_GAMMA.yml job_spec/WATER_MAP.yml
-            instance_types: r6id.xlarge
+            instance_types: r6id.xlarge,r5dn.xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640
             required_surplus: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.21.1]
+### Changed
+- Upgraded Batch compute environments to the latest generation `r6id`/`c6id` EC2 instance types
+
 ## [2.21.0]
 ### Added
 - Added `processing_times` field to the Job schema in the API in order to support jobs with multiple processing steps.

--- a/apps/main-cf.yml.j2
+++ b/apps/main-cf.yml.j2
@@ -81,7 +81,7 @@ Parameters:
   InstanceTypes:
     Description: EC2 instance types to include in AWS Batch Compute Environment
     Type: CommaDelimitedList
-    Default: r5d.xlarge
+    Default: r6id.xlarge
 
   {% if security_environment != 'EDC' %}
   DomainName:


### PR DESCRIPTION
These instance types were made available earlier this year and AWS Batch added support on on 2022-09-15.
- https://aws.amazon.com/about-aws/whats-new/2022/05/introducing-amazon-ec2-c6id-instances/
- https://aws.amazon.com/about-aws/whats-new/2022/06/introducing-amazon-r6id-instances/

A new generation of the network-optimized `r5dn` instance type is not (yet) available.

Overall this should reduce both the processing time and processing cost for HyP3 jobs, possibly by 10-20%. I've attached the spot price history for the relevant instance types for comparison. The [AWS Spot Advisor]() shows the new instance types have seen similar interruption rates over the last month.

Using the new instance types exclusively should deliver the lowest costs, but they may introduce more volatility. We could instead *add* the new instance types to our existing pool, only realizing a portion of the savings but greatly reducing volatility. Adding an option to set the Spot [BidPercentage](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-batch-computeenvironment-computeresources.html#cfn-batch-computeenvironment-computeresources-bidpercentage) attribute could give us the best of both worlds.

## Compute Optimized
![Screenshot from 2022-09-16 08-31-11](https://user-images.githubusercontent.com/17994518/190686599-9344aa4c-952b-4885-9df2-6262c773298d.png)
![Screenshot from 2022-09-16 08-18-04](https://user-images.githubusercontent.com/17994518/190684468-4068f3e1-5509-4259-8d53-0006453155f9.png)
![Screenshot from 2022-09-16 08-18-18](https://user-images.githubusercontent.com/17994518/190684481-20b5e090-9ad4-480a-8cbe-7f53a1eefcf0.png)

![Screenshot from 2022-09-16 08-19-30](https://user-images.githubusercontent.com/17994518/190684681-5ccf775f-eb86-4fbf-bd52-08c1a8ea1d66.png)
![Screenshot from 2022-09-16 08-19-40](https://user-images.githubusercontent.com/17994518/190684690-7a5847c4-50d0-426e-b72c-db3552e64d88.png)

## Memory Optimized (xlarge)
![Screenshot from 2022-09-16 08-31-11](https://user-images.githubusercontent.com/17994518/190686630-7ab1e2a3-dd81-455e-9df2-e5aeaa73b9f8.png)
![Screenshot from 2022-09-16 08-20-58](https://user-images.githubusercontent.com/17994518/190684996-01a81091-b88f-4e3d-a243-ee37ceb85e97.png)
![Screenshot from 2022-09-16 08-21-05](https://user-images.githubusercontent.com/17994518/190685009-0d9a8dca-eb99-464b-8b3f-8e30f0f69da6.png)
![Screenshot from 2022-09-16 08-21-18](https://user-images.githubusercontent.com/17994518/190685015-bb33aa2e-b06f-4306-ac11-d8836f45ee24.png)

![Screenshot from 2022-09-16 08-21-46](https://user-images.githubusercontent.com/17994518/190685133-e3741b70-f327-4776-a4b6-58bfe25b0546.png)
![Screenshot from 2022-09-16 08-21-56](https://user-images.githubusercontent.com/17994518/190685141-f9571d5d-bd63-48d3-90e7-2368c93bbf85.png)
![Screenshot from 2022-09-16 08-22-07](https://user-images.githubusercontent.com/17994518/190685149-e0f0efe1-8f1d-4ff4-a15b-088fab567045.png)

## Memory Optimized (4xlarge)
![Screenshot from 2022-09-16 08-31-11](https://user-images.githubusercontent.com/17994518/190686630-7ab1e2a3-dd81-455e-9df2-e5aeaa73b9f8.png)
![Screenshot from 2022-09-16 08-22-52](https://user-images.githubusercontent.com/17994518/190685302-ff039d84-964c-4fd4-a99a-e75877f3b79c.png)
![Screenshot from 2022-09-16 08-23-00](https://user-images.githubusercontent.com/17994518/190685310-1bf79cd2-6e27-4910-bb28-9d4d05de5d1a.png)
![Screenshot from 2022-09-16 08-23-13](https://user-images.githubusercontent.com/17994518/190685316-c9230f0f-e4a3-4c53-b5e9-5be796edd564.png)

![Screenshot from 2022-09-16 08-23-41](https://user-images.githubusercontent.com/17994518/190685429-59538e13-e51a-4b45-aa16-b5f3e121fdf0.png)
![Screenshot from 2022-09-16 08-23-52](https://user-images.githubusercontent.com/17994518/190685437-558ea1ec-6c84-4a48-9c5c-3015b021e26c.png)
![Screenshot from 2022-09-16 08-24-02](https://user-images.githubusercontent.com/17994518/190685446-e52a4116-2323-4baf-a359-c7c5fb48ba2d.png)
