### PR TITLE
Release v4.5.1 -- output_resolution numeric type fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.5.1]
+### Fixed
+- `output_resolution` in the `INSAR_ISCE_TEST` job spec is now correctly specified as an int instead of number, which can be a float or an int.
+
 ## [4.5.0]
 ### Changed
 - Update `INSAR_ISCE` and `INSAR_ISCE_TEST` job spec for GUNW version 3+ standard and custom products

--- a/job_spec/INSAR_ISCE_TEST.yml
+++ b/job_spec/INSAR_ISCE_TEST.yml
@@ -58,12 +58,12 @@ INSAR_ISCE_TEST:
         minimum: 0
     output_resolution:
       api_schema:
-        default:  90.0
+        default:  90
         description: Desired output resolution in meters of GUNW product; standard ARIA products requires resolution to be set to 90 m.
-        type: number
+        type: integer
         enum:
-          - 30.0
-          - 90.0
+          - 30
+          - 90
     unfiltered_coherence:
       api_schema:
         default: true


### PR DESCRIPTION
Test `INSAR_ISCE_TEST` jobs:
* :x: with no `output_resolution` specified:
  https://hyp3-enterprise-test.asf.alaska.edu/jobs?user_id=jhkennedy&name=Los-Angeles-0_64_HRRR_1121_part-deux
  * these failed due to the job timeout being hit, but did start running succfully, which they did not in v4.5.0, so really, :heavy_check_mark: for this PR
* :heavy_check_mark:  with `output_resolution` specified as an int:
  https://hyp3-enterprise-test.asf.alaska.edu/jobs/2b718b83-7684-449b-9db2-a6c9d6dc7e41
* :heavy_check_mark: and I get the expected rejection with a float `output_resolution`:
  ![image](https://github.com/ASFHyP3/hyp3/assets/7882693/347da886-4a9d-4fe0-a3b3-6c746ea34c67)



