### PR TITLE
use lists instead of dictionaries in GET /costs response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.3.0]
+
+### Changed
+- `/costs` API endpoint now returns a list of job cost dictionaries, instead of a dictionary of dictionaries.
+- Cost table parameters are now contained within the `parameter_value` dictionary key.
+- Cost table costs are now contained within the `cost` dictionary key.
+
 ## [6.2.0]
 
 HyP3 is in the process of transitioning from a monthly job quota to a credits system. [HyP3 v6.0.0](https://github.com/ASFHyP3/hyp3/releases/tag/v6.0.0) implemented the new credits system without changing the number of jobs that users can run per month. This release implements the capability to assign a different credit cost to each type of job, again without actually changing the number of jobs that users can run per month.

--- a/apps/api/src/hyp3_api/api-spec/openapi-spec.yml.j2
+++ b/apps/api/src/hyp3_api/api-spec/openapi-spec.yml.j2
@@ -25,7 +25,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/costs"
+                $ref: "#/components/schemas/costs_response"
 
   /jobs:
 
@@ -117,9 +117,34 @@ paths:
 components:
   schemas:
 
-    costs:
-      description: Table of job costs.
-      type: object
+    costs_response:
+      description: List of job costs.
+      type: array
+      items:
+        type: object
+        required:
+          - job_type
+        properties:
+          job_type:
+            $ref: "./job_parameters.yml#/components/schemas/job_type"
+          cost:
+            $ref: "#/components/schemas/credits"
+          cost_parameter:
+            type: string
+          cost_table:
+            type: array
+            items:
+              type: object
+              required:
+                - parameter_value
+                - cost
+              properties:
+                parameter_value:
+                  oneOf:
+                    - type: string
+                    - type: number
+                cost:
+                  $ref: "#/components/schemas/credits"
 
     post_jobs_body:
       description: List for new jobs to submit for processing.

--- a/apps/render_cf.py
+++ b/apps/render_cf.py
@@ -48,12 +48,15 @@ def render_default_params_by_job_type(job_types: dict) -> None:
 
 
 def render_costs(job_types: dict, cost_profile: str) -> None:
-    costs = {
-        job_type: job_spec['cost_profiles'][cost_profile]
+    costs = [
+        {
+            'job_type': job_type,
+            **job_spec['cost_profiles'][cost_profile],
+        }
         for job_type, job_spec in job_types.items()
-    }
-    with open(Path('lib') / 'dynamo' / 'dynamo' / 'costs.yml', 'w') as f:
-        yaml.safe_dump(costs, f)
+    ]
+    with open(Path('lib') / 'dynamo' / 'dynamo' / 'costs.json', 'w') as f:
+        json.dump(costs, f, indent=2)
 
 
 def main():

--- a/job_spec/INSAR_GAMMA.yml
+++ b/job_spec/INSAR_GAMMA.yml
@@ -74,8 +74,10 @@ INSAR_GAMMA:
     EDC:
       cost_parameter: looks
       cost_table:
-        20x4: 10.0
-        10x2: 15.0
+        - parameter_value: 20x4
+          cost: 10.0
+        - parameter_value: 10x2
+          cost: 15.0
     DEFAULT:
       cost: 1.0
   validators:

--- a/job_spec/RTC_GAMMA.yml
+++ b/job_spec/RTC_GAMMA.yml
@@ -93,9 +93,12 @@ RTC_GAMMA:
     EDC:
       cost_parameter: resolution
       cost_table:
-        30.0: 5.0
-        20.0: 15.0
-        10.0: 60.0
+        - parameter_value: 30.0
+          cost: 5.0
+        - parameter_value: 20.0
+          cost: 15.0
+        - parameter_value: 10.0
+          cost: 60.0
     DEFAULT:
       cost: 1.0
   validators:

--- a/lib/dynamo/setup.py
+++ b/lib/dynamo/setup.py
@@ -8,11 +8,10 @@ setup(
     install_requires=[
         'boto3',
         'python-dateutil',
-        'pyyaml',
     ],
     python_requires='~=3.9',
 
     packages=find_packages(),
 
-    package_data={'dynamo': ['*.json', '*.yml']},
+    package_data={'dynamo': ['*.json']},
 )


### PR DESCRIPTION
TODO:
- [x] changelog
- [ ] add example values for some fields in 'openapi-spec.yml.j2`?
- [x] double-check float vs Decimal typing everywhere

Old response:
```
{
  "AUTORIFT": {
    "cost": 25
  },
  "INSAR_GAMMA": {
    "cost_parameter": "looks",
    "cost_table": {
      "10x2": 15,
      "20x4": 10
    }
  },
  "INSAR_ISCE_BURST": {
    "cost": 1
  },
  "INSAR_ISCE_TEST": {
    "cost": 1
  },
  "RTC_GAMMA": {
    "cost_parameter": "resolution",
    "cost_table": {
      "10.0": 60,
      "20.0": 15,
      "30.0": 5
    }
  }
}
```

New response:
```
[
  {
    "job_type": "AUTORIFT",
    "cost": 25
  },
  {
    "job_type": "INSAR_GAMMA",
    "cost_parameter": "looks",
    "cost_table": [
      {
        "parameter_value": "10x2",
        "cost": 15
      },
      {
        "parameter_value": "20x4",
        "cost": 10
      }
    ]
  },
  {
    "job_type": "INSAR_ISCE_BURST",
    "cost": 1
  },
  {
    "job_type": "RTC_GAMMA",
    "cost_parameter": "resolution",
    "cost_table": [
      {
        "parameter_value": 10,
        "cost": 60
      },
      {
        "parameter_value": 20,
        "cost": 15
      },
      {
        "parameter_value": 30,
        "cost": 5
      }
    ]
  }
]
```