### PR TITLE
drop unused LambdaArn output from subscription manager cloudformation template

### DIFF
--- a/apps/subscription-manager/subscription-manager-cf.yml.j2
+++ b/apps/subscription-manager/subscription-manager-cf.yml.j2
@@ -19,11 +19,6 @@ Parameters:
     Type: CommaDelimitedList
   {% endif %}
 
-Outputs:
-
-  LambdaArn:
-    Value: !GetAtt Lambda.Arn
-
 Resources:
 
   LogGroup:


### PR DESCRIPTION
Inspection and cfn-lint confirm the output isn't being used, so I prefer to remove it. I assume this was copy/paste from the subscription worker template, which *does* need an output.