### PR TITLE
Burst Granule Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.7]
+### Changed
+- The `INSAR_ISCE_BURST` job type now validates that polarizations and burst ids are the same.
+
 ## [3.10.4]
 ### Changed
 - The `hyp3-edc-uat` deployment now uses the latest Earthdata Cloud AMI with additional software installed.

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -87,9 +87,7 @@ def check_dem_coverage(job, granule_metadata):
 
 
 def check_same_burst_ids(job, granule_metadata):
-    burst_ids = [g['name'].split('_')[1] for g in granule_metadata]
-    ref_burst_id = burst_ids[0]
-    sec_burst_id = burst_ids[1]
+    ref_burst_id, sec_burst_id = [granule['name'].split('_')[1] for granule in granule_metadata]
     if ref_burst_id != sec_burst_id:
         raise GranuleValidationError(
             f'The requested scenes do not have the same burst id: {ref_burst_id} and {sec_burst_id}'

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -86,6 +86,24 @@ def check_dem_coverage(job, granule_metadata):
         raise GranuleValidationError(f'Some requested scenes do not have DEM coverage: {", ".join(bad_granules)}')
 
 
+def check_same_burst_ids(job, granule_metadata):
+    burst_ids = [g['name'].split('_')[1] for g in granule_metadata]
+    ref_burst_id = burst_ids[0]
+    sec_burst_id = burst_ids[1]
+    if ref_burst_id != sec_burst_id:
+        raise GranuleValidationError(f'The requested scenes do not have the same burst id: {ref_burst_id} and {sec_burst_id}')
+
+
+def check_valid_polarizations(job, granule_metadata):
+    polarizations = [g['name'].split('_')[4] for g in granule_metadata]
+    ref_polarization = polarizations[0]
+    sec_polarization = polarizations[1]
+    if ref_polarization != sec_polarization:
+        raise GranuleValidationError(f'The requested scenes do not have the same polarization: {ref_polarization} and {sec_polarization}')
+    if ref_polarization != 'VV' and ref_polarization != 'HH':
+        raise GranuleValidationError(f'Only VV and HH polarizations are currently supported, got: {ref_polarization}')
+
+
 def format_points(point_string):
     converted_to_float = [float(x) for x in point_string.split(' ')]
     points = [list(t) for t in zip(converted_to_float[1::2], converted_to_float[::2])]

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -91,7 +91,9 @@ def check_same_burst_ids(job, granule_metadata):
     ref_burst_id = burst_ids[0]
     sec_burst_id = burst_ids[1]
     if ref_burst_id != sec_burst_id:
-        raise GranuleValidationError(f'The requested scenes do not have the same burst id: {ref_burst_id} and {sec_burst_id}')
+        raise GranuleValidationError(
+            f'The requested scenes do not have the same burst id: {ref_burst_id} and {sec_burst_id}'
+        )
 
 
 def check_valid_polarizations(job, granule_metadata):
@@ -99,7 +101,9 @@ def check_valid_polarizations(job, granule_metadata):
     ref_polarization = polarizations[0]
     sec_polarization = polarizations[1]
     if ref_polarization != sec_polarization:
-        raise GranuleValidationError(f'The requested scenes do not have the same polarization: {ref_polarization} and {sec_polarization}')
+        raise GranuleValidationError(
+            f'The requested scenes do not have the same polarization: {ref_polarization} and {sec_polarization}'
+        )
     if ref_polarization != 'VV' and ref_polarization != 'HH':
         raise GranuleValidationError(f'Only VV and HH polarizations are currently supported, got: {ref_polarization}')
 

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -95,9 +95,7 @@ def check_same_burst_ids(job, granule_metadata):
 
 
 def check_valid_polarizations(job, granule_metadata):
-    polarizations = [g['name'].split('_')[4] for g in granule_metadata]
-    ref_polarization = polarizations[0]
-    sec_polarization = polarizations[1]
+    ref_polarization, sec_polarization = [granule['name'].split('_')[4] for granule in granule_metadata]
     if ref_polarization != sec_polarization:
         raise GranuleValidationError(
             f'The requested scenes do not have the same polarization: {ref_polarization} and {sec_polarization}'

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -90,7 +90,7 @@ def check_same_burst_ids(job, granule_metadata):
     ref_burst_id, sec_burst_id = [granule['name'].split('_')[1] for granule in granule_metadata]
     if ref_burst_id != sec_burst_id:
         raise GranuleValidationError(
-            f'The requested scenes do not have the same burst id: {ref_burst_id} and {sec_burst_id}'
+            f'The requested scenes do not have the same burst ID: {ref_burst_id} and {sec_burst_id}'
         )
 
 

--- a/job_spec/INSAR_ISCE_BURST.yml
+++ b/job_spec/INSAR_ISCE_BURST.yml
@@ -36,6 +36,8 @@ INSAR_ISCE_BURST:
           - 5x1
   validators:
     - check_dem_coverage
+    - check_valid_polarizations
+    - check_same_burst_ids
   tasks:
     - name: ''
       image: ghcr.io/asfhyp3/hyp3-isce2

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -191,11 +191,11 @@ def test_check_valid_polarizations():
         }
     ]
 
