### PR TITLE
Release v3.3.0

### DIFF
--- a/.github/workflows/deploy-enterprise-test.yml
+++ b/.github/workflows/deploy-enterprise-test.yml
@@ -23,7 +23,7 @@ jobs:
             deploy_ref: refs/heads/develop
             job_files: >-
               job_spec/AUTORIFT.yml
-              job_spec/INSAR_GAMMA.yml
+              job_spec/INSAR_GAMMA_TEST.yml
               job_spec/RTC_GAMMA.yml
               job_spec/INSAR_ISCE_TEST.yml
               job_spec/WATER_MAP.yml

--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -80,7 +80,7 @@ jobs:
             image_tag: latest
             product_lifetime_in_days: 365000
             quota: 0
-            job_files: job_spec/INSAR_GAMMA.yml
+            job_files: job_spec/INSAR_GAMMA.yml job_spec/INSAR_GAMMA_TEST.yml
             instance_types: r6id.xlarge,r5dn.xlarge,r5d.xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640

--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -164,6 +164,21 @@ jobs:
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
             distribution_url: ''
 
+          - environment: hyp3-carter
+            domain: hyp3-carter.asf.alaska.edu
+            template_bucket: cf-templates-1qx2mwia5g4kh-us-west-2
+            image_tag: latest
+            product_lifetime_in_days: 30
+            quota: 0
+            job_files: job_spec/INSAR_GAMMA.yml job_spec/RTC_GAMMA.yml
+            instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r5dn.xlarge,r5dn.2xlarge,r5d.xlarge,r5d.2xlarge
+            default_max_vcpus: 640
+            expanded_max_vcpus: 640
+            required_surplus: 0
+            security_environment: ASF
+            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2/recommended/image_id
+            distribution_url: ''
+
     environment:
       name: ${{ matrix.environment }}
       url: https://${{ matrix.domain }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0]
+### Added
+- An [`INSAR_GAMMA_TEST.yml`](job_spec/INSAR_GAMMA_TEST.yml) job spec  has been added, exposing the adaptive phase filter parameter used when processing InSAR products.
+- `INSAR_GAMMA_TEST.yml` job spec has been added to the HyP3 Enterprise Test and HyP3 AVO deployments.
+
 ## [3.2.1]
 ### Changed
 - Increased the `hyp3-streamflow` product lifecycle from 14 days to 90 days.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.3.0]
 ### Added
+- Added `hyp3-carter` deployment.
 - An [`INSAR_GAMMA_TEST.yml`](job_spec/INSAR_GAMMA_TEST.yml) job spec  has been added, exposing the adaptive phase filter parameter used when processing InSAR products.
 - `INSAR_GAMMA_TEST.yml` job spec has been added to the HyP3 Enterprise Test and HyP3 AVO deployments.
 

