### PR TITLE
Switch to using granules for water map raster link field

### DIFF
--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -66,7 +66,7 @@ def get_cmr_metadata(granules):
 
 
 def is_third_party_granule(granule):
-    return granule.startswith('S2') or granule.startswith('L')
+    return granule.startswith('S2') or granule.startswith('L') or granule.startswith('/vsicurl')
 
 
 def check_granules_exist(granules, granule_metadata):

--- a/job_spec/WATER_MAP.yml
+++ b/job_spec/WATER_MAP.yml
@@ -1,7 +1,19 @@
 WATER_MAP:
   required_parameters:
-    - wm_raster
+    - granules
   parameters:
+    granules:
+      default: '""'
+      api_schema:
+        type: array
+        minItems: 1
+        maxItems: 1
+        items:
+          anyOf:
+            - description: /vsicurl link to a water map raster
+              type: string
+              pattern: "^\/vsicurl\/https:\/\/.*_WM\.tif"
+              example: /vsicurl/https://hyp3-nasa-disasters.s3-us-west-2.amazonaws.com/hkh/S1A_IW_20230316T113240_DVR_RTC30_G_gpufed_DCE6_WM.tif
     bucket_prefix:
       default:  '""'
     flood_depth_estimator:
@@ -35,10 +47,7 @@ WATER_MAP:
         description: Maximum bound used for iterative method. Ignored when flood_depth_estimator is None.
         default: 15
         type: integer
-    wm_raster:
-      api_schema:
-        description: WM vsicurl
-        type: string
+
   validators: []
   tasks:
     - name: FLOOD_MAP
@@ -61,7 +70,7 @@ WATER_MAP:
         - --iterative-max
         - Ref::iterative_max
         - --wm-raster
-        - Ref::wm_raster
+        - Ref::granules
       timeout: 86400
       vcpu: 1
       memory: 126000


### PR DESCRIPTION
HyP3 seems to have implicit "granules" is an existing key assumption built in, so we'll want to pass the water map vsicurl raster link in through the granules field and register it as a third part granule.