### PR TITLE
reduce worker concurrency by running manager twice as often for half the jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [2.21.4]
 ### Changed
 - Batches of step function executions are now started in parallel using a manager to launch one worker per batch of jobs
-  (currently up to 6 batches of 300 jobs for a total of 1800 jobs each time the manager runs).
+  (currently up to 3 batches of 300 jobs for a total of 900 jobs each time the manager runs).
 
 ## [2.21.3]
 ### Added

--- a/apps/start-execution-manager/src/start_execution_manager.py
+++ b/apps/start-execution-manager/src/start_execution_manager.py
@@ -28,7 +28,7 @@ def lambda_handler(event, context) -> None:
     worker_function_arn = os.environ['START_EXECUTION_WORKER_ARN']
     logger.info(f'Worker function ARN: {worker_function_arn}')
 
-    pending_jobs = dynamo.jobs.get_jobs_waiting_for_execution(limit=1800)
+    pending_jobs = dynamo.jobs.get_jobs_waiting_for_execution(limit=900)
     logger.info(f'Got {len(pending_jobs)} pending jobs')
 
     batch_size = 300

--- a/apps/start-execution-manager/start-execution-manager-cf.yml.j2
+++ b/apps/start-execution-manager/start-execution-manager-cf.yml.j2
@@ -101,7 +101,7 @@ Resources:
   Schedule:
     Type: AWS::Events::Rule
     Properties:
-      ScheduleExpression: "rate(2 minutes)"
+      ScheduleExpression: "rate(1 minute)"
       Targets:
         - Arn: !GetAtt Lambda.Arn
           Id: lambda

--- a/tests/test_start_execution_manager.py
+++ b/tests/test_start_execution_manager.py
@@ -53,46 +53,42 @@ def test_invoke_worker():
         )
 
 
-def test_lambda_handler_1800_jobs():
+def test_lambda_handler_900_jobs():
     with patch('dynamo.jobs.get_jobs_waiting_for_execution') as mock_get_jobs_waiting_for_execution, \
             patch('start_execution_manager.invoke_worker') as mock_invoke_worker, \
             patch.dict(os.environ, {'START_EXECUTION_WORKER_ARN': 'test-worker-function-arn'}, clear=True):
-        mock_jobs = list(range(1800))
+        mock_jobs = list(range(900))
         mock_get_jobs_waiting_for_execution.return_value = mock_jobs
 
         mock_invoke_worker.return_value = {'StatusCode': None}
 
         start_execution_manager.lambda_handler(None, None)
 
-        mock_get_jobs_waiting_for_execution.assert_called_once_with(limit=1800)
+        mock_get_jobs_waiting_for_execution.assert_called_once_with(limit=900)
 
         assert mock_invoke_worker.mock_calls == [
             call('test-worker-function-arn', mock_jobs[0:300]),
             call('test-worker-function-arn', mock_jobs[300:600]),
             call('test-worker-function-arn', mock_jobs[600:900]),
-            call('test-worker-function-arn', mock_jobs[900:1200]),
-            call('test-worker-function-arn', mock_jobs[1200:1500]),
-            call('test-worker-function-arn', mock_jobs[1500:1800]),
         ]
 
 
-def test_lambda_handler_700_jobs():
+def test_lambda_handler_400_jobs():
     with patch('dynamo.jobs.get_jobs_waiting_for_execution') as mock_get_jobs_waiting_for_execution, \
             patch('start_execution_manager.invoke_worker') as mock_invoke_worker, \
             patch.dict(os.environ, {'START_EXECUTION_WORKER_ARN': 'test-worker-function-arn'}, clear=True):
-        mock_jobs = list(range(700))
+        mock_jobs = list(range(400))
         mock_get_jobs_waiting_for_execution.return_value = mock_jobs
 
         mock_invoke_worker.return_value = {'StatusCode': None}
 
         start_execution_manager.lambda_handler(None, None)
 
-        mock_get_jobs_waiting_for_execution.assert_called_once_with(limit=1800)
+        mock_get_jobs_waiting_for_execution.assert_called_once_with(limit=900)
 
         assert mock_invoke_worker.mock_calls == [
             call('test-worker-function-arn', mock_jobs[0:300]),
-            call('test-worker-function-arn', mock_jobs[300:600]),
-            call('test-worker-function-arn', mock_jobs[600:700]),
+            call('test-worker-function-arn', mock_jobs[300:400]),
         ]
 
 
@@ -107,7 +103,7 @@ def test_lambda_handler_50_jobs():
 
         start_execution_manager.lambda_handler(None, None)
 
-        mock_get_jobs_waiting_for_execution.assert_called_once_with(limit=1800)
+        mock_get_jobs_waiting_for_execution.assert_called_once_with(limit=900)
 
         assert mock_invoke_worker.mock_calls == [
             call('test-worker-function-arn', mock_jobs),
@@ -122,6 +118,6 @@ def test_lambda_handler_no_jobs():
 
         start_execution_manager.lambda_handler(None, None)
 
-        mock_get_jobs_waiting_for_execution.assert_called_once_with(limit=1800)
+        mock_get_jobs_waiting_for_execution.assert_called_once_with(limit=900)
 
         mock_invoke_worker.assert_not_called()


### PR DESCRIPTION
@jtherrmann Here's a draft of the straightforward way to handle the batch.submit_job service limit; I imagine there's more discussion to be had but I at least wanted to see what this version looked like.