### PR TITLE
set omp-num-threads for INSAR_ISCE_TEST, add larger instances for hyp3-tibet-jpl

### DIFF
--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -54,7 +54,7 @@ jobs:
             product_lifetime_in_days: 14
             quota: 0
             job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
-            instance_types: c6id.xlarge
+            instance_types: c6id.xlarge,c6id.2xlarge,c6id.4xlarge,c6id.8xlarge
             default_max_vcpus: 1600
             expanded_max_vcpus: 1600
             required_surplus: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.9.9]
+### Changed
+- Added larger `c6id` instance types to hyp3-tibet-jpl deployment
+- Set `++omp-num-threads=4` for `INSAR_ISCE_TEST` jobs
+
 ## [3.9.8]
 ### Removed
 - Removed `c5d.xlarge` instance types from hyp3-tibet-jpl and hyp3-nisar-jpl deployments.

--- a/job_spec/INSAR_ISCE_TEST.yml
+++ b/job_spec/INSAR_ISCE_TEST.yml
@@ -69,6 +69,8 @@ INSAR_ISCE_TEST:
       image: ghcr.io/access-cloud-based-insar/dockerizedtopsapp
       image_tag: test
       command:
+        - ++omp-num-threads
+        - '4'
         - --bucket
         - '!Ref Bucket'
         - --bucket-prefix


### PR DESCRIPTION
Leverages the new `++omp-num-threads` parameter merged into `DockerizedTopsApp:dev` this morning: https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsApp/pull/132

If validation succeeds with the `INSAR_ISCE_TEST` job type in the `hyp3-tibet-jpl` deployment, we'll then want to:
- merge the new parameter to `DockerizedTopsApp:main`
- set the parameter for the `INSAR_ISCE` job type
- add the additional instance types to the `hyp3-a19-jpl` and `hyp3-nisar-jpl` deployments