### PR TITLE
set --omp-num-threads=4 for daac autorift jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.23.0]
 ### Changed
-- Set `++omp-num-threads 4` for RTC_GAMMA, INSAR_GAMMA, and WATER_MAP jobs to drastically reduce CPU contention when
-  running multiple jobs on the same EC2 instance.
+- Set `++omp-num-threads 4` for RTC_GAMMA, INSAR_GAMMA, WATER_MAP, and AUTORIFT jobs to drastically reduce CPU
+  contention when running multiple jobs on the same EC2 instance.
 - Updated DAAC deployments to include larger EC2 instance types capable of running multiple jobs per instance.
 
 ## [2.22.0]

--- a/job_spec/AUTORIFT.yml
+++ b/job_spec/AUTORIFT.yml
@@ -47,7 +47,7 @@ AUTORIFT:
         - --naming-scheme
         - ITS_LIVE_OD
         - --omp-num-threads
-        - "4"
+        - '4'
         - Ref::granules
       timeout: 10800
       vcpu: 1

--- a/job_spec/AUTORIFT.yml
+++ b/job_spec/AUTORIFT.yml
@@ -46,6 +46,8 @@ AUTORIFT:
         - '/vsicurl/http://its-live-data.s3.amazonaws.com/autorift_parameters/v001/autorift_landice_0120m.shp'
         - --naming-scheme
         - ITS_LIVE_OD
+        - --omp-num-threads
+        - "4"
         - Ref::granules
       timeout: 10800
       vcpu: 1


### PR DESCRIPTION
to be merged after https://github.com/ASFHyP3/hyp3-autorift/pull/199

This leaves the thread limit unset for the ITS_LIVE deployment.