--- a/job_spec/INSAR_GAMMA_TEST.yml
+++ b/job_spec/INSAR_GAMMA_TEST.yml
@@ -1,0 +1,112 @@
+INSAR_GAMMA_TEST:
+  required_parameters:
+    - granules
+  parameters:
+    granules:
+      default:  '""'
+      api_schema:
+        type: array
+        minItems: 2
+        maxItems: 2
+        example:
+          - S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8
+          - S1A_IW_SLC__1SSV_20150504T120217_20150504T120229_005771_00769E_EF9A
+        items:
+          description: The name of the Sentinel-1 SLC granule to process
+          type: string
+          pattern: "^S1[AB]_IW_SLC__1S[SD][VH]"
+          minLength: 67
+          maxLength: 67
+          example: S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8
+    bucket_prefix:
+      default:  '""'
+    include_look_vectors:
+      api_schema:
+        description: Include the look vector theta and phi files in the product package
+        default: false
+        type: boolean
+    include_los_displacement:
+      api_schema:
+        description: Include a GeoTIFF in the product package containing displacement values along the Line-Of-Sight (LOS)
+        default: false
+        type: boolean
+    include_displacement_maps:
+      api_schema:
+        description: Include displacement maps (line-of-sight and vertical) in the product package
+        default: false
+        type: boolean
+    include_inc_map:
+      api_schema:
+        description: Include the incidence angle map(s) in the product package
+        default: false
+        type: boolean
+    include_dem:
+      api_schema:
+        description: Include the DEM file in the product package
+        default: false
+        type: boolean
+    include_wrapped_phase:
+      api_schema:
+        description: Include the wrapped phase GeoTIFF in the product package
+        default: false
+        type: boolean
+    apply_water_mask:
+      api_schema:
+        description: Sets pixels over coastal and large inland waterbodies as invalid for phase unwrapping.
+        default: false
+        type: boolean
+    looks:
+      api_schema:
+        description: Number of looks to take in range and azimuth
+        type: string
+        default: 20x4
+        enum:
+          - 20x4
+          - 10x2
+    phase_filter_parameter:
+      api_schema:
+        description: Adaptive phase filter parameter
+        type: number
+        minimum: 0.0
+        maximum: 1.0
+        default: 0.6
+  validators:
+    - check_dem_coverage
+  tasks:
+    - name: ''
+      image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma
+      image_tag: test
+      command:
+        - ++process
+        - insar
+        - ++omp-num-threads
+        - '4'
+        - --bucket
+        - '!Ref Bucket'
+        - --bucket-prefix
+        - Ref::bucket_prefix
+        - --include-look-vectors
+        - Ref::include_look_vectors
+        - --include-los-displacement
+        - Ref::include_los_displacement
+        - --include-displacement-maps
+        - Ref::include_displacement_maps
+        - --include-inc-map
+        - Ref::include_inc_map
+        - --include-dem
+        - Ref::include_dem
+        - --include-wrapped-phase
+        - Ref::include_wrapped_phase
+        - --apply-water-mask
+        - Ref::apply_water_mask
+        - --looks
+        - Ref::looks
+        - --phase-filter-parameter
+        - Ref::phase_filter_parameter
+        - Ref::granules
+      timeout: 10800
+      vcpu: 1
+      memory: 31600
+      secrets:
+        - EARTHDATA_USERNAME
+        - EARTHDATA_PASSWORD

--- a/job_spec/INSAR_GAMMA_TEST.yml
+++ b/job_spec/INSAR_GAMMA_TEST.yml
@@ -68,6 +68,7 @@ INSAR_GAMMA_TEST:
         description: Adaptive phase filter parameter
         type: number
         minimum: 0.0
+        exclusiveMinimum: true
         maximum: 1.0
         default: 0.6
   validators:


### PR DESCRIPTION
For INSAR_GAMMA_TEST, we were able to submit these fou jobs with different `phase_filter_paramter` values:

- ❌ 0.0: https://hyp3-enterprise-test.asf.alaska.edu/jobs/2ca0785c-5689-4b26-99b4-6421e99be0e1
- ✅ 0.2: https://hyp3-enterprise-test.asf.alaska.edu/jobs/d99efd2d-2162-4501-922c-65f90a51b29e
- ✅ 0.6: https://hyp3-enterprise-test.asf.alaska.edu/jobs/98874430-e549-42b5-821b-960b064fc1aa
- ✅ 1.0: https://hyp3-enterprise-test.asf.alaska.edu/jobs/e3d3227d-c8bf-4fc1-be21-ee5fcbabb44d

The 0.0 job failed because GAMMA has an exclusive minimum to the valid phase filter range (0.0, 1.0].

After patching the container and API for the exclusive minimum, I submitted this job:
- ✅ 0.4: https://hyp3-enterprise-test.asf.alaska.edu/jobs/ab67c293-eaca-4aff-9f74-6bc735e67174

---

TODOs:
 - [x] confirm API rejects `"phase_filter_parameter": 0.0` and other values outside of the valid range
 - [x] ASFHyP3/hyp3-gamma#449
