### PR TITLE
Provide ESA creds to insar and rtc jobs

### DIFF
--- a/job_spec/INSAR_GAMMA.yml
+++ b/job_spec/INSAR_GAMMA.yml
@@ -109,3 +109,5 @@ INSAR_GAMMA:
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD
+        - ESA_USERNAME
+        - ESA_PASSWORD

--- a/job_spec/RTC_GAMMA.yml
+++ b/job_spec/RTC_GAMMA.yml
@@ -131,3 +131,5 @@ RTC_GAMMA:
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD
+        - ESA_USERNAME
+        - ESA_PASSWORD


### PR DESCRIPTION
This will allow testing the new `hyp3lib` orbit fetching implementation on `hyp3-test`. Afterwards, we can either revert this PR (if we're not going to release the new orbit fetching implementation), or add a Changelog entry and release these changes (adding the secrets for any other job types that need them, as well).