### PR TITLE
Release v2.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `INSAR_ISCE` and `INSAR_ISCE_TEST` jobs now accept a `weather_model` parameter to specify which weather model to use 
    when estimating trophospheric delay data.
+- Increases the memory available to `AUTORIFT` jobs for Landsat pairs
 
 ## [2.24.0]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.24.1]
+## [2.25.0]
 ### Added
 - `INSAR_ISCE` and `INSAR_ISCE_TEST` jobs now accept a `weather_model` parameter to specify which weather model to use 
    when estimating trophospheric delay data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.24.1]
+### Added
+- `INSAR_ISCE` and `INSAR_ISCE_TEST` jobs now accept a `weather_model` parameter to specify which weather model to use 
+   when estimating trophospheric delay data.
+
 ## [2.24.0]
 ### Added
 - Made `resolution=10.0` parameter option for RTC_GAMMA and WATER_MAP jobs available in all deployments

--- a/apps/step-function.json.j2
+++ b/apps/step-function.json.j2
@@ -123,7 +123,7 @@
         "ResourceRequirements": [
           {
             "Type": "MEMORY",
-            "Value": "10500"
+            "Value": "15750"
           }
         ]
       },

--- a/job_spec/INSAR_ISCE.yml
+++ b/job_spec/INSAR_ISCE.yml
@@ -27,6 +27,16 @@ INSAR_ISCE:
           minLength: 67
           maxLength: 67
           example: S1B_IW_SLC__1SDV_20210711T014947_20210711T015013_027740_034F80_D404
+    weather_model:
+      api_schema:
+        description: Weather model used to generate tropospheric delay estimations
+        default: None
+        type: string
+        enum:
+          - None
+          - HRRR
+          - HRES
+          - GMAO
     bucket_prefix:
       default:  '""'
   validators: []
@@ -42,6 +52,20 @@ INSAR_ISCE:
         - Ref::granules
         - --secondary-scenes
         - Ref::secondary_granules
+      timeout: 10800
+      vcpu: 1
+      memory: 7500
+    - name: TROPOSPHERE
+      image: ghcr.io/dbekaert/raider
+      command:
+        - ++process
+        - calcDelaysGunw
+        - --bucket
+        - '!Ref Bucket'
+        - --bucket-prefix
+        - Ref::bucket_prefix
+        - --weather-model
+        - Ref::weather_model
       timeout: 10800
       vcpu: 1
       memory: 7500

--- a/job_spec/INSAR_ISCE.yml
+++ b/job_spec/INSAR_ISCE.yml
@@ -59,7 +59,7 @@ INSAR_ISCE:
       image: ghcr.io/dbekaert/raider
       command:
         - ++process
-        - calcDelaysGunw
+        - calcDelaysGUNW
         - --bucket
         - '!Ref Bucket'
         - --bucket-prefix

--- a/job_spec/INSAR_ISCE_TEST.yml
+++ b/job_spec/INSAR_ISCE_TEST.yml
@@ -27,6 +27,16 @@ INSAR_ISCE_TEST:
           minLength: 67
           maxLength: 67
           example: S1B_IW_SLC__1SDV_20210711T014947_20210711T015013_027740_034F80_D404
+    weather_model:
+      api_schema:
+        description: Weather model used to generate tropospheric delay estimations
+        default: None
+        type: string
+        enum:
+          - None
+          - HRRR
+          - HRES
+          - GMAO
     bucket_prefix:
       default:  '""'
   validators: []
@@ -43,6 +53,21 @@ INSAR_ISCE_TEST:
         - Ref::granules
         - --secondary-scenes
         - Ref::secondary_granules
+      timeout: 10800
+      vcpu: 1
+      memory: 7500
+    - name: TROPOSPHERE
+      image: ghcr.io/dbekaert/raider
+      image_tag: test
+      command:
+        - ++process
+        - calcDelaysGunw
+        - --bucket
+        - '!Ref Bucket'
+        - --bucket-prefix
+        - Ref::bucket_prefix
+        - --weather-model
+        - Ref::weather_model
       timeout: 10800
       vcpu: 1
       memory: 7500

--- a/job_spec/INSAR_ISCE_TEST.yml
+++ b/job_spec/INSAR_ISCE_TEST.yml
@@ -61,7 +61,7 @@ INSAR_ISCE_TEST:
       image_tag: test
       command:
         - ++process
-        - calcDelaysGunw
+        - calcDelaysGUNW
         - --bucket
         - '!Ref Bucket'
         - --bucket-prefix

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -6,16 +6,16 @@
 -r requirements-apps-start-execution-manager.txt
 -r requirements-apps-start-execution-worker.txt
 -r requirements-apps-update-db.txt
-boto3==1.26.49
+boto3==1.26.51
 jinja2==3.1.2
 moto[dynamodb]==4.1.0
-pytest==7.2.0
+pytest==7.2.1
 PyYAML==6.0
 responses==0.22.0
 flake8==6.0.0
 flake8-import-order==0.18.2
 flake8-blind-except==0.2.1
 flake8-builtins==2.1.0
