### PR TITLE
Drop c5d instance size to overcome disk space issues for Hawaii

### DIFF
--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -34,7 +34,7 @@ jobs:
             product_lifetime_in_days: 180
             quota: 0
             job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
-            instance_types: c6id.xlarge,c5d.2xlarge
+            instance_types: c6id.xlarge
             default_max_vcpus: 1600
             expanded_max_vcpus: 1600
             required_surplus: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.21.10]
 ### Changed
-- Double the instance size due to disk space limitations for GUNW product generation in the ACCESS19 JPL deployment.
+- Drop the `c5d` instance family due to disk space limitations for GUNW product generation in the ACCESS19 JPL deployment.
 
 ## [2.21.9]
 ### Added


### PR DESCRIPTION
`c6id.xlarge`'s have more than twice the storage as the `c5d.xlarge` instances and won't cause multiple jobs to compete for disk on the same instance like moving to the `c5d.2xlarge`.