### PR TITLE
Add `/api` server URL to OpenAPI spec for EDC deployments

### DIFF
--- a/apps/api/src/hyp3_api/api-spec/openapi-spec.yml.j2
+++ b/apps/api/src/hyp3_api/api-spec/openapi-spec.yml.j2
@@ -8,6 +8,7 @@ security:
   - EarthDataLogin: []
 
 {% if security_environment == 'EDC' %}
+# See https://github.com/ASFHyP3/hyp3/pull/2009 for context.
 servers:
   - url: /
   - url: /api

--- a/apps/api/src/hyp3_api/api-spec/openapi-spec.yml.j2
+++ b/apps/api/src/hyp3_api/api-spec/openapi-spec.yml.j2
@@ -7,6 +7,12 @@ info:
 security:
   - EarthDataLogin: []
 
+{% if security_environment == 'EDC' %}
+servers:
+  - url: /
+  - url: /api
+{% endif %}
+
 paths:
 
   /jobs:


### PR DESCRIPTION
As explained at <https://github.com/ASFHyP3/hyp3/issues/1193#issuecomment-1886059722>, all API requests to <https://hyp3-test-api.asf.alaska.edu> (EDC UAT) are currently failing with `400` errors like `Server not found for https://vd2gh6uqw3.execute-api.us-west-2.amazonaws.com/api/user`, but requests to <https://hyp3-enterprise-test.asf.alaska.edu> are working fine.

The error message comes from [openapi-core](https://github.com/python-openapi/openapi-core) when it validates the API request. It turns out that OpenAPI 3.0 spec files may include an optional `servers` array, as explained by the [Swagger docs](https://swagger.io/docs/specification/api-host-and-base-path/). Importantly:

> If the `servers` array is not provided or is empty, the server URL defaults to `/`

For our non-EDC deployments, requests received by our Flask app have URLs like `https://hyp3-enterprise-test.asf.alaska.edu/user`. However, for our EDC deployments, a CloudFront distribution forwards requests to our ApiGateway resource with URLs like `https://vd2gh6uqw3.execute-api.us-west-2.amazonaws.com/api/user`.

The important part is the path after the host name: `/user` for the non-EDC deployment and `/api/user` for the EDC deployment. The `openapi-core` package fails to validate our requests in EDC because, by default, OpenAPI expects requests to be relative to the root `/` path, but our requests are relative to `/api` in EDC.

Therefore, the solution is to add an `/api` URL to the `servers` array in our OpenAPI spec file for EDC deployments. By just specifying the `/api` URL, requests to `https://hyp3-test-api.asf.alaska.edu` succeed using the HyP3 SDK. However, the Swagger UI then forces us to send requests to `https://hyp3-test-api.asf.alaska.edu/api/`, which is not what we want. So we also have to add the `/` URL to the `servers` array if we want Swagger to work.