### PR TITLE
add c5d.xlarge back to GUNW deployments

### DIFF
--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -34,7 +34,7 @@ jobs:
             product_lifetime_in_days: 180
             quota: 0
             job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
-            instance_types: c6id.xlarge
+            instance_types: c6id.xlarge,c5d.xlarge
             default_max_vcpus: 1600
             expanded_max_vcpus: 1600
             required_surplus: 0
@@ -49,7 +49,7 @@ jobs:
             product_lifetime_in_days: 180
             quota: 0
             job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
-            instance_types: c6id.xlarge
+            instance_types: c6id.xlarge,c5d.xlarge
             default_max_vcpus: 1600
             expanded_max_vcpus: 1600
             required_surplus: 0
@@ -64,7 +64,7 @@ jobs:
             product_lifetime_in_days: 180
             quota: 0
             job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
-            instance_types: c6id.xlarge
+            instance_types: c6id.xlarge,c5d.xlarge
             default_max_vcpus: 1600
             expanded_max_vcpus: 1600
             required_surplus: 0


### PR DESCRIPTION
We switched from `c5d.xlarge` to `c6id.xlarge` in v2.21.1. After the last week of activity, it does not appear there is sufficient spot capacity for our GUNW workloads using `c6id.xlarge` alone. This PR adds `c5d.xlarge` back in addition to `c6id.xlarge`, so overall capacity should be better than either instance type alone.

Spot price graph shows prices rising quickly since processing began in the hyp3-nisar-jpl deployment:
![image](https://user-images.githubusercontent.com/17994518/193702369-4d3806a6-34a6-4b87-8cf3-51ee2c8d15e7.png)

The auto-scaling group for the hyp3-a19-jpl deployment shows insufficient capacity to scale up to 1,600 vcpus; it's currenly only able to provision 188 vcpus.
![image](https://user-images.githubusercontent.com/17994518/193702593-fc394edc-ee1b-41a5-b052-278811a5af82.png)

Similar for the hyp3-nisar-jpl deployment, only 372 of 1,600 vcpus provisioned:
![image](https://user-images.githubusercontent.com/17994518/193702807-03a1b0aa-9a59-4c76-88ab-a537d1a0f633.png)
