### PR TITLE
Revert "Log unhandled exceptions in lambdas with logging configured"

### DIFF
--- a/apps/start-execution-manager/src/start_execution_manager.py
+++ b/apps/start-execution-manager/src/start_execution_manager.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import sys
 
 import boto3
 
@@ -12,13 +11,6 @@ LAMBDA_CLIENT = boto3.client('lambda')
 logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
-
-
-def handle_exception(exc_type, value, traceback) -> None:
-    logger.critical('Unhandled exception', exc_info=(exc_type, value, traceback))
-
-
-sys.excepthook = handle_exception
 
 
 def invoke_worker(worker_function_arn: str, jobs: list[dict]) -> dict:

--- a/apps/start-execution-worker/src/start_execution_worker.py
+++ b/apps/start-execution-worker/src/start_execution_worker.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import sys
 from typing import Any
 
 import boto3
@@ -11,13 +10,6 @@ STEP_FUNCTION = boto3.client('stepfunctions')
 logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
-
-
-def handle_exception(exc_type, value, traceback) -> None:
-    logger.critical('Unhandled exception', exc_info=(exc_type, value, traceback))
-
-
-sys.excepthook = handle_exception
 
 
 def convert_to_string(obj: Any) -> str:

--- a/apps/subscription-manager/src/subscription_manager.py
+++ b/apps/subscription-manager/src/subscription_manager.py
@@ -1,24 +1,16 @@
 import json
 import logging
 import os
-import sys
 
 import boto3
 
 import dynamo
 
-LAMBDA_CLIENT = boto3.client('lambda')
-
 logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-
-def handle_exception(exc_type, value, traceback) -> None:
-    logger.critical('Unhandled exception', exc_info=(exc_type, value, traceback))
-
-
-sys.excepthook = handle_exception
+LAMBDA_CLIENT = boto3.client('lambda')
 
 
 def invoke_worker(worker_function_arn: str, subscription: dict) -> dict:

--- a/apps/subscription-worker/src/subscription_worker.py
+++ b/apps/subscription-worker/src/subscription_worker.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 
@@ -11,13 +10,6 @@ import dynamo
 logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
-
-
-def handle_exception(exc_type, value, traceback) -> None:
-    logger.critical('Unhandled exception', exc_info=(exc_type, value, traceback))
-
-
-sys.excepthook = handle_exception
 
 
 def get_unprocessed_granules(subscription):


### PR DESCRIPTION
Reverts ASFHyP3/hyp3#1289

Confirmed that this does not work because it seems that assigning to `sys.excepthook` in AWS Lambda does not work; see comments on https://github.com/ASFHyP3/hyp3/issues/1286