### PR TITLE
reduce product lifetime for hyp3-its-life to 45 days

### DIFF
--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -16,7 +16,7 @@ jobs:
             domain: hyp3-its-live.asf.alaska.edu
             template_bucket: cf-templates-3o5lnspmwmzg-us-west-2
             image_tag: latest
-            product_lifetime_in_days: 180
+            product_lifetime_in_days: 45
             quota: 0
             job_files: job_spec/AUTORIFT_ITS_LIVE.yml job_spec/AUTORIFT_ITS_LIVE_TEST.yml
             instance_types: r6id.xlarge,r5dn.xlarge,r5d.xlarge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1]
+### Changed
+- Reduced `ITS_LIVE` product lifetime cycle from 180 days to 45 days. 
+
 ## [3.0.0]
 ### Changed
 - `WATER_MAP` and `RIVER_WIDTH` jobs are now run as a series of multiple tasks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.0.1]
-### Changed
-- Reduced `ITS_LIVE` product lifetime cycle from 180 days to 45 days. 
-
 ## [3.0.0]
 ### Changed
 - `WATER_MAP` and `RIVER_WIDTH` jobs are now run as a series of multiple tasks.
 - The `flood_depth_estimator` parameter for `WATER_MAP` jobs is now restricted to a set of possible values.
 - Changed the default value for the `flood_depth_estimator` parameter for `WATER_MAP` jobs from `iterative` to `None`.
   A value of `None` indicates that a flood map will not be included.
+- Reduced `ITS_LIVE` product lifetime cycle from 180 days to 45 days. 
 ### Removed
 - Removed the `include_flood_depth` parameter for `WATER_MAP` jobs.
 


### PR DESCRIPTION
Tighten up the product cycle lifetime from 180 days to 45 days for the its_live enterprise deployment https://asfdaac.atlassian.net/browse/TOOL-1327?atlOrigin=eyJpIjoiYmRlY2VkZjkyMTE4NDVhMmFjNDA0ZjAxNTI3MzljMTEiLCJwIjoiaiJ9