### PR TITLE
Rework for test GUNW deployments

### DIFF
--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -48,7 +48,6 @@ jobs:
               job_spec/AUTORIFT.yml
               job_spec/INSAR_GAMMA.yml
               job_spec/RTC_GAMMA.yml
-              job_spec/INSAR_ISCE_TEST.yml
               job_spec/INSAR_ISCE_BURST.yml
             instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge
             default_max_vcpus: 1200

--- a/.github/workflows/deploy-enterprise-test.yml
+++ b/.github/workflows/deploy-enterprise-test.yml
@@ -27,7 +27,6 @@ jobs:
               job_spec/AUTORIFT_ITS_LIVE.yml
               job_spec/INSAR_GAMMA.yml
               job_spec/RTC_GAMMA.yml
-              job_spec/INSAR_ISCE_TEST.yml
               job_spec/INSAR_ISCE_BURST.yml
               job_spec/WATER_MAP.yml
               job_spec/WATER_MAP_EQ.yml
@@ -37,6 +36,23 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
+            distribution_url: ''
+
+          - environment: hyp3-a19-jpl-test
+            domain: hyp3-a19-jpl-test.asf.alaska.edu
+            template_bucket: cf-templates-v4pvone059de-us-west-2
+            image_tag: test
+            product_lifetime_in_days: 14
+            default_credits_per_user: 0
+            reset_credits_monthly: true
+            cost_profile: DEFAULT
+            job_files: job_spec/INSAR_ISCE_TEST.yml
+            instance_types: m6id.xlarge,m6id.2xlarge,m6id.4xlarge,m6id.8xlarge,m6idn.xlarge,m6idn.2xlarge,m6idn.4xlarge,m6idn.8xlarge
+            default_max_vcpus: 640
+            expanded_max_vcpus: 640
+            required_surplus: 0
+            security_environment: JPL-public
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
             distribution_url: ''
 

--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -42,7 +42,7 @@ jobs:
             default_credits_per_user: 0
             reset_credits_monthly: true
             cost_profile: DEFAULT
-            job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
+            job_files: job_spec/INSAR_ISCE.yml
             instance_types: c6id.xlarge,c6id.2xlarge,c6id.4xlarge,c6id.8xlarge
             default_max_vcpus: 4000
             expanded_max_vcpus: 4000
@@ -59,7 +59,7 @@ jobs:
             default_credits_per_user: 0
             reset_credits_monthly: true
             cost_profile: DEFAULT
-            job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
+            job_files: job_spec/INSAR_ISCE.yml
             instance_types: c6id.xlarge,c6id.2xlarge,c6id.4xlarge,c6id.8xlarge
             default_max_vcpus: 1000
             expanded_max_vcpus: 1000
@@ -76,7 +76,7 @@ jobs:
             default_credits_per_user: 0
             reset_credits_monthly: true
             cost_profile: DEFAULT
-            job_files: job_spec/INSAR_ISCE.yml job_spec/INSAR_ISCE_TEST.yml
+            job_files: job_spec/INSAR_ISCE.yml
             instance_types: c6id.xlarge,c6id.2xlarge,c6id.4xlarge,c6id.8xlarge
             default_max_vcpus: 1600
             expanded_max_vcpus: 1600

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [7.1.0]
+### Added
+- A `hyp3-a19-jpl-test` deployment to [`deploy-enterprise-test.yml`](.github/workflows/deploy-enterprise-test.yml) for ARIA testing of the `m6id[n]` instance families
+
+### Changed
+
+- The `INSAR_ISCE_TEST.yml` job spec now only differs from the `INSAR_ISCE.yml` with respect to the `++omp-num-threads` parameter, because the value is specific to a particular instance family
+
 ## [7.0.0]
 
 This release marks the final transition to the new credits system. These changes apply to the production HyP3 API at <https://hyp3-api.asf.alaska.edu>. Read the [announcement](https://hyp3-docs.asf.alaska.edu/using/credits/) for full details.

--- a/job_spec/INSAR_ISCE.yml
+++ b/job_spec/INSAR_ISCE.yml
@@ -50,6 +50,30 @@ INSAR_ISCE:
         description: Whether to apply ionosphere correction to the ARIA-S1-GUNW as an additional layer; standard ARIA products include the ionsphere correction to be turned on and include multiple ionosphere correction layers.
         default: true
         type: boolean
+    goldstein_filter_power:
+      api_schema:
+        description: The filter power of the adaptive goldsetin filter; 0 means no filter applied. Standard product requires strength to be set to 0.5.
+        default: 0.5
+        type: number
+        minimum: 0
+    output_resolution:
+      api_schema:
+        default:  90
+        description: Desired output resolution in meters of GUNW product; standard ARIA products requires resolution to be set to 90 m.
+        type: integer
+        enum:
+          - 30
+          - 90
+    unfiltered_coherence:
+      api_schema:
+        default: true
+        type: boolean
+        description: Whether to add unfiltered_coherence layer to ARIA-S1-GUNW products; standard ARIA products must include this layer.
+    dense_offsets:
+      api_schema:
+        default: false
+        type: boolean
+        description: Whether to include 2 extra layers (azimuth and range pixel offsets) that measure via patch cross-correlation the change between reference and secondary in radar coordinates; standard ARIA products do NOT include this layer.
     weather_model:
       api_schema:
         description: Weather model used to generate tropospheric delay estimations.
@@ -90,6 +114,14 @@ INSAR_ISCE:
         - Ref::frame_id
         - --compute-solid-earth-tide
         - Ref::compute_solid_earth_tide
+        - --output-resolution
+        - Ref::output_resolution
+        - --dense-offsets
+        - Ref::dense_offsets
+        - --goldstein-filter-power
+        - Ref::goldstein_filter_power
+        - --unfiltered-coherence
+        - Ref::unfiltered_coherence
       timeout: 21600
       vcpu: 1
       memory: 7500

--- a/job_spec/INSAR_ISCE_TEST.yml
+++ b/job_spec/INSAR_ISCE_TEST.yml
@@ -1,4 +1,4 @@
-INSAR_ISCE_TEST:
+INSAR_ISCE:
   required_parameters:
     - granules
     - secondary_granules
@@ -89,18 +89,15 @@ INSAR_ISCE_TEST:
     bucket_prefix:
       default:  '""'
   cost_profiles:
-    EDC:
-      cost: 1.0
     DEFAULT:
       cost: 1.0
   validators: []
   tasks:
     - name: ''
       image: ghcr.io/access-cloud-based-insar/dockerizedtopsapp
-      image_tag: test
       command:
         - ++omp-num-threads
-        - '4'
+        - '2'  # 2 for the m instance family; 4 for the c
         - --bucket
         - '!Ref Bucket'
         - --bucket-prefix
@@ -135,7 +132,6 @@ INSAR_ISCE_TEST:
         - ESA_PASSWORD
     - name: TROPOSPHERE
       image: ghcr.io/dbekaert/raider
-      image_tag: test
       command:
         - ++process
         - calcDelaysGUNW


### PR DESCRIPTION
Instead of using a test job type, this stands up a test stack.

Since we want to explore different instance families in the test stack, the `--opt-num-threads` parameter will need to change on a per instance family basis. I've retained the `INSAR_ISCE_TEST.yml` file to vary this parameter, and now *only* differs there compared to the `INSAR_ISCE.yml` job spec.

I've dropped INSAR_ISCE or INSAR_ISCE_TEST jobs from all non-ARIA deployments because they would also have an un-optimized `--opt-num-threads` parameter for the instance families used there, aren't being used in non-ARIA deployments, and we do all ARIA testing in the ARIA accounts.