### PR TITLE
add new execution_started index to jobs table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [2.21.3]
+## [2.21.4]
 ### Added
 - A new `execution_started` global secondary index has been added to the DynamoDB Jobs table.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [2.21.3]
+### Added
+- A new `execution_started` global secondary index has been added to the DynamoDB Jobs table.
+
 ## [2.21.3]
 ### Added
 - AutoRIFT jobs now allow submission of Landsat 4, 5, and 7 Collection 2 scene pairs

--- a/apps/main-cf.yml.j2
+++ b/apps/main-cf.yml.j2
@@ -354,6 +354,8 @@ Resources:
           AttributeType: S
         - AttributeName: request_time
           AttributeType: S
+        - AttributeName: execution_started
+          AttributeType: B
       KeySchema:
         - AttributeName: job_id
           KeyType: HASH
@@ -369,6 +371,12 @@ Resources:
         - IndexName: status_code
           KeySchema:
             - AttributeName: status_code
+              KeyType: HASH
+          Projection:
+            ProjectionType: ALL
+        - IndexName: execution_started
+          KeySchema:
+            - AttributeName: execution_started
               KeyType: HASH
           Projection:
             ProjectionType: ALL

--- a/apps/main-cf.yml.j2
+++ b/apps/main-cf.yml.j2
@@ -378,6 +378,8 @@ Resources:
           KeySchema:
             - AttributeName: execution_started
               KeyType: HASH
+            - AttributeName: request_time
+              KeyType: RANGE
           Projection:
             ProjectionType: ALL
 


### PR DESCRIPTION
Should we include a `RANGE` key on `request_time` to the new index as well? It's not strictly necessary; the `status_code` index we're replacing didn't have one, but adding one would let us prioritize starting executions in the order that they were submitted.