### PR TITLE
use new SPOT_PRICE_CAPACITY_OPTIMIZED allocation strategy for all dep…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [4.3.0]
 ### Added
 - An `iterative_min_size` parameter has been added to the `WATER_MAP_TEST` job spec.
-#### Changed
+### Changed
 - For `WATER_MAP_TEST` jobs, the default `minimization_metric` is now `ts`.
 - Use Amazon Linux 2023 AMI in non-Earthdata Cloud environments
+- All deployments now use the `SPOT_PRICE_CAPACITY_OPTIMIZED` allocation strategy for AWS Batch. This includes JPL
+  deployments, reverting the temporary change to On Demand instances in HyP3 v3.10.8
 
 ## [4.2.1]
 ### Changed

--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -69,13 +69,8 @@ Resources:
       ServiceRole: !GetAtt BatchServiceRole.Arn
       Type: MANAGED
       ComputeResources:
-        {% if security_environment in ('JPL', 'JPL-public') %}
-        Type: EC2
-        AllocationStrategy: BEST_FIT_PROGRESSIVE
-        {% else %}
         Type: SPOT
-        AllocationStrategy: SPOT_CAPACITY_OPTIMIZED
-        {% endif %}
+        AllocationStrategy: SPOT_PRICE_CAPACITY_OPTIMIZED
         MinvCpus: 0
         MaxvCpus: !Ref MaxvCpus
         InstanceTypes: !Ref InstanceTypes


### PR DESCRIPTION
…loyments

Reverts the temporary change to On Demand instances for JPL deployments made in v3.10.8: https://github.com/ASFHyP3/hyp3/compare/v3.10.7...v3.10.8

The new `SPOT_PRICE_CAPACITY_OPTIMIZED` allocation strategy was made available Aug 2: https://aws.amazon.com/about-aws/whats-new/2023/08/aws-batch-price-capacity-optimized-allocation-strategy-spot-instances/

From the latest documentation: https://docs.aws.amazon.com/batch/latest/userguide/allocation-strategies.html
> We recommend that you use SPOT_PRICE_CAPACITY_OPTIMIZED rather than SPOT_CAPACITY_OPTIMIZED in most instances.