### PR TITLE
add temporary hyp3-edc-contingency environment to deploy-daac.yml

### DIFF
--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -58,7 +58,7 @@ jobs:
             template_bucket: cf-templates-118ylv0o6jp2n-us-west-2
             image_tag: test
             product_lifetime_in_days: 14
-            quota: 1000
+            quota: 10
             deploy_ref: refs/heads/develop
             job_files: >-
               job_spec/AUTORIFT.yml
@@ -67,9 +67,9 @@ jobs:
               job_spec/INSAR_ISCE.yml
               job_spec/WATER_MAP.yml
             instance_types: r6id.xlarge,r5dn.xlarge
-            default_max_vcpus: 1000
-            expanded_max_vcpus: 2000
-            required_surplus: 2000
+            default_max_vcpus: 20
+            expanded_max_vcpus: 40
+            required_surplus: 50
             security_environment: EDC
             ami_id: image_id_ecs_amz2
             distribution_url: 'https://d1riv60tezqha9.cloudfront.net'

--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -72,7 +72,7 @@ jobs:
             required_surplus: 2000
             security_environment: EDC
             ami_id: image_id_ecs_amz2
-            distribution_url: 'https://foo.cloudfront.net'
+            distribution_url: 'https://d1riv60tezqha9.cloudfront.net'
 
     environment:
       name: ${{ matrix.environment }}

--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -52,6 +52,28 @@ jobs:
             ami_id: image_id_ecs_amz2
             distribution_url: 'https://d1riv60tezqha9.cloudfront.net'
 
+          - environment: hyp3-edc-contingency
+            domain: ''
+            api_name: hyp3-contingency
+            template_bucket: cf-templates-118ylv0o6jp2n-us-west-2
+            image_tag: test
+            product_lifetime_in_days: 14
+            quota: 1000
+            deploy_ref: refs/heads/develop
+            job_files: >-
+              job_spec/AUTORIFT.yml
+              job_spec/INSAR_GAMMA.yml
+              job_spec/RTC_GAMMA.yml
+              job_spec/INSAR_ISCE.yml
+              job_spec/WATER_MAP.yml
+            instance_types: r6id.xlarge,r5dn.xlarge
+            default_max_vcpus: 1000
+            expanded_max_vcpus: 2000
+            required_surplus: 2000
+            security_environment: EDC
+            ami_id: image_id_ecs_amz2
+            distribution_url: 'https://foo.cloudfront.net'
+
     environment:
       name: ${{ matrix.environment }}
       url: https://${{ matrix.domain }}


### PR DESCRIPTION
Should we actually merge this into `develop`, or should we use an alternate `deploy_ref` so we don't have a merge/revert in our git history?

Corresponding hyp3-edc-contingency github environment has been created.