### PR TITLE
Make the WATER_MAP and WATER_MAP_TEST `flood_depth_estimator` nullable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.7.0]
 ### Added
 - Added the `WATER_MAP_TEST` job spec to the `hyp3-watermap` deployment.
+### Changed
+- the `flood_depth_estimator` parameter in both the `WATER_MAP` and `WATER_MAP_TEST` job spec is now nullable.
 
 ## [3.6.1]
 ### Changed

--- a/job_spec/WATER_MAP.yml
+++ b/job_spec/WATER_MAP.yml
@@ -65,9 +65,10 @@ WATER_MAP:
         type: number
     flood_depth_estimator:
       api_schema:
-        description: Flood depth estimation approach. A value of None indicates that flood depth estimation will not be performed.
-        default: None
+        description: Flood depth estimation approach. A value of null or None indicates that flood depth estimation will not be performed.
+        default: null
         type: string
+        nullable: true
         enum:
           - iterative
           - logstat

--- a/job_spec/WATER_MAP_TEST.yml
+++ b/job_spec/WATER_MAP_TEST.yml
@@ -65,9 +65,10 @@ WATER_MAP_TEST:
         type: number
     flood_depth_estimator:
       api_schema:
-        description: Flood depth estimation approach. A value of None indicates that flood depth estimation will not be performed.
-        default: None
+        description: Flood depth estimation approach. A value of null or None indicates that flood depth estimation will not be performed.
+        default: null
         type: string
+        nullable: true
         enum:
           - iterative
           - logstat


### PR DESCRIPTION
As we learned in https://github.com/ASFHyP3/asf-tools/pull/197, HyP3 converts `null` parameter values to the string `None` when it starts the step function execution, so allowing this to be nullable *and* accepting the string None is effectively the same.

Nicely, on the SDK side, `null` JSON/DynamoDB values get represented as `None` type objects in Python and vice versa, so when we create a job definition, we can write it either as:
```python
    'flood_depth_estimator' = 'None',
```
or more naturally
```python
    'flood_depth_estimator' = None,
```