### PR TITLE
lower job memory reservations to accomodate AL2023 AMI

### DIFF
--- a/apps/step-function.json.j2
+++ b/apps/step-function.json.j2
@@ -138,7 +138,7 @@
         "ResourceRequirements": [
           {
             "Type": "MEMORY",
-            "Value": "7900"
+            "Value": "7800"
           }
         ]
       },

--- a/apps/step-function.json.j2
+++ b/apps/step-function.json.j2
@@ -138,7 +138,7 @@
         "ResourceRequirements": [
           {
             "Type": "MEMORY",
-            "Value": "7800"
+            "Value": "7875"
           }
         ]
       },

--- a/job_spec/AUTORIFT.yml
+++ b/job_spec/AUTORIFT.yml
@@ -51,7 +51,7 @@ AUTORIFT:
         - Ref::granules
       timeout: 10800
       vcpu: 1
-      memory: 31600
+      memory: 31500
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD

--- a/job_spec/AUTORIFT_ITS_LIVE.yml
+++ b/job_spec/AUTORIFT_ITS_LIVE.yml
@@ -54,7 +54,7 @@ AUTORIFT:
         - Ref::granules
       timeout: 10800
       vcpu: 1
-      memory: 31600
+      memory: 31500
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD

--- a/job_spec/AUTORIFT_ITS_LIVE_TEST.yml
+++ b/job_spec/AUTORIFT_ITS_LIVE_TEST.yml
@@ -55,7 +55,7 @@ AUTORIFT_TEST:
         - Ref::granules
       timeout: 10800
       vcpu: 1
-      memory: 31600
+      memory: 31500
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD

--- a/job_spec/INSAR_GAMMA.yml
+++ b/job_spec/INSAR_GAMMA.yml
@@ -105,7 +105,7 @@ INSAR_GAMMA:
         - Ref::granules
       timeout: 10800
       vcpu: 1
-      memory: 31600
+      memory: 31500
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD

--- a/job_spec/RIVER_WIDTH.yml
+++ b/job_spec/RIVER_WIDTH.yml
@@ -89,4 +89,4 @@ RIVER_WIDTH:
         - Ref::bucket_prefix
       timeout: 36000
       vcpu: 1
-      memory: 31600
+      memory: 31500

--- a/job_spec/RTC_GAMMA.yml
+++ b/job_spec/RTC_GAMMA.yml
@@ -127,7 +127,7 @@ RTC_GAMMA:
         - Ref::granules
       timeout: 36000
       vcpu: 1
-      memory: 31600
+      memory: 31500
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD

--- a/job_spec/WATER_MAP.yml
+++ b/job_spec/WATER_MAP.yml
@@ -133,7 +133,7 @@ WATER_MAP:
         - Ref::granules
       timeout: 36000
       vcpu: 1
-      memory: 31600
+      memory: 31500
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD

--- a/job_spec/WATER_MAP_EQ.yml
+++ b/job_spec/WATER_MAP_EQ.yml
@@ -90,7 +90,7 @@ WATER_MAP_EQ:
         - Ref::granules
       timeout: 36000
       vcpu: 1
-      memory: 31600
+      memory: 31500
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD

--- a/job_spec/WATER_MAP_TEST.yml
+++ b/job_spec/WATER_MAP_TEST.yml
@@ -142,7 +142,7 @@ WATER_MAP_TEST:
         - Ref::granules
       timeout: 36000
       vcpu: 1
-      memory: 31600
+      memory: 31500
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD


### PR DESCRIPTION
The ECS Agent running on the AL2023 AMI reserves slightly more memory than on the AL2 AMI. This leaves only 31,517 MB available for jobs on an `r6id.xlarge`; 126,722 available on an `r6id.4xlarge`, ect.

This PR lowers the memory reserved for jobs to 7,875 MB/vcpu so they'll fit on any of the `r6id` family.

![Screenshot from 2023-10-25 17-16-57](https://github.com/ASFHyP3/hyp3/assets/17994518/41e03f09-0f82-4f0d-945c-17599594c6f7)

# TODO
- [ ] double-check 10m rtc memory reservation