### PR TITLE
Standardize parameters for GUNW

### DIFF
--- a/job_spec/INSAR_ISCE_TEST.yml
+++ b/job_spec/INSAR_ISCE_TEST.yml
@@ -2,6 +2,7 @@ INSAR_ISCE_TEST:
   required_parameters:
     - granules
     - secondary_granules
+    - frame_id
   parameters:
     granules:
       default:  '""'
@@ -27,28 +28,47 @@ INSAR_ISCE_TEST:
           minLength: 67
           maxLength: 67
           example: S1B_IW_SLC__1SDV_20210711T014947_20210711T015013_027740_034F80_D404
+    frame_id:
+      api_schema:
+        description: Subset GUNW products to this frame. When set to `-1`, no subsetting applied. If no frame specified (i.e. `-1`), then output GUNW is not a "standard" GUNW and will not be delivered to DAAC.
+        default: '""'
+        type: integer
+    goldstein_filter_power:
+      api_schema:
+        description: The filter power of the goldsetin filter; 0 means no filter applied
+        default: -1.0
+        type: number
+        minimum: 0
     esd_coherence_threshold:
       api_schema:
-        description: Coherence threshold value for determining which points to include when performing ESD. Must be any value between 0 and 1 (inclusive), or -1 for no ESD correction.
+        description: Coherence threshold value for determining which points to include when performing ESD. Must be any value between 0 and 1 (inclusive), or -1 for no ESD correction. Standard products do NOT include ESD.
         default: -1.0
         type: number
         minimum: -1.0
         maximum: 1.0
     estimate_ionosphere_delay:
       api_schema:
-        description: Whether to apply ionosphere correction to the ARIA-S1-GUNW as an additional layer.
-        default: false
+        description: Whether to apply ionosphere correction to the ARIA-S1-GUNW as an additional layer; standard products include this layer
+        default: true
         type: boolean
-    frame_id:
+    output_resolution:
       api_schema:
-        description: Subset GUNW products to this frame. The default is `-1` with no subsetting of the products.
-        default: -1
-        type: integer
+        default:  90.0
+        description: Desired output resolution in meters; standard products are 90 m
+        type: number
+        enum:
+          - 30.0
+          - 90.0
     compute_solid_earth_tide:
       api_schema:
-        default: false
+        default: true
         type: boolean
-        description: "Whether to compute a solid earth tide correction layer for ARIA-S1-GUNW products"
+        description: Whether to compute a solid earth tide correction layer for ARIA-S1-GUNW products; standard products include this layer
+    unfiltered_coherence:
+      api_schema:
+        default: true
+        type: boolean
+        description: Whether to unfiltered_coherence for ARIA-S1-GUNW products; standard products include this layer included
     weather_model:
       api_schema:
         description: Weather model used to generate tropospheric delay estimations
@@ -87,6 +107,14 @@ INSAR_ISCE_TEST:
         - Ref::frame_id
         - --compute-solid-earth-tide
         - Ref::compute_solid_earth_tide
+        - --output-resolution
+        - Ref::output_resolution
+        - --dense-offsets
+        - Ref::dense_offsets
+        - --goldstein-filter-power
+        - Ref::goldstein_filter_power
+        - --unfiltered-coherence
+        - Ref::unfiltered_coherence 
       timeout: 21600
       vcpu: 1
       memory: 7500


### PR DESCRIPTION
* Require `frame_id`
* Set default parameters for version 3+ GUNW products
* Expose additional customizable parameters and specify "standard" parameters where possible.