### PR TITLE
Fix sandbox replace-hkh API throwing 500s

### DIFF
--- a/job_spec/WATER_MAP.yml
+++ b/job_spec/WATER_MAP.yml
@@ -40,8 +40,6 @@ WATER_MAP:
         description: WM vsicurl
         type: string
 
-  validators:
-    - check_dem_coverage
   tasks:
     - name: FLOOD_MAP
       image: ghcr.io/asfhyp3/asf-tools


### PR DESCRIPTION
The replace-hkh API is throwing 500s because it's trying to validate DEM coverage for granues, but doesn't have a granule input. 
```
Traceback (most recent call last):
  File "/var/task/flask/app.py", line 2528, in wsgi_app
    response = self.full_dispatch_request()
  File "/var/task/flask/app.py", line 1825, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/var/task/flask_cors/extension.py", line 165, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
  File "/var/task/flask/app.py", line 1823, in full_dispatch_request
    rv = self.dispatch_request()
  File "/var/task/flask/app.py", line 1799, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)
  File "/var/task/flask/views.py", line 107, in view
    return current_app.ensure_sync(self.dispatch_request)(**kwargs)
  File "/var/task/openapi_core/contrib/flask/views.py", line 26, in dispatch_request
    return decorator(super(FlaskOpenAPIView, self).dispatch_request)(
  File "/var/task/openapi_core/validation/decorators.py", line 33, in decorated
    response = self._handle_request_view(
  File "/var/task/openapi_core/contrib/flask/decorators.py", line 31, in _handle_request_view
    return super(FlaskOpenAPIViewDecorator, self)._handle_request_view(
  File "/var/task/openapi_core/validation/decorators.py", line 47, in _handle_request_view
    return view(*args, **kwargs)
  File "/var/task/flask/views.py", line 188, in dispatch_request
    return current_app.ensure_sync(meth)(**kwargs)
  File "/var/task/hyp3_api/routes.py", line 137, in post
    return jsonify(handlers.post_jobs(request.get_json(), g.user))
  File "/var/task/hyp3_api/handlers.py", line 38, in post_jobs
    validate_jobs(body['jobs'])
  File "/var/task/hyp3_api/validation.py", line 102, in validate_jobs
    granules = get_granules(jobs)
  File "/var/task/hyp3_api/util.py", line 14, in get_granules
    for granule in job['job_parameters']['granules']:
KeyError: 'granules'
```
The remove the validator.