### PR TITLE
update INSAR_ISCE job type for DockerizedTopsApp v0.2.4 release

### DIFF
--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -39,7 +39,7 @@ jobs:
             product_lifetime_in_days: 180
             quota: 0
             job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
-            instance_types: c6id.xlarge
+            instance_types: c6id.xlarge,c6id.2xlarge,c6id.4xlarge,c6id.8xlarge
             default_max_vcpus: 1600
             expanded_max_vcpus: 1600
             required_surplus: 0
@@ -69,7 +69,7 @@ jobs:
             product_lifetime_in_days: 14
             quota: 0
             job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
-            instance_types: c6id.xlarge
+            instance_types: c6id.xlarge,c6id.2xlarge,c6id.4xlarge,c6id.8xlarge
             default_max_vcpus: 1600
             expanded_max_vcpus: 1600
             required_surplus: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.5]
+### Changed
+- Updated INSAR_ISCE job specification for [DockerizedTopsApp](https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsApp) v0.2.4
+- Added larger `c6id` instance types to hyp3-a19-jpl and hyp3-nisar-jpl deployments
+
 ## [3.10.4]
 ### Changed
 - The `hyp3-edc-uat` deployment now uses the latest Earthdata Cloud AMI with additional software installed.

--- a/job_spec/INSAR_ISCE.yml
+++ b/job_spec/INSAR_ISCE.yml
@@ -27,6 +27,28 @@ INSAR_ISCE:
           minLength: 67
           maxLength: 67
           example: S1B_IW_SLC__1SDV_20210711T014947_20210711T015013_027740_034F80_D404
+    esd_coherence_threshold:
+      api_schema:
+        description: Coherence threshold value for determining which points to include when performing ESD. Must be any value between 0 and 1 (inclusive), or -1 for no ESD correction.
+        default: -1.0
+        type: number
+        minimum: -1.0
+        maximum: 1.0
+    estimate_ionosphere_delay:
+      api_schema:
+        description: Whether to apply ionosphere correction to the ARIA-S1-GUNW as an additional layer.
+        default: false
+        type: boolean
+    frame_id:
+      api_schema:
+        description: Subset GUNW products to this frame. The default is `-1` with no subsetting of the products.
+        default: -1
+        type: integer
+    compute_solid_earth_tide:
+      api_schema:
+        default: false
+        type: boolean
+        description: "Whether to compute a solid earth tide correction layer for ARIA-S1-GUNW products"
     weather_model:
       api_schema:
         description: Weather model used to generate tropospheric delay estimations
@@ -34,9 +56,11 @@ INSAR_ISCE:
         type: string
         enum:
           - None
+          - ERA5
+          - ERA5T
+          - GMAO
           - HRES
           - HRRR
-          - GMAO
     bucket_prefix:
       default:  '""'
   validators: []
@@ -44,6 +68,8 @@ INSAR_ISCE:
     - name: ''
       image: ghcr.io/access-cloud-based-insar/dockerizedtopsapp
       command:
+        - ++omp-num-threads
+        - '4'
         - --bucket
         - '!Ref Bucket'
         - --bucket-prefix
@@ -52,7 +78,15 @@ INSAR_ISCE:
         - Ref::granules
         - --secondary-scenes
         - Ref::secondary_granules
-      timeout: 10800
+        - --esd-coherence-threshold
+        - Ref::esd_coherence_threshold
+        - --estimate-ionosphere-delay
+        - Ref::estimate_ionosphere_delay
+        - --frame-id
+        - Ref::frame_id
+        - --compute-solid-earth-tide
+        - Ref::compute_solid_earth_tide
+      timeout: 21600
       vcpu: 1
       memory: 7500
       secrets:
@@ -75,4 +109,8 @@ INSAR_ISCE:
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD
-
+        - RAIDER_ECMWF_ERA5_UID
+        - RAIDER_ECMWF_ERA5_API_KEY
+        - RAIDER_HRES_EMAIL
+        - RAIDER_HRES_API_KEY
+        - RAIDER_HRES_URL


### PR DESCRIPTION
Updates INSAR_ISCE job spec to match INSAR_ISCE_TEST to reflect the upcomming [DockerizedTopsApp](https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsApp) v0.2.4 release.

The only differences between INSAR_ISCE and INSAR_ISCE_TEST will be the job type name and the docker image tag used to run jobs:
```
$ diff INSAR_ISCE.yml INSAR_ISCE_TEST.yml
1c1
< INSAR_ISCE:
---
> INSAR_ISCE_TEST:
69a70
>       image_tag: test
96a98
>       image_tag: test
```