### PR TITLE
Allow for nullable known_water_threshold

### DIFF
--- a/job_spec/WATER_MAP_TEST.yml
+++ b/job_spec/WATER_MAP_TEST.yml
@@ -81,9 +81,10 @@ WATER_MAP_TEST:
         type: number
     known_water_threshold:
       api_schema:
-        description: Threshold for extracting known water area in percent. A water threshold is computed when value is None. Ignored when flood_depth_estimator is None.
-        default: None
+        description: Threshold for extracting known water area in percent. A water threshold is computed when value is null. Ignored when flood_depth_estimator is None.
+        default: null
         type: number
+        nullable: true
     iterative_min:
       api_schema:
         description: Minimum bound used for iterative method. Ignored when flood_depth_estimator is None.


### PR DESCRIPTION
Since `None` is not a valid number, but `null` can be supported:
* https://github.com/OAI/OpenAPI-Specification/issues/603
* https://swagger.io/docs/specification/data-models/data-types/#null

Supported by ASFHyP3/asf-tools#196