### PR TITLE
remove obsolete PermissionBoundaryPolicyArn parameter for Earthdata Cloud deployments

### DIFF
--- a/.github/actions/deploy-hyp3/action.yml
+++ b/.github/actions/deploy-hyp3/action.yml
@@ -53,9 +53,6 @@ inputs:
   REQUIRED_SURPLUS:
     description: "Amount by which month-to-date budget must exceed month-to-date spending to increase fleet size, in dollars. Ignored when DefaultMaxvCpus = ExpandedMaxvCpus."
     required: true
-  PERMISSIONS_BOUNDARY_ARN:
-    description: "Arn of permissions boundary to provide to any created IAM roles"
-    required: true
   ORIGIN_ACCESS_IDENTITY_ID:
     description: "ID of the CloudFront Origin Access Identity used to access data in S3 for Earthdata Cloud deployments"
     required: true
@@ -93,9 +90,6 @@ runs:
           [ -z ${{ inputs.CERTIFICATE_ARN }} ] && export CERTIFICATE_ARN="" \
             || export CERTIFICATE_ARN="CertificateArn=${{ inputs.CERTIFICATE_ARN }}"
 
-          [ -z ${{ inputs.PERMISSIONS_BOUNDARY_ARN }} ] && export PERMISSIONS_BOUNDARY_ARN="" \
-            || export PERMISSIONS_BOUNDARY_ARN="PermissionsBoundaryPolicyArn=${{ inputs.PERMISSIONS_BOUNDARY_ARN }}"
-
           [ -z ${{ inputs.ORIGIN_ACCESS_IDENTITY_ID }} ] && export ORIGIN_ACCESS_IDENTITY_ID="" \
             || export ORIGIN_ACCESS_IDENTITY_ID="OriginAccessIdentityId=${{ inputs.ORIGIN_ACCESS_IDENTITY_ID }}"
 
@@ -119,7 +113,6 @@ runs:
                 ProductLifetimeInDays='${{ inputs.PRODUCT_LIFETIME }}' \
                 $DOMAIN_NAME \
                 $CERTIFICATE_ARN \
-                $PERMISSIONS_BOUNDARY_ARN \
                 $ORIGIN_ACCESS_IDENTITY_ID \
                 $DISTRIBUTION_URL \
                 MonthlyJobQuotaPerUser='${{ inputs.MONTHLY_JOB_QUOTA_PER_USER }}' \

--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -92,7 +92,6 @@ jobs:
           EXPANDED_MAX_VCPUS: ${{ matrix.expanded_max_vcpus }}
           MONTHLY_BUDGET: ${{ secrets.MONTHLY_BUDGET }}
           REQUIRED_SURPLUS: ${{ matrix.required_surplus }}
-          PERMISSIONS_BOUNDARY_ARN: ${{ secrets.PERMISSIONS_BOUNDARY_ARN }}
           ORIGIN_ACCESS_IDENTITY_ID: ${{ secrets.ORIGIN_ACCESS_IDENTITY_ID }}
           SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
           AMI_ID: ${{ matrix.ami_id }}

--- a/.github/workflows/deploy-enterprise-test.yml
+++ b/.github/workflows/deploy-enterprise-test.yml
@@ -77,7 +77,6 @@ jobs:
           EXPANDED_MAX_VCPUS: ${{ matrix.expanded_max_vcpus }}
           MONTHLY_BUDGET: ${{ secrets.MONTHLY_BUDGET }}
           REQUIRED_SURPLUS: ${{ matrix.required_surplus }}
-          PERMISSIONS_BOUNDARY_ARN: ${{ secrets.PERMISSIONS_BOUNDARY_ARN }}
           ORIGIN_ACCESS_IDENTITY_ID: ${{ secrets.ORIGIN_ACCESS_IDENTITY_ID }}
           SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
           AMI_ID: ${{ matrix.ami_id }}

