### PR TITLE
Don't require float format for phase filter param

### DIFF
--- a/job_spec/INSAR_GAMMA.yml
+++ b/job_spec/INSAR_GAMMA.yml
@@ -67,7 +67,6 @@ INSAR_GAMMA:
       api_schema:
         description: Adaptive phase filter exponent (alpha). Larger values result in more aggressive filtering. If zero, adaptive phase filter will be skipped. We recommend against values less than 0.2, or values with more than two decimal places of precision.
         type: number
-        format: float
         minimum: 0.0
         maximum: 1.0
         default: 0.6


### PR DESCRIPTION
Ah, this option requires the *user* to pass numbers as floats, e.g. `0` fails but `0.0` passes. This is not what we want.