### PR TITLE
Revert "Bump asf-search from 6.0.2 to 6.5.0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.2]
+### Fixed
+- Reverted `asf_search` to v6.0.2. Fixes [#1672](https://github.com/ASFHyP3/hyp3/issues/1672).
+
 ## [3.9.1]
 ### Fixed
 - Invalid `install_requires` clause in `dynamo/setup.py`. Fixes [#1666](https://github.com/ASFHyP3/hyp3/issues/1666).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.9.2]
 ### Fixed
-- Reverted `asf_search` to v6.0.2. Fixes [#1672](https://github.com/ASFHyP3/hyp3/issues/1672).
+- Reverted `asf_search` to v6.0.2. Fixes [#1673](https://github.com/ASFHyP3/hyp3/issues/1673).
 
 ## [3.9.1]
 ### Fixed

--- a/requirements-apps-subscription-worker.txt
+++ b/requirements-apps-subscription-worker.txt
@@ -1,3 +1,3 @@
-asf-search==6.5.0
+asf-search==6.0.2
 ./lib/dynamo/
 ./lib/lambda_logging/


### PR DESCRIPTION
Reverts ASFHyP3/hyp3#1665

The subscription worker lambda is failing after this upgrade due to an asf_search bug causing `raise_if_incomplete()` at https://github.com/ASFHyP3/hyp3/blob/develop/apps/subscription-worker/src/subscription_worker.py#L20 to raise an exception for successful queries, see https://github.com/asfadmin/Discovery-asf_search/issues/204

```
[ERROR]	2023-06-15T22:55:37.912Z	dd59a9e3-d0de-4d97-974c-f5d7ab0e3625	Unhandled exception
Traceback (most recent call last):
  File "/var/task/lambda_logging/__init__.py", line 18, in wrapper
    lambda_handler(event, context)
  File "/var/task/subscription_worker.py", line 84, in lambda_handler
    handle_subscription(subscription)
  File "/var/task/subscription_worker.py", line 70, in handle_subscription
    jobs = get_jobs_for_subscription(subscription, limit=20)
  File "/var/task/subscription_worker.py", line 57, in get_jobs_for_subscription
    granules = get_unprocessed_granules(subscription)
  File "/var/task/subscription_worker.py", line 20, in get_unprocessed_granules
    search_results.raise_if_incomplete()
  File "/var/task/asf_search/ASFSearchResults.py", line 78, in raise_if_incomplete
    raise ASFSearchError(msg)
asf_search.exceptions.ASFSearchError: Results are incomplete due to a search error. See logging for more details. (ASFSearchResults.raise_if_incomplete called)
```