### PR TITLE
Increase lifetime of mock API auth cookie

### DIFF
--- a/apps/api/src/hyp3_api/auth.py
+++ b/apps/api/src/hyp3_api/auth.py
@@ -15,7 +15,7 @@ def decode_token(token):
         return None
 
 
-def get_mock_jwt_cookie(user, lifetime_in_seconds=100):
+def get_mock_jwt_cookie(user: str, lifetime_in_seconds: int):
     payload = {
         'urs-user-id': user,
         'exp': int(time.time()) + lifetime_in_seconds,

--- a/tests/test_api/conftest.py
+++ b/tests/test_api/conftest.py
@@ -24,6 +24,10 @@ def client():
         yield test_client
 
 
+def login(client, username=DEFAULT_USERNAME):
+    client.set_cookie('localhost', AUTH_COOKIE, auth.get_mock_jwt_cookie(username, lifetime_in_seconds=10_000))
+
+
 def make_job(granules=None, name='someName', job_type='RTC_GAMMA', parameters=None):
     if granules is None:
         granules = ['S1B_IW_SLC__1SDV_20200604T082207_20200604T082234_021881_029874_5E38']
@@ -115,7 +119,3 @@ def setup_requests_mock(batch):
         for granule in get_granules(batch)
     ]
     setup_requests_mock_with_given_polygons(granule_polygon_pairs)
-
-
-def login(client, username=DEFAULT_USERNAME):
-    client.set_cookie('localhost', AUTH_COOKIE, auth.get_mock_jwt_cookie(username))

--- a/tests/test_api/test_api_spec.py
+++ b/tests/test_api/test_api_spec.py
@@ -47,7 +47,7 @@ def test_invalid_cookie(client):
 
 def test_expired_cookie(client):
     for uri in ENDPOINTS:
-        client.set_cookie('localhost', AUTH_COOKIE, auth.get_mock_jwt_cookie('user', -1))
+        client.set_cookie('localhost', AUTH_COOKIE, auth.get_mock_jwt_cookie('user', lifetime_in_seconds=-1))
         response = client.get(uri)
         assert response.status_code == HTTPStatus.UNAUTHORIZED
 


### PR DESCRIPTION
As described [here](https://github.com/ASFHyP3/hyp3/issues/1193#issuecomment-1636464029), I recently encountered a problem in which tests were running extremely slowly (unrelated to this PR), which caused the slowest tests to fail due to mock API calls returning `401 Unauthorized` responses, because the mock auth cookie had timed out. The problem was made more confusing by the fact that the tests were passing when run individually, I assume because they were running just fast enough to avoid the cookie timeout. This lead me down a red herring of attempting to determine if our mocks were causing side effects beyond the function scope.

In an attempt to prevent this from happening again, this PR makes the following changes:
* Remove the default `lifetime_in_seconds` value so that it must be passed to `get_mock_jwt_cookie` explicitly.
* Move the `login` function definition near the top of `tests/test_api/conftest.py`.
* Pass a cookie lifetime of 10,000 seconds in the `login` function (previous default value was 100 seconds).