### PR TITLE
reduce hyp3-tibet-jpl deployment to 700 vcpus

### DIFF
--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -65,8 +65,8 @@ jobs:
             quota: 0
             job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
             instance_types: c6id.xlarge,c5d.xlarge
-            default_max_vcpus: 1600
-            expanded_max_vcpus: 1600
+            default_max_vcpus: 700
+            expanded_max_vcpus: 700
             required_surplus: 0
             security_environment: JPL-public
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id

--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -50,8 +50,8 @@ jobs:
             quota: 0
             job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
             instance_types: c6id.xlarge,c5d.xlarge
-            default_max_vcpus: 1600
-            expanded_max_vcpus: 1600
+            default_max_vcpus: 700
+            expanded_max_vcpus: 700
             required_surplus: 0
             security_environment: JPL-public
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
@@ -65,8 +65,8 @@ jobs:
             quota: 0
             job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
             instance_types: c6id.xlarge,c5d.xlarge
-            default_max_vcpus: 700
-            expanded_max_vcpus: 700
+            default_max_vcpus: 1600
+            expanded_max_vcpus: 1600
             required_surplus: 0
             security_environment: JPL-public
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.21.7]
+### Changed
+- Reduced hyp3-nisar-jpl deployment to 700 maximum VCPUs.
+
 ## [2.21.6]
 ### Added
 - Included `r5d.xlarge` EC2 instances types in most deployments to improve Spot availability

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.21.7]
 ### Changed
-- Reduced hyp3-nisar-jpl deployment to 700 maximum VCPUs.
+- Reduced hyp3-tibet-jpl deployment to 700 maximum VCPUs.
 
 ## [2.21.6]
 ### Added


### PR DESCRIPTION
Per discussion with @cmarshak , we want to reduce spending for the Tibet deployment to a maximum of ~$300/day. We've seen a maximum spending of ~$700/day when running at 1600 vcpus. $1600 vpucs / $700 * $300 = 685 vpucs, so 700 vcpus should be a reasonable round number.