### PR TITLE
update ec2 user data for al2023

### DIFF
--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -57,8 +57,9 @@ Resources:
             --==BOUNDARY==
             Content-Type: text/cloud-boothook; charset="us-ascii"
 
+            #!/bin/bash
             cloud-init-per instance mkfs_ssd mkfs.ext4 /dev/nvme1n1
-            cloud-init-per instance mount_ssd mount /dev/nvme1n1 /var/lib/docker
+            mount /dev/nvme1n1 /var/lib/docker
 
             --==BOUNDARY==--
 


### PR DESCRIPTION
The existing userdata script to mount the EC2 instance store worked on Amazon Linux 2, but fails with this error on Amazon Linux 2023:
```
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/cloudinit/subp.py", line 291, in subp
    sp = subprocess.Popen(
  File "/usr/lib64/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib64/python3.9/subprocess.py", line 1821, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
OSError: [Errno 8] Exec format error: b'/var/lib/cloud/instances/i-0acc8d507952336ee/boothooks/part-002'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/cloudinit/handlers/boot_hook.py", line 51, in handle_part
    subp.subp([filepath], env=env)
  File "/usr/lib/python3.9/site-packages/cloudinit/subp.py", line 304, in subp
    raise ProcessExecutionError(
cloudinit.subp.ProcessExecutionError: Exec format error. Missing #! in script?
```

I confirmed the updated userdata works on both AMIs after adding the explicit `#!/bin/bash` line.

This also removes the "only run once per instance" directive from the `mount` command. The `mkfs` command to create the filesystem should only be run once per instance; it fails if run a second time because the filesystem already exists. The `mount` command should be re-run every time the instance reboots (although in the AWS Batch context that never matters since we never reboot).