### PR TITLE
require burst granules to exist in CMR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [3.9.5]
 ### Added
 - `apply_water_mask` option for `INSAR_ISCE_BURST` jobs
+### Changed
+- `POST /jobs` now returns HTTP 400 for Sentinel-1 Burst granules that do not exist in CMR
 
 ## [3.9.4]
 ### Fixed

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -66,8 +66,7 @@ def get_cmr_metadata(granules):
 
 
 def is_third_party_granule(granule):
-    # FIXME remove the -BURST case when we integrate with prod CMR
-    return granule.startswith('S2') or granule.startswith('L') or granule.endswith('-BURST')
+    return granule.startswith('S2') or granule.startswith('L')
 
 
 def check_granules_exist(granules, granule_metadata):

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -176,8 +176,7 @@ def test_is_third_party_granule():
     assert validation.is_third_party_granule('LC09_L1GT_215109_20220125_20220125_02_T2')
     assert validation.is_third_party_granule('LO09_L1GT_215109_20220210_20220210_02_T2')
     assert validation.is_third_party_granule('LT09_L1GT_215109_20220210_20220210_02_T2')
-    # FIXME remove the -BURST case when we integrate with prod CMR
-    assert validation.is_third_party_granule('S1_249434_IW1_20230523T170733_VV_8850-BURST')
+    assert not validation.is_third_party_granule('S1_249434_IW1_20230523T170733_VV_8850-BURST')
     assert not validation.is_third_party_granule('S1A_IW_SLC__1SSH_20150608T205059_20150608T205126_006287_0083E8_C4F0')
     assert not validation.is_third_party_granule('foo')
 


### PR DESCRIPTION
I had overlooked this change to require burst granules to exist in CMR when we pointed hyp3-isce2 at production CMR in [v0.5.0](https://github.com/ASFHyP3/hyp3-isce2/blob/develop/CHANGELOG.md#050)