### PR TITLE
Remove INSAR_ISCE_BURST job type from hyp3-edc-uat deployment

### DIFF
--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -45,7 +45,6 @@ jobs:
               job_spec/INSAR_GAMMA.yml
               job_spec/RTC_GAMMA.yml
               job_spec/INSAR_ISCE_TEST.yml
-              job_spec/INSAR_ISCE_BURST.yml
               job_spec/WATER_MAP.yml
             instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r5dn.xlarge,r5dn.2xlarge,r5d.xlarge,r5d.2xlarge
             default_max_vcpus: 1500

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.8.0]
 ### Added
-- Added `INSAR_ISCE_BURST` job spec to the `hyp3-test` and `hyp3-enterprise-test` deployments.
+- Added `INSAR_ISCE_BURST` job spec to the `hyp3-enterprise-test` deployment.
 - Added the `S1_CORRECTION_ITS_LIVE` job spec to the `hyp3-enterprise-test` and `hyp3-its-live` deployments.
 
 ### Changed


### PR DESCRIPTION
Requests to sentinel1-burst.asf.alaska.edu are failing with an SSL error when run from our Earthdata Cloud environment:
`requests.exceptions.SSLError: HTTPSConnectionPool(host='sentinel1-burst.asf.alaska.edu', port=443): Max retries exceeded with url: /S1A_IW_SLC__1SDV_20230523T170718_20230523T170745_048664_05DA5B_8850/IW1/VV/5.xml (Caused by SSLError(CertificateError("hostname 'sentinel1-burst.asf.alaska.edu' doesn't match either of '*.execute-api.us-west-2.amazonaws.com', '*.execute-api.us-west-2.vpce.amazonaws.com'")))`

Jobs run in hyp3-enterprise-test do not encounter this error.