### PR TITLE
add AUTORIFT_TEST job type to hyp3-its-live deployment

### DIFF
--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -18,7 +18,7 @@ jobs:
             image_tag: latest
             product_lifetime_in_days: 180
             quota: 0
-            job_files: job_spec/AUTORIFT_ITS_LIVE.yml
+            job_files: job_spec/AUTORIFT_ITS_LIVE.yml job_spec/AUTORIFT_ITS_LIVE_TEST.yml
             instance_types: r6id.xlarge,r5dn.xlarge
             default_max_vcpus: 10000
             expanded_max_vcpus: 10000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.21.5]
+### Added
+- A new `AUTORIFT_TEST` job type for the hyp3-its-live deployment running the `test` version of the container.
+
 ## [2.21.4]
 ### Changed
 - Batches of step function executions are now started in parallel using a manager to launch one worker per batch of jobs

--- a/job_spec/AUTORIFT_ITS_LIVE_TEST.yml
+++ b/job_spec/AUTORIFT_ITS_LIVE_TEST.yml
@@ -1,0 +1,59 @@
+AUTORIFT_TEST:
+  required_parameters:
+    - granules
+  parameters:
+    granules:
+      default:  '""'
+      api_schema:
+        type: array
+        minItems: 2
+        maxItems: 2
+        example:
+          - S2B_13CES_20200105_0_L1C
+          - S2B_13CES_20200315_0_L1C
+        items:
+          anyOf:
+            - description: The name of the Sentinel-1 SLC granule to process
+              type: string
+              pattern: "^S1[AB]_IW_SLC__1S[SD][VH]"
+              minLength: 67
+              maxLength: 67
+              example: S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8
+            - description: The name of the Sentinel-2 granule to process (ESA naming convention)
+              type: string
+              pattern: "^S2[AB]_MSIL1C_"
+              minLength: 60
+              maxLength: 60
+              example: S2A_MSIL1C_20200627T150921_N0209_R025_T22WEB_20200627T170912
+            - description: The name of the Sentinel-2 granule to process (Element 84 Earth Search naming convention)
+              type: string
+              pattern: "^S2[AB]_.*_L1C"
+              minLength: 23
+              maxLength: 25
+              example: S2A_22WEB_20200627_0_L1C
+            - description: The name of the Landsat 4, 5, 7, 8 or 9 Collection 2 granule to process
+              type: string
+              pattern: "^L([CO]0[89]|E07|T0[45])_L1"
+              minLength: 40
+              maxLength: 40
+              example: LC08_L1GT_118112_20210107_20210107_02_T2
+    bucket_prefix:
+      default:  '""'
+  validators: []
+  tasks:
+    - name: ''
+      image: ghcr.io/asfhyp3/hyp3-autorift
+      image_tag: test
+      command:
+        - --bucket
+        - '!Ref Bucket'
+        - --bucket-prefix
+        - Ref::bucket_prefix
+        - --parameter-file
+        - '/vsicurl/http://its-live-data.s3.amazonaws.com/autorift_parameters/v001/autorift_landice_0120m.shp'
+        - --naming-scheme
+        - ITS_LIVE_PROD
+        - Ref::granules
+      timeout: 10800
+      vcpu: 1
+      memory: 31600


### PR DESCRIPTION
We want to run a non-trivial amount of data processing to validate the `hyp3-autorift:test` container before a production release. This PR adds the ability to run jobs using the test container to the hyp3-its-live.asf.alaska.edu deployment so the validation jobs can be run there and billed to the project.

It's helpful to diff `AUTORIFT_ITS_LIVE_TEST.yml` with `AUTORIFT_ITS_LIVE.yml`; the only differences should be the `AUTORIFT_TEST` job name and the `image_tag: test` field.

Does this deserve a changelog entry? I imagine we'll release it immediately, and I always lean against bumpless releases.