### PR TITLE
Remove c5 instances with less disk for INSAR ISCE jobs

### DIFF
--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -54,7 +54,7 @@ jobs:
             product_lifetime_in_days: 14
             quota: 0
             job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
-            instance_types: c6id.xlarge,c5d.xlarge
+            instance_types: c6id.xlarge
             default_max_vcpus: 1600
             expanded_max_vcpus: 1600
             required_surplus: 0
@@ -69,7 +69,7 @@ jobs:
             product_lifetime_in_days: 14
             quota: 0
             job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
-            instance_types: c6id.xlarge,c5d.xlarge
+            instance_types: c6id.xlarge
             default_max_vcpus: 1600
             expanded_max_vcpus: 1600
             required_surplus: 0


### PR DESCRIPTION
Based on discussion here: https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsApp/issues/145#issuecomment-1668251751

Need extra disk space based on new generatin of instsances. Note the access instances are restricted to the new instance type with 118 GB of space.