-    validation.check_valid_polarizations('', valid_case)
+    validation.check_valid_polarizations(None, valid_case)
     with raises(validation.GranuleValidationError, match=r'.*do not have the same polarization.*'):
-        validation.check_valid_polarizations('', different_polarizations)
+        validation.check_valid_polarizations(None, different_polarizations)
     with raises(validation.GranuleValidationError, match=r'.*Only VV and HH.*'):
-        validation.check_valid_polarizations('', unsupported_polarizations)
+        validation.check_valid_polarizations(None, unsupported_polarizations)
 
 
 def test_check_granules_exist():

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -161,7 +161,7 @@ def test_check_same_burst_ids():
     ]
 
     validation.check_same_burst_ids('', valid_case)
-    with raises(validation.GranuleValidationError, match=r'.*do not have the same burst id.*'):
+    with raises(validation.GranuleValidationError, match=r'.*do not have the same burst ID.*'):
         validation.check_same_burst_ids('', invalid_case)
 
 

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -142,6 +142,62 @@ def test_check_dem_coverage():
         validation.check_dem_coverage(job, [neither])
 
 
+def test_check_same_burst_ids():
+    valid_case = [
+        {
+            'name': 'S1_136231_IW2_20200604T022312_VV_7C85-BURST'
+        },
+        {
+            'name': 'S1_136231_IW2_20200616T022313_VV_5D11-BURST'
+        }
+    ]
+    invalid_case = [
+        {
+            'name': 'S1_136231_IW2_20200604T022312_VV_7C85-BURST'
+        },
+        {
+            'name': 'S1_136232_IW2_20200616T022313_HH_5D11-BURST'
+        }
+    ]
+
+    validation.check_same_burst_ids('', valid_case)
+    with raises(validation.GranuleValidationError, match=r'.*do not have the same burst id.*'):
+        validation.check_same_burst_ids('', invalid_case)
+
+
+def test_check_valid_polarizations():
+    valid_case = [
+        {
+            'name': 'S1_136231_IW2_20200604T022312_VV_7C85-BURST'
+        },
+        {
+            'name': 'S1_136231_IW2_20200616T022313_VV_5D11-BURST'
+        }
+    ]
+    different_polarizations = [
+        {
+            'name': 'S1_136231_IW2_20200604T022312_VV_7C85-BURST'
+        },
+        {
+            'name': 'S1_136231_IW2_20200616T022313_HH_5D11-BURST'
+        }
+    ]
+    unsupported_polarizations = [
+        {
+            'name': 'S1_136231_IW2_20200604T022312_VH_7C85-BURST'
+        },
+        {
+            'name': 'S1_136231_IW2_20200616T022313_VH_5D11-BURST'
+        }
+    ]
+
+    validation.check_valid_polarizations('', valid_case)
+    with raises(validation.GranuleValidationError, match=r'.*do not have the same polarization.*'):
+        validation.check_valid_polarizations('', different_polarizations)
+    with raises(validation.GranuleValidationError, match=r'.*Only VV and HH.*'):
+        validation.check_valid_polarizations('', unsupported_polarizations)
+
+
 def test_check_granules_exist():
     granule_metadata = [
         {

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -162,7 +162,7 @@ def test_check_same_burst_ids():
 
     validation.check_same_burst_ids(None, valid_case)
     with raises(validation.GranuleValidationError, match=r'.*do not have the same burst ID.*'):
-        validation.check_same_burst_ids('', invalid_case)
+        validation.check_same_burst_ids(None, invalid_case)
 
 
 def test_check_valid_polarizations():

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -160,7 +160,7 @@ def test_check_same_burst_ids():
         }
     ]
 
-    validation.check_same_burst_ids('', valid_case)
+    validation.check_same_burst_ids(None, valid_case)
     with raises(validation.GranuleValidationError, match=r'.*do not have the same burst ID.*'):
         validation.check_same_burst_ids('', invalid_case)
 


### PR DESCRIPTION
For INSAR_ISCE_BURST: Added validation functions to check that bursts have the same burst ids and the same polarizations. Also checks if the polarizations are supported (VV or HH).