### PR TITLE
Make flood-depth-estimator nullable 

### DIFF
--- a/job_spec/WATER_MAP.yml
+++ b/job_spec/WATER_MAP.yml
@@ -73,6 +73,7 @@ WATER_MAP:
           - iterative
           - logstat
           - nmad
+          - null
           - numpy
           - None
     water_level_sigma:

--- a/job_spec/WATER_MAP_TEST.yml
+++ b/job_spec/WATER_MAP_TEST.yml
@@ -73,6 +73,7 @@ WATER_MAP_TEST:
           - iterative
           - logstat
           - nmad
+          - null
           - numpy
           - None
     water_level_sigma:


### PR DESCRIPTION
Started the ball rolling on how to make the `flood-depth-estimator` value functionally nullable in `WATER_MAP` and `WATER_MAP_TEST`. The current implementation will not accept `null` as valid and gets   `"status": 400,
  "title": "Bad Request"`. 
@jhkennedy I didn't know what your thoughts were, but I started by just [enumerating null](https://github.com/OAI/OpenAPI-Specification/issues/1900#issuecomment-578409376). Open to any and all other ideas! 