### PR TITLE
Add `lambda_logging` package and log unhandled exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
 lib64/
 parts/
 sdist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.21.12]
+### Added
+- Added `lambda_logging` library for re-usable Lambda logging functionality.
+
 ## [2.21.11]
 ### Changed
 - Increase vCPU and monthly budget values for test and production EDC deployments.

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ render:
 static: flake8 openapi-validate cfn-lint
 
 flake8:
-	flake8 --ignore=E731 --max-line-length=120 --import-order-style=pycharm --statistics --application-import-names hyp3_api,get_files,handle_batch_event,check_processing_time,start_execution_manager,start_execution_worker,update_db,upload_log,dynamo,subscription_manager,subscription_worker,scale_cluster apps tests lib
+	flake8 --ignore=E731 --max-line-length=120 --import-order-style=pycharm --statistics --application-import-names hyp3_api,get_files,handle_batch_event,check_processing_time,start_execution_manager,start_execution_worker,update_db,upload_log,dynamo,lambda_logging,subscription_manager,subscription_worker,scale_cluster apps tests lib
 
 openapi-validate: render
 	openapi-spec-validator apps/api/src/hyp3_api/api-spec/openapi-spec.yml

--- a/apps/start-execution-manager/src/start_execution_manager.py
+++ b/apps/start-execution-manager/src/start_execution_manager.py
@@ -1,16 +1,12 @@
 import json
-import logging
 import os
 
 import boto3
 
 import dynamo
+from lambda_logging import log_exceptions, logger
 
 LAMBDA_CLIENT = boto3.client('lambda')
-
-logging.basicConfig()
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
 
 
 def invoke_worker(worker_function_arn: str, jobs: list[dict]) -> dict:
@@ -24,6 +20,7 @@ def invoke_worker(worker_function_arn: str, jobs: list[dict]) -> dict:
     )
 
 
+@log_exceptions
 def lambda_handler(event, context) -> None:
     worker_function_arn = os.environ['START_EXECUTION_WORKER_ARN']
     logger.info(f'Worker function ARN: {worker_function_arn}')

--- a/apps/start-execution-worker/src/start_execution_worker.py
+++ b/apps/start-execution-worker/src/start_execution_worker.py
@@ -1,15 +1,12 @@
 import json
-import logging
 import os
 from typing import Any
 
 import boto3
 
-STEP_FUNCTION = boto3.client('stepfunctions')
+from lambda_logging import log_exceptions, logger
 
-logging.basicConfig()
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
+STEP_FUNCTION = boto3.client('stepfunctions')
 
 
 def convert_to_string(obj: Any) -> str:
@@ -36,6 +33,7 @@ def submit_jobs(jobs: list[dict]) -> None:
         )
 
 
+@log_exceptions
 def lambda_handler(event, context) -> None:
     jobs = event['jobs']
     logger.info(f'Submitting {len(jobs)} jobs')

--- a/apps/subscription-manager/src/subscription_manager.py
+++ b/apps/subscription-manager/src/subscription_manager.py
@@ -1,14 +1,10 @@
 import json
-import logging
 import os
 
 import boto3
 
 import dynamo
-
-logging.basicConfig()
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
+from lambda_logging import log_exceptions, logger
 
 LAMBDA_CLIENT = boto3.client('lambda')
 
@@ -24,6 +20,7 @@ def invoke_worker(worker_function_arn: str, subscription: dict) -> dict:
     )
 
 
+@log_exceptions
 def lambda_handler(event, context):
     worker_function_arn = os.environ['SUBSCRIPTION_WORKER_ARN']
     logger.info(f'Worker function ARN: {worker_function_arn}')

--- a/apps/subscription-worker/src/subscription_worker.py
+++ b/apps/subscription-worker/src/subscription_worker.py
@@ -1,4 +1,3 @@
-import logging
 from copy import deepcopy
 from datetime import datetime, timedelta, timezone
 
@@ -6,10 +5,7 @@ import asf_search
 import dateutil.parser
 
 import dynamo
-
-logging.basicConfig()
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
+from lambda_logging import log_exceptions, logger
 
 
 def get_unprocessed_granules(subscription):
@@ -75,6 +71,7 @@ def handle_subscription(subscription):
         dynamo.jobs.put_jobs(subscription['user_id'], jobs, fail_when_over_quota=False)
 
 
+@log_exceptions
 def lambda_handler(event, context) -> None:
     subscription = event['subscription']
     logger.info(f'Handling subscription {subscription["subscription_id"]} for user {subscription["user_id"]}')

