### PR TITLE
Up the landsat memory to reduce number of OutOfMemory failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [2.24.1]
+### Changed
+- Increases the memory available to `AUTORIFT` jobs for Landsat pairs
+
 ## [2.24.0]
 ### Added
 - Made `resolution=10.0` parameter option for RTC_GAMMA and WATER_MAP jobs available in all deployments
@@ -17,7 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set `++omp-num-threads 4` for RTC_GAMMA, INSAR_GAMMA, WATER_MAP, and AUTORIFT jobs to drastically reduce CPU
   contention when running multiple jobs on the same EC2 instance.
 - Updated DAAC deployments to include larger EC2 instance types capable of running multiple jobs per instance.
-- Increases the memory available to `AUTORIFT` jobs for Landsat pairs 
 
 ## [2.22.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set `++omp-num-threads 4` for RTC_GAMMA, INSAR_GAMMA, WATER_MAP, and AUTORIFT jobs to drastically reduce CPU
   contention when running multiple jobs on the same EC2 instance.
 - Updated DAAC deployments to include larger EC2 instance types capable of running multiple jobs per instance.
+- Increases the memory available to `AUTORIFT` jobs for Landsat pairs 
 
 ## [2.22.0]
 ### Added

--- a/apps/step-function.json.j2
+++ b/apps/step-function.json.j2
@@ -123,7 +123,7 @@
         "ResourceRequirements": [
           {
             "Type": "MEMORY",
-            "Value": "10500"
+            "Value": "15750"
           }
         ]
       },


### PR DESCRIPTION
Here is a random sample of 200 test pairs that previously failed with OutOfMemory:
[L_memory_failure_sample.csv](https://github.com/ASFHyP3/hyp3/files/10340449/L_memory_failure_sample.csv)
