### PR TITLE
Increase flood map, water map, and river width timeouts

### DIFF
--- a/job_spec/RIVER_WIDTH.yml
+++ b/job_spec/RIVER_WIDTH.yml
@@ -71,7 +71,7 @@ RIVER_WIDTH:
         - '!Ref Bucket'
         - --bucket-prefix
         - Ref::bucket_prefix
-      timeout: 10800
+      timeout: 36000
       vcpu: 1
       memory: 126000
     - name: ''
@@ -81,6 +81,6 @@ RIVER_WIDTH:
         - '!Ref Bucket'
         - --bucket-prefix
         - Ref::bucket_prefix
-      timeout: 10800
+      timeout: 36000
       vcpu: 1
       memory: 31600

--- a/job_spec/WATER_MAP.yml
+++ b/job_spec/WATER_MAP.yml
@@ -172,6 +172,6 @@ WATER_MAP:
         - Ref::iterative_min
         - --iterative-max
         - Ref::iterative_max
-      timeout: 50400
+      timeout: 86400
       vcpu: 1
       memory: 126000

--- a/job_spec/WATER_MAP.yml
+++ b/job_spec/WATER_MAP.yml
@@ -172,6 +172,6 @@ WATER_MAP:
         - Ref::iterative_min
         - --iterative-max
         - Ref::iterative_max
-      timeout: 25200
+      timeout: 50400
       vcpu: 1
       memory: 126000

--- a/job_spec/WATER_MAP.yml
+++ b/job_spec/WATER_MAP.yml
@@ -150,7 +150,7 @@ WATER_MAP:
         - Ref::hand_fraction
         - --membership-threshold
         - Ref::membership_threshold
-      timeout: 10800
+      timeout: 36000
       vcpu: 1
       memory: 126000
     - name: FLOOD_MAP


### PR DESCRIPTION
Job https://hyp3-enterprise-test.asf.alaska.edu/jobs/828bc939-7e5d-4df9-aebf-32d1f67283a8 (`WATER_MAP` job with `iterative` flood depth estimator) timed out on the `FLOOD_MAP` step, so we need to increase the timeout value. The [log](https://hyp3-enterprise-test-contentbucket-971tpd9cdoef.s3.us-west-2.amazonaws.com/828bc939-7e5d-4df9-aebf-32d1f67283a8/828bc939-7e5d-4df9-aebf-32d1f67283a8.log) shows `Detected 65920 water bodies` and that the job failed at `58545/65919` (89%). Below is the RGB image for granule `S1A_IW_GRDH_1SDV_20210413T235641_20210413T235706_037439_0469D0_3F2B`:

![S1A_IW_GRDH_1SDV_20210413T235641_20210413T235706_037439_0469D0_3F2B](https://user-images.githubusercontent.com/19476938/215572353-4d33bb1d-6f57-4d6e-806f-879eec96a282.jpg)

Assuming that the groups of blue pixels are a good indicator of the number of water bodies (happy to be corrected on that), I feel like there are other scenes that likely include many more water bodies, and would therefore take longer to process?

I have doubled the timeout value from 7 to 14 hours as a placeholder, but would like feedback on how to determine a better value.

TODO:

- [x] We set timeout values for the following steps in https://github.com/ASFHyP3/hyp3/pull/1426. Do we want to revisit those values as well? (Also see [this comment](https://github.com/ASFHyP3/hyp3/pull/1426#pullrequestreview-1262781295) regarding the timeout values.)
     * 3 hours for the `WATER_MAP` step in the `WATER_MAP` and `RIVER_WIDTH` job specs
     * 3 hours for the `RIVER_WIDTH` step in the `RIVER_WIDTH` job spec.