-setuptools==65.7.0
+setuptools==66.0.0
 openapi-spec-validator==0.4.0
-cfn-lint==0.72.8
+cfn-lint==0.72.9

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -16,6 +16,6 @@ flake8==6.0.0
 flake8-import-order==0.18.2
 flake8-blind-except==0.2.1
 flake8-builtins==2.1.0
-setuptools==65.6.3
+setuptools==65.7.0
 openapi-spec-validator==0.4.0
 cfn-lint==0.72.7

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -18,4 +18,4 @@ flake8-blind-except==0.2.1
 flake8-builtins==2.1.0
 setuptools==65.7.0
 openapi-spec-validator==0.4.0
-cfn-lint==0.72.7
+cfn-lint==0.72.8

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -16,6 +16,6 @@ flake8==6.0.0
 flake8-import-order==0.18.2
 flake8-blind-except==0.2.1
 flake8-builtins==2.1.0
-setuptools==66.0.0
+setuptools==66.1.0
 openapi-spec-validator==0.4.0
 cfn-lint==0.72.9

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -6,7 +6,7 @@
 -r requirements-apps-start-execution-manager.txt
 -r requirements-apps-start-execution-worker.txt
 -r requirements-apps-update-db.txt
-boto3==1.26.46
+boto3==1.26.47
 jinja2==3.1.2
 moto[dynamodb]==4.1.0
 pytest==7.2.0

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -6,7 +6,7 @@
 -r requirements-apps-start-execution-manager.txt
 -r requirements-apps-start-execution-worker.txt
 -r requirements-apps-update-db.txt
-boto3==1.26.51
+boto3==1.26.53
 jinja2==3.1.2
 moto[dynamodb]==4.1.0
 pytest==7.2.1

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -6,7 +6,7 @@
 -r requirements-apps-start-execution-manager.txt
 -r requirements-apps-start-execution-worker.txt
 -r requirements-apps-update-db.txt
-boto3==1.26.47
+boto3==1.26.49
 jinja2==3.1.2
 moto[dynamodb]==4.1.0
 pytest==7.2.0

--- a/requirements-apps-api.txt
+++ b/requirements-apps-api.txt
@@ -3,7 +3,7 @@ Flask-Cors==3.0.10
 openapi-core==0.14.5
 prance==0.22.11.4.0
 PyJWT==2.6.0
-requests==2.28.1
+requests==2.28.2
 serverless_wsgi==3.0.1
 shapely==2.0.0
 strict-rfc3339==0.7

--- a/requirements-apps-start-execution-manager.txt
+++ b/requirements-apps-start-execution-manager.txt
@@ -1,3 +1,3 @@
-boto3==1.26.51
+boto3==1.26.53
 ./lib/dynamo/
 ./lib/lambda_logging/

--- a/requirements-apps-start-execution-manager.txt
+++ b/requirements-apps-start-execution-manager.txt
@@ -1,3 +1,3 @@
-boto3==1.26.49
+boto3==1.26.51
 ./lib/dynamo/
 ./lib/lambda_logging/

--- a/requirements-apps-start-execution-manager.txt
+++ b/requirements-apps-start-execution-manager.txt
@@ -1,3 +1,3 @@
-boto3==1.26.47
+boto3==1.26.49
 ./lib/dynamo/
 ./lib/lambda_logging/

--- a/requirements-apps-start-execution-manager.txt
+++ b/requirements-apps-start-execution-manager.txt
@@ -1,3 +1,3 @@
-boto3==1.26.46
+boto3==1.26.47
 ./lib/dynamo/
 ./lib/lambda_logging/

--- a/requirements-apps-start-execution-worker.txt
+++ b/requirements-apps-start-execution-worker.txt
@@ -1,2 +1,2 @@
-boto3==1.26.49
+boto3==1.26.51
 ./lib/lambda_logging/

--- a/requirements-apps-start-execution-worker.txt
+++ b/requirements-apps-start-execution-worker.txt
@@ -1,2 +1,2 @@
-boto3==1.26.47
+boto3==1.26.49
 ./lib/lambda_logging/

--- a/requirements-apps-start-execution-worker.txt
+++ b/requirements-apps-start-execution-worker.txt
@@ -1,2 +1,2 @@
-boto3==1.26.46
+boto3==1.26.47
 ./lib/lambda_logging/

--- a/requirements-apps-start-execution-worker.txt
+++ b/requirements-apps-start-execution-worker.txt
@@ -1,2 +1,2 @@
-boto3==1.26.51
+boto3==1.26.53
 ./lib/lambda_logging/


### PR DESCRIPTION
This release includes changes to INSAR_ISCE jobs to accept a [weather_model parameter to specify which weather model to use when estimating tropospheric delay data](https://github.com/ASFHyP3/hyp3/issues/1416). This release also increases the memory available to AUTORIFT jobs for Landsat pairs