### PR TITLE
automate updates of github action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 # To get started with Dependabot version updates, you'll need to specify which
 # package ecosystems to update and where the package manifests are located.
 # Please see the documentation for all configuration options:
-# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
 version: 2
 updates:
@@ -12,5 +12,11 @@ updates:
     ignore:
       - dependency-name: "cryptography"
       - dependency-name: "openapi-spec-validator"
+    labels:
+      - "bumpless"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
     labels:
       - "bumpless"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,6 +13,6 @@ on:
 
 jobs:
   call-changelog-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@main
+    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@0.4.0
     secrets:
       USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,6 +13,6 @@ on:
 
 jobs:
   call-changelog-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-changelog-check.yml@v0.4.0
     secrets:
       USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -101,6 +101,6 @@ jobs:
   call-bump-version-workflow:
     if: github.ref == 'refs/heads/main'
     needs: deploy
-    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@main
+    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@0.4.0
     secrets:
       USER_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}

--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -101,6 +101,6 @@ jobs:
   call-bump-version-workflow:
     if: github.ref == 'refs/heads/main'
     needs: deploy
-    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-bump-version.yml@v0.4.0
     secrets:
       USER_TOKEN: ${{ secrets.TOOLS_BOT_PAK }}

--- a/.github/workflows/labeled-pr.yml
+++ b/.github/workflows/labeled-pr.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   call-labeled-pr-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@main
+    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@0.4.0

--- a/.github/workflows/labeled-pr.yml
+++ b/.github/workflows/labeled-pr.yml
@@ -12,4 +12,4 @@ on:
 
 jobs:
   call-labeled-pr-check-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-labeled-pr-check.yml@v0.4.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-release-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@main
+    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@0.4.0
     with:
       release_prefix: HyP3
     secrets:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   call-release-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-release.yml@v0.4.0
     with:
       release_prefix: HyP3
     secrets:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -87,4 +87,4 @@ jobs:
           snyk iac test --severity-threshold=high
 
   call-secrets-analysis-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@0.4.0
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@v0.4.0

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -71,7 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: snyk/actions/setup@master
+      - uses: snyk/actions/setup@0.3.0
       - uses: actions/setup-python@v1
         with:
           python-version: 3.9
@@ -87,4 +87,4 @@ jobs:
           snyk iac test --severity-threshold=high
 
   call-secrets-analysis-workflow:
-    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@main
+    uses: ASFHyP3/actions/.github/workflows/reusable-secrets-analysis.yml@0.4.0

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,4 +19,3 @@ jobs:
 
       - name: run pytest
         run: make tests
-


### PR DESCRIPTION
copied from the already-working dependabot.yml at https://github.com/ASFHyP3/actions/blob/develop/.github/dependabot.yml

We now also pin all github actions to specific versions in their `uses: ` fields. Currently pins are a mix of major and patch versions. Should we consider everything to a patch version, or maybe only to a minor version?