### PR TITLE
quota yes/no strings to keep yaml parser from changing them to true/false

### DIFF
--- a/apps/main-cf.yml.j2
+++ b/apps/main-cf.yml.j2
@@ -219,7 +219,7 @@ Resources:
       {% if security_environment == 'EDC' %}
       Tags:
         - Key: DAR
-          Value: YES
+          Value: "YES"
       {% endif %}
 
   LogBucketPolicy:
@@ -281,7 +281,7 @@ Resources:
       {% if security_environment == 'EDC' %}
       Tags:
         - Key: DAR
-          Value: NO
+          Value: "NO"
       {% endif %}
 
   {% if security_environment != 'JPL' %}


### PR DESCRIPTION
Without quotes, the CloudFormation yaml parser interprets yes/no as boolean true/false. The value of the applied tag in the S3 console ended up being the strings "true" or "false" instead of the strings "YES" or "NO".

![Screenshot from 2024-02-01 12-33-22](https://github.com/ASFHyP3/hyp3/assets/17994518/6ec73b13-edc2-4701-befd-3424475d8973)
![Screenshot from 2024-02-01 12-33-35](https://github.com/ASFHyP3/hyp3/assets/17994518/8c668395-5d34-4f28-bb8b-d026b1100c70)
