### PR TITLE
Increase RIVER_WIDTH_RTC memory

### DIFF
--- a/job_spec/RIVER_WIDTH.yml
+++ b/job_spec/RIVER_WIDTH.yml
@@ -61,7 +61,7 @@ RIVER_WIDTH:
         - Ref::granules
       timeout: 36000
       vcpu: 1
-      memory: 31600
+      memory: 63200
     - name: WATER_MAP
       image: ghcr.io/asfhyp3/asf-tools
       command:


### PR DESCRIPTION
See https://github.com/ASFHyP3/hyp3/issues/1456

`RIVER_WIDTH_RTC` jobs run at 10m resolution, so need twice the memory.