### PR TITLE
Update INSAR_ISCE_TEST job to provide an option for Solid Earth Tides correction

### DIFF
--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -44,7 +44,7 @@ jobs:
               job_spec/AUTORIFT.yml
               job_spec/INSAR_GAMMA.yml
               job_spec/RTC_GAMMA.yml
-              job_spec/INSAR_ISCE.yml
+              job_spec/INSAR_ISCE_TEST.yml
               job_spec/WATER_MAP.yml
             instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r5dn.xlarge,r5dn.2xlarge,r5d.xlarge,r5d.2xlarge
             default_max_vcpus: 1500

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.2]
+### Added
+- `INSAR_ISCE_TEST` jobs now accept an `compute_solid_earth_tide` option to solid earth tide ionosphere correction.
+
 ## [3.1.1]
 ### Fixed
 - `INSAR_ISCE` and `INSAR_ISCE_TEST` jobs no longer accept the unsupported `NCMR` weather model; [see RAiDER#485](https://github.com/dbekaert/RAiDER/issues/485).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.1.2]
 ### Added
-- `INSAR_ISCE_TEST` jobs now accept an `compute_solid_earth_tide` option to solid earth tide ionosphere correction.
+- `INSAR_ISCE_TEST` jobs now accept an `compute_solid_earth_tide` option to compute the solid earth tide ionosphere correction layer.
 
 ## [3.1.1]
 ### Fixed

--- a/job_spec/INSAR_ISCE_TEST.yml
+++ b/job_spec/INSAR_ISCE_TEST.yml
@@ -47,7 +47,7 @@ INSAR_ISCE_TEST:
     compute_solid_earth_tide:
       api_schema:
         default: false
-        type: bool
+        type: boolean
         description: "Whether to compute and add solid earth tide correction to the ARIA-S1-GUNW as an additional layer"
     weather_model:
       api_schema:

--- a/job_spec/INSAR_ISCE_TEST.yml
+++ b/job_spec/INSAR_ISCE_TEST.yml
@@ -48,7 +48,7 @@ INSAR_ISCE_TEST:
       api_schema:
         default: false
         type: boolean
-        description: "Whether to compute and add solid earth tide correction to the ARIA-S1-GUNW as an additional layer"
+        description: "Whether to compute a solid earth tide correction layer for ARIA-S1-GUNW products"
     weather_model:
       api_schema:
         description: Weather model used to generate tropospheric delay estimations

--- a/job_spec/INSAR_ISCE_TEST.yml
+++ b/job_spec/INSAR_ISCE_TEST.yml
@@ -44,6 +44,11 @@ INSAR_ISCE_TEST:
         description: Subset GUNW products to this frame. The default is `-1` with no subsetting of the products.
         default: -1
         type: integer
+    compute_solid_earth_tide:
+      api_schema:
+        default: false
+        type: bool
+        description: "Whether to compute and add solid earth tide correction to the ARIA-S1-GUNW as an additional layer"
     weather_model:
       api_schema:
         description: Weather model used to generate tropospheric delay estimations
@@ -78,6 +83,8 @@ INSAR_ISCE_TEST:
         - Ref::estimate_ionosphere_delay
         - --frame-id
         - Ref::frame_id
+        - --compute-solid-earth-tide
+        - Ref::compute_solid_earth_tide
       timeout: 21600
       vcpu: 1
       memory: 7500


### PR DESCRIPTION
Adding support for Solid Earth tides using PR #1440 as a reference.

Fixes #1447