### PR TITLE
set OMP_NUM_THREADS for GAMMA job types and expand DAAC EC2 instance types

### DIFF
--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -22,7 +22,7 @@ jobs:
             quota: 1000
             deploy_ref: refs/heads/main
             job_files: job_spec/AUTORIFT.yml job_spec/INSAR_GAMMA.yml job_spec/RTC_GAMMA.yml
-            instance_types: r6id.xlarge,r5dn.xlarge,r5d.xlarge
+            instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r5dn.xlarge,r5dn.2xlarge,r5d.xlarge,r5d.2xlarge
             default_max_vcpus: 1500
             expanded_max_vcpus: 3000
             required_surplus: 3000
@@ -44,7 +44,7 @@ jobs:
               job_spec/RTC_GAMMA.yml
               job_spec/INSAR_ISCE.yml
               job_spec/WATER_MAP.yml
-            instance_types: r6id.xlarge,r5dn.xlarge,r5d.xlarge
+            instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r5dn.xlarge,r5dn.2xlarge,r5d.xlarge,r5d.2xlarge
             default_max_vcpus: 1500
             expanded_max_vcpus: 3000
             required_surplus: 3000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.23.0]
+### Changed
+- Set `++omp-num-threads 4` for RTC_GAMMA, INSAR_GAMMA, and WATER_MAP jobs to drastically reduce CPU contention when
+  running multiple jobs on the same EC2 instance.
+- Updated DAAC deployments to include larger EC2 instance types capable of running multiple jobs per instance.
+
 ## [2.22.0]
 ### Added
 - In addition to `power` and `amplitude`, `decibel` can now be provided as the `scale` for `RTC_GAMMA` jobs

--- a/job_spec/INSAR_GAMMA.yml
+++ b/job_spec/INSAR_GAMMA.yml
@@ -71,6 +71,8 @@ INSAR_GAMMA:
       command:
         - ++process
         - insar
+        - ++omp-num-threads
+        - '4'
         - --bucket
         - '!Ref Bucket'
         - --bucket-prefix

--- a/job_spec/RTC_GAMMA.yml
+++ b/job_spec/RTC_GAMMA.yml
@@ -96,6 +96,8 @@ RTC_GAMMA:
       command:
         - ++process
         - rtc
+        - ++omp-num-threads
+        - '4'
         - --bucket
         - '!Ref Bucket'
         - --bucket-prefix

--- a/job_spec/WATER_MAP.yml
+++ b/job_spec/WATER_MAP.yml
@@ -99,6 +99,8 @@ WATER_MAP:
       command:
         - ++process
         - water_map
+        - ++omp-num-threads
+        - '4'
         - --bucket
         - '!Ref Bucket'
         - --bucket-prefix


### PR DESCRIPTION
Previously, running multiple GAMMA jobs on the same EC2 instance led to severe CPU contention. For example, RTC_GAMMA jobs typically finish in 15-20m when running a single job on an `r5d.xlarge` instance. Running four RTC_GAMMA jobs in parallel on an `r5d.4xlarge` instance would cause most jobs to not finish before their 90 minute timeout.

With this change, running four RTC_GAMMA jobs on a single `r5d.4xlarge` instance is marginally *faster* than running them on four separate `r5d.xlarge` instances. Similar results for INSAR_GAMMA jobs.

This is a significant change that will require monitoring in production for any unintended cost or performance changes.

I've added all memory-optimized instances that match the `r5d.xlarge` proportions of 4 vCPU and 150 GB disk per  32 GB memory to the DAAC deployments:
- `r6id.xlarge`
- `r6id.2xlarge`
- `r6id.4xlarge`
- `r6id.8xlarge`
- `r5dn.xlarge`
- `r5dn.2xlarge`
- `r5d.xlarge`
- `r5d.2xlarge`

Larger instance types in each family break their disk space into multiple SSDs. Docker can only leverage on of those drives, so these larger instance types don't have sufficient disk to support being fully loaded with 10x2 InSAR jobs.