### PR TITLE
Fix numeric type in INSAR_ISCE_TEST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.5.1]
+### Fixed
+- `output_resolution` in the `INSAR_ISCE_TEST` job spec is now correctly specified as an int instead of number, which can be a float or an int.
+
 ## [4.5.0]
 ### Changed
 - Update `INSAR_ISCE` and `INSAR_ISCE_TEST` job spec for GUNW version 3+ standard and custom products

--- a/job_spec/INSAR_ISCE_TEST.yml
+++ b/job_spec/INSAR_ISCE_TEST.yml
@@ -58,12 +58,12 @@ INSAR_ISCE_TEST:
         minimum: 0
     output_resolution:
       api_schema:
-        default:  90.0
+        default:  90
         description: Desired output resolution in meters of GUNW product; standard ARIA products requires resolution to be set to 90 m.
-        type: number
+        type: integer
         enum:
-          - 30.0
-          - 90.0
+          - 30
+          - 90
     unfiltered_coherence:
       api_schema:
         default: true


### PR DESCRIPTION
The DockerizedTopsApp container expects the `--output-resolution`  to be an integer
https://github.com/ACCESS-Cloud-Based-InSAR/DockerizedTopsApp/blob/dev/isce2_topsapp/__main__.py#L188C1-L188C85

but we specify it as a [number](https://swagger.io/docs/specification/data-models/data-types/#numbers) without a format, which can be any numbers (ints or floats)
https://github.com/ASFHyP3/hyp3/blob/develop/job_spec/INSAR_ISCE_TEST.yml#L59-L66

Even though our `enum` and `default` are floats, these get simplified to ints in both the OpenAPI Spec and the example job dict:
![image](https://github.com/ASFHyP3/hyp3/assets/7882693/6feb8a13-ec74-45d9-b3e9-c7c18367e822)

*I find this extremely surprising.*

So my test job, which I submitted by editing the example job dict, was able to run successfully as ints were passed down to the container:
https://hyp3-enterprise-test.asf.alaska.edu/jobs/85256792-e7c7-41f6-9592-d1167a628cf8

However, if you don't specify `output_resolution` when you submit, the default of 90.0, a float, is used and the container bonks with:
https://hyp3-a19-jpl-contentbucket-1wfnatpznlg8b.s3.us-west-2.amazonaws.com/9e6cc5ad-e164-4d6e-b5a6-3891175a22f6/9e6cc5ad-e164-4d6e-b5a6-3891175a22f6.log
```
gunw_slc: error: argument --output-resolution: invalid int value: '90.0'
```

This PR restricts the `output_resolution` to and integer.






