### PR TITLE
add secrets to missed autorift job

### DIFF
--- a/job_spec/AUTORIFT.yml
+++ b/job_spec/AUTORIFT.yml
@@ -52,3 +52,6 @@ AUTORIFT:
       timeout: 10800
       vcpu: 1
       memory: 31600
+      secrets:
+        - EARTHDATA_USERNAME
+        - EARTHDATA_PASSWORD


### PR DESCRIPTION
I missed this one in #1510 

Failure example: https://hyp3-enterprise-test.asf.alaska.edu/jobs/1f29f6fe-f92f-4505-a2cb-4a47fa59300b