### PR TITLE
Specify jwt auth public key as github secret

### DIFF
--- a/.github/actions/deploy-hyp3/action.yml
+++ b/.github/actions/deploy-hyp3/action.yml
@@ -68,6 +68,9 @@ inputs:
   DISTRIBUTION_URL:
     description: "CloudFront Distribution URL for Earthdata Cloud environments"
     required: true
+  AUTH_PUBLIC_KEY:
+    description: "Public key for jwt auth provider"
+    required: true
 
 runs:
   using: "composite"
@@ -111,6 +114,7 @@ runs:
                 SecretArn='${{ inputs.SECRET_ARN }}' \
                 ImageTag='${{ inputs.IMAGE_TAG }}' \
                 ProductLifetimeInDays='${{ inputs.PRODUCT_LIFETIME }}' \
+                AuthPublicKey='${{ inputs.AUTH_PUBLIC_KEY }}' \
                 $DOMAIN_NAME \
                 $CERTIFICATE_ARN \
                 $ORIGIN_ACCESS_IDENTITY_ID \

--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -98,6 +98,7 @@ jobs:
           AMI_ID: ${{ matrix.ami_id }}
           INSTANCE_TYPES: ${{ matrix.instance_types }}
           DISTRIBUTION_URL: ${{ matrix.distribution_url }}
+          AUTH_PUBLIC_KEY: ${{ secrets.AUTH_PUBLIC_KEY }}
 
   call-bump-version-workflow:
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/deploy-enterprise-test.yml
+++ b/.github/workflows/deploy-enterprise-test.yml
@@ -82,3 +82,4 @@ jobs:
           AMI_ID: ${{ matrix.ami_id }}
           INSTANCE_TYPES: ${{ matrix.instance_types }}
           DISTRIBUTION_URL: ${{ matrix.distribution_url }}
+          AUTH_PUBLIC_KEY: ${{ secrets.AUTH_PUBLIC_KEY }}

--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -241,3 +241,4 @@ jobs:
           AMI_ID: ${{ matrix.ami_id }}
           INSTANCE_TYPES: ${{ matrix.instance_types }}
           DISTRIBUTION_URL: ${{ matrix.distribution_url }}
+          AUTH_PUBLIC_KEY: ${{ secrets.AUTH_PUBLIC_KEY }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.10.9]
+### Changed
+- The public key for the JWT auth provider is now specified as a GitHub Secret. Fixes https://github.com/ASFHyP3/hyp3/issues/1765
+
 ## [3.10.8]
 ### Changed
 - HyP3 deployments at JPL now use On Demand instances instead of Spot instances to prevent `INSAR_ISCE` jobs from being interrupted.

--- a/apps/main-cf.yml.j2
+++ b/apps/main-cf.yml.j2
@@ -23,9 +23,8 @@ Parameters:
     Default: 14
 
   AuthPublicKey:
-    Description: Public key for jwt auth provider, if using https://auth.asf.alaska.edu then keep default.
+    Description: Public key for jwt auth provider
     Type: String
-    Default: ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCnUEi9E+KNwH2hq0OXR4YyuVPQoNy6CtxQZv3VNXE+TRkmlo7nZbZXQp3JVQAvVaq+ixwNeSvCDI979UGA+SlUpryWy+XFJNAMDlIz9kBVYkTQdT8uFA8IN/fjN1jioOfgpbDJnSaKbb1/NsiTp9cesQQB0qiW5iUsGUfi3Y2x6r446KFt9oJqDzpR2MumKwmHX8tSe1AFUQG+5P4ncoZKS/2EPwfgTuiLW5f/9Duz4vt3peA/wJzBUWd5k9pOz44e2vAbwwLym2APpa7m740Ftyo2lXAZZkejg5MUUza1das5PjN7srt7jJwkBVqd27e1eKHAM4kzAMxcny3SBW2FC6pg6q04NZmPWN6A7y7GzLYJCBuqBwu4OWEzcc4KVkFyTVV+HGUlLX9n2iM4O5RML6+qx+DuK4Ml1kvEBObJ5ce7s4XaNFcg9XmymYiRpZUQmawD1/E5D1l1JNoXNNv8VlJ21c4QYWfmHIhKUF8/dwaRxl6GYd5CrdseEMZtjss88ncmml2cm+7tcpHHJi9Q/wsvAfV7RjFV5JW1PR2UPrATUpJxL+M9dFiGd0KROpqVQ4r6OLAnQQiOrWUquw/38a6JRPW4Y8MH3+JNJMm6MdhB8lFjEKzPic5qBzLJ4yQkOo8K/k0h0K88kT39tRIKVl4Upxvw3iPoVTDGWbkK1w== douglassorensen@FBK-3CGMD6R.local\n
 
   AuthAlgorithm:
     Description: Algorithm for jwt auth provider, if using https://auth.asf.alaska.edu then keep default.


### PR DESCRIPTION
See https://github.com/ASFHyP3/hyp3/issues/1765

Before merging:

- [x] Add `AUTH_PUBLIC_KEY` as a repository secret (use the value from https://sentinel1.asf.alaska.edu/pubkey)

After merging:

- [ ] Authenticate to the `hyp3-test` API with a fresh cookie and confirm I can query the endpoints