--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -236,7 +236,6 @@ jobs:
           EXPANDED_MAX_VCPUS: ${{ matrix.expanded_max_vcpus }}
           MONTHLY_BUDGET: ${{ secrets.MONTHLY_BUDGET }}
           REQUIRED_SURPLUS: ${{ matrix.required_surplus }}
-          PERMISSIONS_BOUNDARY_ARN: ${{ secrets.PERMISSIONS_BOUNDARY_ARN }}
           ORIGIN_ACCESS_IDENTITY_ID: ${{ secrets.ORIGIN_ACCESS_IDENTITY_ID }}
           SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
           AMI_ID: ${{ matrix.ami_id }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.9.3]
+## [3.10.0]
+### Removed
+- `PermissionsBoundaryPolicyArn` stack parameter; this setting is no longer required for Earthdata Cloud deployments
 ### Fixed
 - Reduced `start-execution-worker` concurrency to address AWS Batch `Too Many Requests` errors. Fixes [#1676](https://github.com/ASFHyP3/hyp3/issues/1676).
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ These resources are required for a successful deployment, but managed separately
 - IAM user and roles for automated CloudFormation deployments (if desired)
 - AWS Secrets Manager Secret containing key-value pairs for all secrets listed in the deployed [`job_spec`s](./job_spec)
 - For Earthdata Cloud deployments:
-  - An IAM permissions boundary policy ARN
+  - SSL certificate in AWS Certificate Manager for custom CloudFront domain name
+  - ID of the CloudFront Origin Access Identity used to access data in S3 
 - For non-Earthdata Cloud deployments:
   - DNS record for custom API domain name
   - SSL certificate in AWS Certificate Manager for custom API domain name

--- a/apps/api/api-cf.yml.j2
+++ b/apps/api/api-cf.yml.j2
@@ -22,9 +22,6 @@ Parameters:
     Type: String
 
   {% if security_environment == 'EDC' %}
-  PermissionsBoundaryPolicyArn:
-    Type: String
-
   VpcId:
     Type: String
 
@@ -144,9 +141,6 @@ Resources:
           Principal:
             Service: lambda.amazonaws.com
           Effect: Allow
-      {% if security_environment == 'EDC' %}
-      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
-      {% endif %}
       ManagedPolicyArns:
         {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole

--- a/apps/check-processing-time/check-processing-time-cf.yml.j2
+++ b/apps/check-processing-time/check-processing-time-cf.yml.j2
@@ -39,9 +39,9 @@ Resources:
           Effect: Allow
       ManagedPolicyArns:
         - !Ref Policy
-      {% if security_environment == 'EDC' %}
+        {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-      {% endif %}
+        {% endif %}
 
   Policy:
     Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}

--- a/apps/check-processing-time/check-processing-time-cf.yml.j2
+++ b/apps/check-processing-time/check-processing-time-cf.yml.j2
@@ -3,9 +3,6 @@ AWSTemplateFormatVersion: 2010-09-09
 {% if security_environment == 'EDC' %}
 Parameters:
 
-  PermissionsBoundaryPolicyArn:
-    Type: String
-
   SecurityGroupId:
     Type: String
 
@@ -44,7 +41,6 @@ Resources:
         - !Ref Policy
       {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
       {% endif %}
 
   Policy:

--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -21,11 +21,6 @@ Parameters:
   InstanceTypes:
     Type: CommaDelimitedList
 
-  {% if security_environment == 'EDC' %}
-  PermissionsBoundaryPolicyArn:
-    Type: String
-  {% endif %}
-
 Outputs:
 
   ComputeEnvironmentArn:
@@ -115,9 +110,6 @@ Resources:
           Principal:
             Service: ecs-tasks.amazonaws.com
           Effect: Allow
-      {% if security_environment == 'EDC' %}
-      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
-      {% endif %}
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
         - !Ref TaskPolicy
@@ -153,9 +145,6 @@ Resources:
           Principal:
             Service: batch.amazonaws.com
           Effect: Allow
-      {% if security_environment == 'EDC' %}
-      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
-      {% endif %}
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole
 
@@ -173,9 +162,6 @@ Resources:
           Principal:
             Service: ec2.amazonaws.com
           Effect: Allow
-      {% if security_environment == 'EDC' %}
-      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
-      {% endif %}
       ManagedPolicyArns:
         - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
 

--- a/apps/get-files/get-files-cf.yml.j2
+++ b/apps/get-files/get-files-cf.yml.j2
@@ -6,9 +6,6 @@ Parameters:
     Type: String
 
   {% if security_environment == 'EDC' %}
-  PermissionsBoundaryPolicyArn:
-    Type: String
-
   SecurityGroupId:
     Type: String
 
@@ -50,7 +47,6 @@ Resources:
         - !Ref Policy
       {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
       {% endif %}
 
   Policy:

--- a/apps/get-files/get-files-cf.yml.j2
+++ b/apps/get-files/get-files-cf.yml.j2
@@ -45,9 +45,9 @@ Resources:
           Effect: Allow
       ManagedPolicyArns:
         - !Ref Policy
-      {% if security_environment == 'EDC' %}
+        {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-      {% endif %}
+        {% endif %}
 
   Policy:
     Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}

--- a/apps/handle-batch-event/handle-batch-event-cf.yml.j2
+++ b/apps/handle-batch-event/handle-batch-event-cf.yml.j2
@@ -40,9 +40,9 @@ Resources:
           Effect: Allow
       ManagedPolicyArns:
         - !Ref Policy
-      {% if security_environment == 'EDC' %}
+        {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-      {% endif %}
+        {% endif %}
 
   Policy:
     Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}

--- a/apps/handle-batch-event/handle-batch-event-cf.yml.j2
+++ b/apps/handle-batch-event/handle-batch-event-cf.yml.j2
@@ -9,9 +9,6 @@ Parameters:
     Type: String
 
   {% if security_environment == 'EDC' %}
-  PermissionsBoundaryPolicyArn:
-    Type: String
-
   SecurityGroupId:
     Type: String
 
@@ -45,7 +42,6 @@ Resources:
         - !Ref Policy
       {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
       {% endif %}
 
   Policy:

--- a/apps/main-cf.yml.j2
+++ b/apps/main-cf.yml.j2
@@ -88,9 +88,6 @@ Parameters:
     Type: String
 
   {% else %}
-  PermissionsBoundaryPolicyArn:
-    Type: String
-
   OriginAccessIdentityId:
     Description: ID of the CloudFront Origin Access Identity used to access data in S3 for Earthdata Cloud deployments
     Type: String
@@ -123,7 +120,6 @@ Resources:
         MonthlyJobQuotaPerUser: !Ref MonthlyJobQuotaPerUser
         SystemAvailable: !Ref SystemAvailable
         {% if security_environment == 'EDC' %}
-        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
         VpcId: !Ref VpcId
         SecurityGroupId: !GetAtt Cluster.Outputs.SecurityGroupId
         SubnetIds: !Join [",", !Ref SubnetIds]
@@ -143,9 +139,6 @@ Resources:
         AmiId: !Ref AmiId
         ContentBucket: !Ref ContentBucket
         InstanceTypes: !Join [",", !Ref InstanceTypes]
-        {% if security_environment == 'EDC' %}
-        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
-        {% endif %}
       TemplateURL: compute-cf.yml
 
   ScaleCluster:
@@ -159,7 +152,6 @@ Resources:
         MonthlyBudget: !Ref MonthlyBudget
         RequiredSurplus: !Ref RequiredSurplus
         {% if security_environment == 'EDC' %}
-        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
         SecurityGroupId: !GetAtt Cluster.Outputs.SecurityGroupId
         SubnetIds: !Join [",", !Ref SubnetIds]
         {% endif %}
@@ -172,7 +164,6 @@ Resources:
         SubscriptionsTable: !Ref SubscriptionsTable
         SubscriptionWorkerArn: !GetAtt SubscriptionWorker.Outputs.LambdaArn
         {% if security_environment == 'EDC' %}
-        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
         SecurityGroupId: !GetAtt Cluster.Outputs.SecurityGroupId
         SubnetIds: !Join [",", !Ref SubnetIds]
         {% endif %}
@@ -187,7 +178,6 @@ Resources:
         SubscriptionsTable: !Ref SubscriptionsTable
         MonthlyJobQuotaPerUser: !Ref MonthlyJobQuotaPerUser
         {% if security_environment == 'EDC' %}
-        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
         SecurityGroupId: !GetAtt Cluster.Outputs.SecurityGroupId
         SubnetIds: !Join [",", !Ref SubnetIds]
         {% endif %}
@@ -200,7 +190,6 @@ Resources:
         JobQueueArn: !GetAtt Cluster.Outputs.JobQueueArn
         JobsTable: !Ref JobsTable
         {% if security_environment == 'EDC' %}
-        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
         SecurityGroupId: !GetAtt Cluster.Outputs.SecurityGroupId
         SubnetIds: !Join [",", !Ref SubnetIds]
         {% endif %}
@@ -217,7 +206,6 @@ Resources:
         ImageTag: !Ref ImageTag
         SecretArn: !Ref SecretArn
         {% if security_environment == 'EDC' %}
-        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
         SecurityGroupId: !GetAtt Cluster.Outputs.SecurityGroupId
         SubnetIds: !Join [",", !Ref SubnetIds]
         DistributionUrl: !Ref DistributionUrl

--- a/apps/scale-cluster/scale-cluster-cf.yml.j2
+++ b/apps/scale-cluster/scale-cluster-cf.yml.j2
@@ -53,9 +53,9 @@ Resources:
           Effect: Allow
       ManagedPolicyArns:
         - !Ref Policy
-      {% if security_environment == 'EDC' %}
+        {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-      {% endif %}
+        {% endif %}
 
   Policy:
     Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}

--- a/apps/scale-cluster/scale-cluster-cf.yml.j2
+++ b/apps/scale-cluster/scale-cluster-cf.yml.j2
@@ -22,9 +22,6 @@ Parameters:
     MinValue: 0
 
   {% if security_environment == 'EDC' %}
-  PermissionsBoundaryPolicyArn:
-    Type: String
-
   SecurityGroupId:
     Type: String
 
@@ -58,7 +55,6 @@ Resources:
         - !Ref Policy
       {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
       {% endif %}
 
   Policy:

--- a/apps/start-execution-manager/start-execution-manager-cf.yml.j2
+++ b/apps/start-execution-manager/start-execution-manager-cf.yml.j2
@@ -40,9 +40,9 @@ Resources:
           Effect: Allow
       ManagedPolicyArns:
         - !Ref Policy
-      {% if security_environment == 'EDC' %}
+        {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-      {% endif %}
+        {% endif %}
 
   Policy:
     Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}

--- a/apps/start-execution-manager/start-execution-manager-cf.yml.j2
+++ b/apps/start-execution-manager/start-execution-manager-cf.yml.j2
@@ -9,9 +9,6 @@ Parameters:
     Type: String
 
   {% if security_environment == 'EDC' %}
-  PermissionsBoundaryPolicyArn:
-    Type: String
-
   SecurityGroupId:
     Type: String
 
@@ -45,7 +42,6 @@ Resources:
         - !Ref Policy
       {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
       {% endif %}
 
   Policy:

--- a/apps/start-execution-worker/start-execution-worker-cf.yml.j2
+++ b/apps/start-execution-worker/start-execution-worker-cf.yml.j2
@@ -6,9 +6,6 @@ Parameters:
     Type: String
 
   {% if security_environment == 'EDC' %}
-  PermissionsBoundaryPolicyArn:
-    Type: String
-
   SecurityGroupId:
     Type: String
 
@@ -47,7 +44,6 @@ Resources:
         - !Ref Policy
       {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
       {% endif %}
 
   Policy:

--- a/apps/start-execution-worker/start-execution-worker-cf.yml.j2
+++ b/apps/start-execution-worker/start-execution-worker-cf.yml.j2
@@ -42,9 +42,9 @@ Resources:
           Effect: Allow
       ManagedPolicyArns:
         - !Ref Policy
-      {% if security_environment == 'EDC' %}
+        {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-      {% endif %}
+        {% endif %}
 
   Policy:
     Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}

--- a/apps/subscription-manager/subscription-manager-cf.yml.j2
+++ b/apps/subscription-manager/subscription-manager-cf.yml.j2
@@ -40,9 +40,9 @@ Resources:
           Effect: Allow
       ManagedPolicyArns:
         - !Ref Policy
-      {% if security_environment == 'EDC' %}
+        {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-      {% endif %}
+        {% endif %}
 
   Policy:
     Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}

--- a/apps/subscription-manager/subscription-manager-cf.yml.j2
+++ b/apps/subscription-manager/subscription-manager-cf.yml.j2
@@ -9,9 +9,6 @@ Parameters:
     Type: String
 
   {% if security_environment == 'EDC' %}
-  PermissionsBoundaryPolicyArn:
-    Type: String
-
   SecurityGroupId:
     Type: String
 
@@ -45,7 +42,6 @@ Resources:
         - !Ref Policy
       {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
       {% endif %}
 
   Policy:

--- a/apps/subscription-worker/subscription-worker-cf.yml.j2
+++ b/apps/subscription-worker/subscription-worker-cf.yml.j2
@@ -15,9 +15,6 @@ Parameters:
     Type: Number
 
   {% if security_environment == 'EDC' %}
-  PermissionsBoundaryPolicyArn:
-    Type: String
-
   SecurityGroupId:
     Type: String
 
@@ -56,7 +53,6 @@ Resources:
         - !Ref Policy
       {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
       {% endif %}
 
   Policy:

--- a/apps/subscription-worker/subscription-worker-cf.yml.j2
+++ b/apps/subscription-worker/subscription-worker-cf.yml.j2
@@ -51,9 +51,9 @@ Resources:
           Effect: Allow
       ManagedPolicyArns:
         - !Ref Policy
-      {% if security_environment == 'EDC' %}
+        {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-      {% endif %}
+        {% endif %}
 
   Policy:
     Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}

--- a/apps/update-db/update-db-cf.yml.j2
+++ b/apps/update-db/update-db-cf.yml.j2
@@ -6,9 +6,6 @@ Parameters:
     Type: String
 
   {% if security_environment == 'EDC' %}
-  PermissionsBoundaryPolicyArn:
-    Type: String
-
   SecurityGroupId:
     Type: String
 
@@ -47,7 +44,6 @@ Resources:
         - !Ref Policy
       {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
       {% endif %}
 
   Policy:

--- a/apps/update-db/update-db-cf.yml.j2
+++ b/apps/update-db/update-db-cf.yml.j2
@@ -42,9 +42,9 @@ Resources:
           Effect: Allow
       ManagedPolicyArns:
         - !Ref Policy
-      {% if security_environment == 'EDC' %}
+        {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-      {% endif %}
+        {% endif %}
 
   Policy:
     Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}

--- a/apps/upload-log/upload-log-cf.yml.j2
+++ b/apps/upload-log/upload-log-cf.yml.j2
@@ -6,9 +6,6 @@ Parameters:
     Type: String
 
   {% if security_environment == 'EDC' %}
-  PermissionsBoundaryPolicyArn:
-    Type: String
-
   SecurityGroupId:
     Type: String
 
@@ -47,7 +44,6 @@ Resources:
         - !Ref Policy
       {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
       {% endif %}
 
   Policy:

--- a/apps/upload-log/upload-log-cf.yml.j2
+++ b/apps/upload-log/upload-log-cf.yml.j2
@@ -42,9 +42,9 @@ Resources:
           Effect: Allow
       ManagedPolicyArns:
         - !Ref Policy
-      {% if security_environment == 'EDC' %}
+        {% if security_environment == 'EDC' %}
         - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
-      {% endif %}
+        {% endif %}
 
   Policy:
     Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}

--- a/apps/workflow-cf.yml.j2
+++ b/apps/workflow-cf.yml.j2
@@ -21,9 +21,6 @@ Parameters:
     Type: String
 
   {% if security_environment == 'EDC' %}
-  PermissionsBoundaryPolicyArn:
-    Type: String
-
   SecurityGroupId:
     Type: String
 
@@ -112,9 +109,6 @@ Resources:
           Effect: Allow
       ManagedPolicyArns:
         - !Ref StepFunctionPolicy
-      {% if security_environment == 'EDC' %}
-      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
-      {% endif %}
 
   StepFunctionPolicy:
     Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}
@@ -161,7 +155,6 @@ Resources:
       Parameters:
         JobsTable: !Ref JobsTable
         {% if security_environment == 'EDC' %}
-        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
         SecurityGroupId: !Ref SecurityGroupId
         SubnetIds: !Join [",", !Ref SubnetIds]
         {% endif %}
@@ -173,7 +166,6 @@ Resources:
       Parameters:
         Bucket: !Ref Bucket
         {% if security_environment == 'EDC' %}
-        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
         SecurityGroupId: !Ref SecurityGroupId
         SubnetIds: !Join [",", !Ref SubnetIds]
         DistributionUrl: !Ref DistributionUrl
@@ -185,7 +177,6 @@ Resources:
     Properties:
       {% if security_environment == 'EDC' %}
       Parameters:
-        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
         SecurityGroupId: !Ref SecurityGroupId
         SubnetIds: !Join [",", !Ref SubnetIds]
       {% endif %}
@@ -198,7 +189,6 @@ Resources:
         JobsTable: !Ref JobsTable
         StartExecutionWorkerArn: !GetAtt StartExecutionWorker.Outputs.LambdaArn
         {% if security_environment == 'EDC' %}
-        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
         SecurityGroupId: !Ref SecurityGroupId
         SubnetIds: !Join [",", !Ref SubnetIds]
         {% endif %}
@@ -210,7 +200,6 @@ Resources:
       Parameters:
         StepFunctionArn: !Ref StepFunction
         {% if security_environment == 'EDC' %}
-        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
         SecurityGroupId: !Ref SecurityGroupId
         SubnetIds: !Join [",", !Ref SubnetIds]
         {% endif %}
@@ -222,7 +211,6 @@ Resources:
       Parameters:
         Bucket: !Ref Bucket
         {% if security_environment == 'EDC' %}
-        PermissionsBoundaryPolicyArn: !Ref PermissionsBoundaryPolicyArn
         SecurityGroupId: !Ref SecurityGroupId
         SubnetIds: !Join [",", !Ref SubnetIds]
         {% endif %}
@@ -245,9 +233,6 @@ Resources:
       ManagedPolicyArns:
         - !Ref ExecutionPolicy
         - arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy
-      {% if security_environment == 'EDC' %}
-      PermissionsBoundary: !Ref PermissionsBoundaryPolicyArn
-      {% endif %}
 
   ExecutionPolicy:
     Type: {{ 'Custom::JplPolicy' if security_environment in ('JPL', 'JPL-public') else 'AWS::IAM::ManagedPolicy' }}


### PR DESCRIPTION
IAM roles created in Earthdata Cloud environments no longer require a Permissions Boundary as of Apr 2023. Tenant permissions are now managed via Service Control Policies instead.