--- a/lib/lambda_logging/lambda_logging/__init__.py
+++ b/lib/lambda_logging/lambda_logging/__init__.py
@@ -1,7 +1,7 @@
 import logging
+import sys
 from functools import wraps
 
-# TODO do we need to modify this since it's now in another module?
 logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -15,6 +15,6 @@ def log_exceptions(lambda_handler):
             lambda_handler(event, context)
         except:  # noqa: E722
             logger.exception('Unhandled exception')
-            raise
+            sys.exit(1)
 
     return wrapper

--- a/lib/lambda_logging/lambda_logging/__init__.py
+++ b/lib/lambda_logging/lambda_logging/__init__.py
@@ -1,0 +1,20 @@
+import logging
+from functools import wraps
+
+# TODO do we need to modify this since it's now in another module?
+logging.basicConfig()
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+
+def log_exceptions(lambda_handler):
+
+    @wraps(lambda_handler)
+    def wrapper(event, context):
+        try:
+            lambda_handler(event, context)
+        except:  # noqa: E722
+            logger.exception('Unhandled exception')
+            raise
+
+    return wrapper

--- a/lib/lambda_logging/setup.py
+++ b/lib/lambda_logging/setup.py
@@ -1,0 +1,9 @@
+from setuptools import find_packages, setup
+
+setup(
+    name='lambda_logging',
+    license='BSD',
+    include_package_data=True,
+    python_requires='~=3.9',
+    packages=find_packages(),
+)

--- a/requirements-apps-start-execution-manager.txt
+++ b/requirements-apps-start-execution-manager.txt
@@ -1,2 +1,3 @@
 boto3==1.26.11
 ./lib/dynamo/
+./lib/lambda_logging

--- a/requirements-apps-start-execution-manager.txt
+++ b/requirements-apps-start-execution-manager.txt
@@ -1,3 +1,3 @@
 boto3==1.26.11
 ./lib/dynamo/
-./lib/lambda_logging
+./lib/lambda_logging/

--- a/requirements-apps-start-execution-worker.txt
+++ b/requirements-apps-start-execution-worker.txt
@@ -1,2 +1,2 @@
 boto3==1.26.11
-./lib/lambda_logging
+./lib/lambda_logging/

--- a/requirements-apps-start-execution-worker.txt
+++ b/requirements-apps-start-execution-worker.txt
@@ -1,1 +1,2 @@
 boto3==1.26.11
+./lib/lambda_logging

--- a/requirements-apps-subscription-manager.txt
+++ b/requirements-apps-subscription-manager.txt
@@ -1,2 +1,2 @@
 ./lib/dynamo/
-./lib/lambda_logging
+./lib/lambda_logging/

--- a/requirements-apps-subscription-manager.txt
+++ b/requirements-apps-subscription-manager.txt
@@ -1,1 +1,2 @@
 ./lib/dynamo/
+./lib/lambda_logging

--- a/requirements-apps-subscription-worker.txt
+++ b/requirements-apps-subscription-worker.txt
@@ -1,3 +1,3 @@
 asf-search==5.1.2
 ./lib/dynamo/
-./lib/lambda_logging
+./lib/lambda_logging/

--- a/requirements-apps-subscription-worker.txt
+++ b/requirements-apps-subscription-worker.txt
@@ -1,2 +1,3 @@
 asf-search==5.1.2
 ./lib/dynamo/
+./lib/lambda_logging

--- a/tests/test_subscription_worker.py
+++ b/tests/test_subscription_worker.py
@@ -286,7 +286,7 @@ def test_lambda_handler(tables):
             subscription_worker.lambda_handler({'subscription': items[0]}, None)
 
             with pytest.raises(ValueError, match=r'subscription sub2 is disabled'):
-                subscription_worker.lambda_handler({'subscription': items[1]}, None)
+                subscription_worker.lambda_handler.__wrapped__({'subscription': items[1]}, None)
 
             subscription_worker.lambda_handler({'subscription': items[2]}, None)
             subscription_worker.lambda_handler({'subscription': items[3]}, None)


### PR DESCRIPTION
See https://github.com/ASFHyP3/hyp3/issues/1286

The motivation behind this PR is to include the AWS request ID when logging unhandled exceptions in Lambda functions.

- [x] Test the `lambda_logging` module in a sandbox stack to see if it works as expected (still logs normal stuff correctly, logs unhandled exceptions correctly, and re-raises the exception).
- [x] Determine if we need to modify the `logging` config since it's now in a separate module rather than in the lambda handler itself.