### PR TITLE
Set insar phase filter parameter minimum value to exclusive

### DIFF
--- a/job_spec/INSAR_GAMMA_TEST.yml
+++ b/job_spec/INSAR_GAMMA_TEST.yml
@@ -68,6 +68,7 @@ INSAR_GAMMA_TEST:
         description: Adaptive phase filter parameter
         type: number
         minimum: 0.0
+        exclusiveMinimum: true
         maximum: 1.0
         default: 0.6
   validators:


### PR DESCRIPTION
```
$ adf 20230227_20230311.diff0.man 20230227_20230311.diff0.man.adf 20230227_20230311.adf.cc 3392 0.0 - 5
*** Adaptive interferogram bandpass filter based on the power spectral density ***
...
ERROR: invalid value for filter exponent:    0.000
```

For the change, see: https://swagger.io/docs/specification/data-models/data-types/