### PR TITLE
restrict INSAR_ISCE granules to VV and VV+VH polarizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated hyp3-enterprise-test, hyp3-watermap, hyp3-streamflow, and hyp3-cargill deployments to include larger EC2
   instance types capable of running multiple jobs per instance.
+- `INSAR_ISCE` and `INSAR_ISCE_TEST` jobs will now only accept SLC scenes with a polarization of VV or VV+VH.
 
 ## [2.23.0]
 ### Changed

--- a/job_spec/INSAR_ISCE.yml
+++ b/job_spec/INSAR_ISCE.yml
@@ -11,7 +11,7 @@ INSAR_ISCE:
         items:
           description: The name of the Sentinel-1 SLC granules to use as reference scenes for InSAR processing
           type: string
-          pattern: "^S1[AB]_IW_SLC__1S[SD][VH]"
+          pattern: "^S1[AB]_IW_SLC__1S[SD]V"
           minLength: 67
           maxLength: 67
           example: S1B_IW_SLC__1SDV_20210723T014947_20210723T015014_027915_0354B4_B3A9
@@ -23,7 +23,7 @@ INSAR_ISCE:
         items:
           description: The name of the Sentinel-1 SLC granules to use as secondary scenes for InSAR processing
           type: string
-          pattern: "^S1[AB]_IW_SLC__1S[SD][VH]"
+          pattern: "^S1[AB]_IW_SLC__1S[SD]V"
           minLength: 67
           maxLength: 67
           example: S1B_IW_SLC__1SDV_20210711T014947_20210711T015013_027740_034F80_D404

--- a/job_spec/INSAR_ISCE_TEST.yml
+++ b/job_spec/INSAR_ISCE_TEST.yml
@@ -11,7 +11,7 @@ INSAR_ISCE_TEST:
         items:
           description: The name of the Sentinel-1 SLC granules to use as reference scenes for InSAR processing
           type: string
-          pattern: "^S1[AB]_IW_SLC__1S[SD][VH]"
+          pattern: "^S1[AB]_IW_SLC__1S[SD]V"
           minLength: 67
           maxLength: 67
           example: S1B_IW_SLC__1SDV_20210723T014947_20210723T015014_027915_0354B4_B3A9
@@ -23,7 +23,7 @@ INSAR_ISCE_TEST:
         items:
           description: The name of the Sentinel-1 SLC granules to use as secondary scenes for InSAR processing
           type: string
-          pattern: "^S1[AB]_IW_SLC__1S[SD][VH]"
+          pattern: "^S1[AB]_IW_SLC__1S[SD]V"
           minLength: 67
           maxLength: 67
           example: S1B_IW_SLC__1SDV_20210711T014947_20210711T015013_027740_034F80_D404


### PR DESCRIPTION
As requested by @cmarshak, `INSAR_ISCE` and `INSAR_ISCE_TEST` jobs will now only accept SLC scenes with a polarization of VV or VV+VH. Attempting to submit jobs for scenes with HH or HH+HV polarization will now generate an error:

```
>>> job = {
...     'job_type': 'INSAR_ISCE',
...     'job_parameters': {
...         'granules': ['S1A_IW_SLC__1SDH_20230109T204748_20230109T204815_046712_05997B_E704'],
...         'secondary_granules': ['S1A_IW_SLC__1SDH_20221228T204749_20221228T204816_046537_05939A_079F'],
...     }
... }
>>> hyp3.submit_prepared_jobs(job)
Traceback (most recent call last):
  File "/home/asjohnston/mambaforge/lib/python3.10/site-packages/hyp3_sdk/exceptions.py", line 29, in _raise_for_hyp3_status
    response.raise_for_status()
  File "/home/asjohnston/mambaforge/lib/python3.10/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: https://hyp3-api.asf.alaska.edu/jobs

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/asjohnston/mambaforge/lib/python3.10/site-packages/hyp3_sdk/hyp3.py", line 187, in submit_prepared_jobs
    _raise_for_hyp3_status(response)
  File "/home/asjohnston/mambaforge/lib/python3.10/site-packages/hyp3_sdk/exceptions.py", line 32, in _raise_for_hyp3_status
    raise HyP3Error(f'{response} {response.json()["detail"]}')
hyp3_sdk.exceptions.HyP3Error: <Response [400]> Value {'jobs': [{'job_type': 'INSAR_ISCE', 'job_parameters': {'granules': ['S1A_IW_SLC__1SDH_20230109T204748_20230109T204815_046712_05997B_E704'], 'secondary_granules': ['S1A_IW_SLC__1SDH_20221228T204749_20221228T204816_046537_05939A_079F']}}]} not valid for schema of type object: (<ValidationError: "{'job_type': 'INSAR_ISCE', 'job_parameters': {'granules': ['S1A_IW_SLC__1SDH_20230109T204748_20230109T204815_046712_05997B_E704'], 'secondary_granules': ['S1A_IW_SLC__1SDH_20221228T204749_20221228T204816_046537_05939A_079F']}} is not valid under any of the given schemas">,)
```