### PR TITLE
Add in frame-id job spec parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1]
+### Added
+- `INSAR_ISCE` and `INSAR_ISCE_TEST` jobs now accept a `frame_id` parameter to apply ESD corrections in `INSAR_ISCE` 
+jobs.
+
 ## [3.0.0]
 ### Added
 - Added `hyp3-bgc-engineering` deployment.

--- a/job_spec/INSAR_ISCE.yml
+++ b/job_spec/INSAR_ISCE.yml
@@ -27,6 +27,11 @@ INSAR_ISCE:
           minLength: 67
           maxLength: 67
           example: S1B_IW_SLC__1SDV_20210711T014947_20210711T015013_027740_034F80_D404
+    frame_id:
+      api_schema:
+        description: Integer to enable ESD corections. The default is "-1" and no corrections will not be applied.
+        default: -1
+        type: integer
     weather_model:
       api_schema:
         description: Weather model used to generate tropospheric delay estimations
@@ -52,6 +57,8 @@ INSAR_ISCE:
         - Ref::granules
         - --secondary-scenes
         - Ref::secondary_granules
+        - --frame-id
+        - Ref::frame_id
       timeout: 10800
       vcpu: 1
       memory: 7500

--- a/job_spec/INSAR_ISCE_TEST.yml
+++ b/job_spec/INSAR_ISCE_TEST.yml
@@ -27,6 +27,11 @@ INSAR_ISCE_TEST:
           minLength: 67
           maxLength: 67
           example: S1B_IW_SLC__1SDV_20210711T014947_20210711T015013_027740_034F80_D404
+    frame_id:
+      api_schema:
+        description: Integer to enable ESD corections. The default is "-1" and no corrections will not be applied.
+        default: -1
+        type: integer
     weather_model:
       api_schema:
         description: Weather model used to generate tropospheric delay estimations
@@ -53,6 +58,8 @@ INSAR_ISCE_TEST:
         - Ref::granules
         - --secondary-scenes
         - Ref::secondary_granules
+        - --frame-id
+        - Ref::frame_id
       timeout: 10800
       vcpu: 1
       memory: 7500


### PR DESCRIPTION
Addresses [Issue #1452](https://github.com/ASFHyP3/hyp3/issues/1452) to specify a frame id for INSAR_ISCE jobs. 
[DockerizedTopsApp](https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsApp) has exposed an option to specify a frame id when creating the GUNW product.
Enabling/disabling ESD corrections is done via the --frame-id parameter, which takes positive integer values or -1 to do nothing (default tp -1), to the DockerizedTopsApp container HyP3 entry point. See https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsApp/pull/88

A discussion on the framing is here: https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsApp#using-fixed-frames-experimental

This feature request is to:

add a new frame_id parameter to the INSAR_ISCE and INSAR_ISCE_TEST jobs which accepts positive integer values or -1 to do nothing