### PR TITLE
Revert "re-add execution_started index with correct attribute type"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-
-## [2.21.4]
-### Added
-- A new `execution_started` global secondary index has been added to the DynamoDB Jobs table.
-
 ## [2.21.3]
 ### Added
 - AutoRIFT jobs now allow submission of Landsat 4, 5, and 7 Collection 2 scene pairs

--- a/apps/main-cf.yml.j2
+++ b/apps/main-cf.yml.j2
@@ -354,8 +354,6 @@ Resources:
           AttributeType: S
         - AttributeName: request_time
           AttributeType: S
-        - AttributeName: execution_started
-          AttributeType: S
       KeySchema:
         - AttributeName: job_id
           KeyType: HASH
@@ -372,14 +370,6 @@ Resources:
           KeySchema:
             - AttributeName: status_code
               KeyType: HASH
-          Projection:
-            ProjectionType: ALL
-        - IndexName: execution_started
-          KeySchema:
-            - AttributeName: execution_started
-              KeyType: HASH
-            - AttributeName: request_time
-              KeyType: RANGE
           Projection:
             ProjectionType: ALL
 


### PR DESCRIPTION
Reverts ASFHyP3/hyp3#1260

This didn't work either. These queries always return zero results:
```
response = table.query(IndexName='execution_started', KeyConditionExpression=Key('execution_started').eq('false'))
response = table.query(IndexName='execution_started', KeyConditionExpression=Key('execution_started').eq('true'))
```
And querying using a boolean type throws an error because the index is expecting a string:
```
response = table.query(IndexName='execution_started', KeyConditionExpression=Key('execution_started').eq(False))

botocore.exceptions.ClientError: An error occurred (ValidationException) when calling the Query operation: One or more parameter values were invalid: Condition parameter type does not match schema type
```

Google suggests it's simply not possible to create in index on a boolean attribute. https://stackoverflow.com/questions/28258024/dynamodb-query-on-boolean-key has some discussion of alternatives.