### PR TITLE
Revert "Bump requests from 2.29.0 to 2.31.0"

### DIFF
--- a/requirements-apps-api.txt
+++ b/requirements-apps-api.txt
@@ -3,7 +3,7 @@ Flask-Cors==3.0.10
 openapi-core==0.14.5
 prance==0.22.11.4.0
 PyJWT==2.7.0
-requests==2.31.0
+requests==2.29.0
 serverless_wsgi==3.0.2
 shapely==2.0.1
 strict-rfc3339==0.7


### PR DESCRIPTION
After this upgrading requests, the HyP3 API is returning HTTP 500 errors with this underlying python exception:
```
Runtime.ImportModuleError: Unable to import module 'hyp3_api.lambda_handler': cannot import name 'DEFAULT_CIPHERS' from 'urllib3.util.ssl_' (/var/task/urllib3/util/ssl_.py)
```

See https://github.com/psf/requests/issues/6438

Likely fixable, but a revert resolves the immediate issue.