### PR TITLE
Raise `UnhandledException` when Lambda function fails

### DIFF
--- a/lib/lambda_logging/lambda_logging/__init__.py
+++ b/lib/lambda_logging/lambda_logging/__init__.py
@@ -1,10 +1,13 @@
 import logging
-import sys
 from functools import wraps
 
 logging.basicConfig()
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
+
+
+class UnhandledException(Exception):
+    pass
 
 
 def log_exceptions(lambda_handler):
@@ -15,6 +18,6 @@ def log_exceptions(lambda_handler):
             lambda_handler(event, context)
         except:  # noqa: E722
             logger.exception('Unhandled exception')
-            sys.exit(1)
+            raise UnhandledException('The Lambda function failed with an unhandled exception (see the logs)')
 
     return wrapper

--- a/tests/test_lambda_logging.py
+++ b/tests/test_lambda_logging.py
@@ -1,5 +1,6 @@
-import lambda_logging
 import pytest
+
+import lambda_logging
 
 
 def test_log_exceptions():

--- a/tests/test_lambda_logging.py
+++ b/tests/test_lambda_logging.py
@@ -1,0 +1,14 @@
+import lambda_logging
+import pytest
+
+
+def test_log_exceptions():
+    @lambda_logging.log_exceptions
+    def lambda_handler(event, context):
+        raise ValueError()
+
+    with pytest.raises(ValueError):
+        lambda_handler.__wrapped__(None, None)
+
+    with pytest.raises(lambda_logging.UnhandledException):
+        lambda_handler(None, None)


### PR DESCRIPTION
Calling `sys.exit(1)` after logging an unhandled exception in a Lambda function was not ideal, as this results in the line `Error: Runtime exited with error: exit status 1` appearing after the unhandled exception traceback in the logs, which means that both error messages are returned when querying CloudWatch Logs Insights for errors. The obvious solution is to exclude the second error message in the query, but I wanted a more explicit error message that would only appear after an unhandled exception has been logged, so that we don't accidentally exclude `Error: Runtime exited with error: exit status 1` if it appears for some other reason.

This PR modifies the `lambda_logging` library to instead raise an `UnhandledException` error after logging an unhandled exception, so that the following line appears after the unhandled exception traceback:

```
UnhandledException: The Lambda handler failed with an unhandled exception (see the logs)
```

This also results in a more helpful error message when invoking the Lambda function synchronously via the AWS CLI.