### PR TITLE
string comparison for resolution in step function

### DIFF
--- a/apps/step-function.json.j2
+++ b/apps/step-function.json.j2
@@ -87,7 +87,7 @@
             },
             {
               "Variable": "$.job_parameters.resolution",
-              "NumericEquals": 10
+              "StringEquals": "10"
             }
           ],
           "Next": "USE_10M_MEMORY"


### PR DESCRIPTION
All of the job parameters are cast to strings by `start-execution`, so the step function payload looks like:
```
  "job_parameters": {
    "dem_matching": "False",
    "dem_name": "copernicus",
    "granules": "S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8",
    "include_dem": "False",
    "include_inc_map": "False",
    "include_rgb": "False",
    "include_scattering_area": "False",
    "radiometry": "gamma0",
    "resolution": "10",
    "scale": "power",
    "speckle_filter": "False"
  },
```

I've confirmed it ends up as `"resolution": "10"` regardless of whether the user specified `"resolution": 10` or `"resolution": 10.0` in the API request.