### PR TITLE
Don't require `granules` job parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The `INSAR_ISCE_TEST.yml` job spec now only differs from the `INSAR_ISCE.yml` with respect to the `++omp-num-threads` parameter, because the value is specific to a particular instance family
+- Job specs are no longer required to include the `granules` parameter.
 
 ### Removed
 - The `AUTORIFT_ITS_LIVE_TEST.yml` job spec which supported running test versions of the AUTORIFT jobs in the production hyp3-its-live deployment

--- a/apps/api/src/hyp3_api/api-spec/job_parameters.yml.j2
+++ b/apps/api/src/hyp3_api/api-spec/job_parameters.yml.j2
@@ -23,7 +23,7 @@ components:
 
     {% for job_type, job_spec in job_types.items() %}
     {{ job_type }}Parameters:
-      description: Parameters for running {{ job_type }} jobs, including specific granules
+      description: Parameters for running {{ job_type }} jobs
       type: object
       additionalProperties: false
       {% for parameter, parameter_spec in job_spec['parameters'].items() if 'api_schema' in parameter_spec and parameter in job_spec.get('required_parameters', []) %}

--- a/apps/api/src/hyp3_api/handlers.py
+++ b/apps/api/src/hyp3_api/handlers.py
@@ -2,11 +2,10 @@ from http.client import responses
 
 import requests
 from flask import abort, jsonify, request
-from jsonschema import draft4_format_checker
 
 import dynamo
 from hyp3_api import util
-from hyp3_api.validation import GranuleValidationError, is_uuid, validate_jobs
+from hyp3_api.validation import GranuleValidationError, validate_jobs
 
 
 def problem_format(status, message):
@@ -19,9 +18,6 @@ def problem_format(status, message):
     response.headers['Content-Type'] = 'application/problem+json'
     response.status_code = status
     return response
-
-
-is_uuid = draft4_format_checker.checks('uuid')(is_uuid)
 
 
 def post_jobs(body, user):

--- a/apps/api/src/hyp3_api/util.py
+++ b/apps/api/src/hyp3_api/util.py
@@ -8,12 +8,8 @@ class TokenDeserializeError(Exception):
     """Raised when paging results and `start_token` fails to deserialize"""
 
 
-def get_granules(jobs):
-    granules = set()
-    for job in jobs:
-        for granule in job['job_parameters']['granules']:
-            granules.add(granule)
-    return granules
+def get_granules(jobs: list[dict]) -> set[str]:
+    return {granule for job in jobs for granule in job['job_parameters'].get('granules', [])}
 
 
 def serialize(payload: dict):

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -2,7 +2,6 @@ import json
 import os
 import sys
 from pathlib import Path
-from uuid import UUID
 
 import requests
 import yaml
@@ -57,16 +56,8 @@ def get_cmr_metadata(granules):
     return granules
 
 
-def is_uuid(val):
-    try:
-        UUID(val, version=4)
-    except ValueError:
-        return False
-    return True
-
-
 def is_third_party_granule(granule):
-    return granule.startswith('S2') or granule.startswith('L') or is_uuid(granule)
+    return granule.startswith('S2') or granule.startswith('L')
 
 
 def check_granules_exist(granules, granule_metadata):

--- a/job_spec/ARIA_RAIDER.yml
+++ b/job_spec/ARIA_RAIDER.yml
@@ -3,7 +3,6 @@ ARIA_RAIDER:
     - job_id
   parameters:
     job_id:
-      default:  '""'
       api_schema:
         description: HyP3 job ID for an INSAR_ISCE job that has successfully completed the DockerizedTopsApp step
         type: string

--- a/job_spec/ARIA_RAIDER.yml
+++ b/job_spec/ARIA_RAIDER.yml
@@ -1,20 +1,14 @@
 ARIA_RAIDER:
   required_parameters:
-    - granules
+    - job_id
   parameters:
-    granules:
+    job_id:
       default:  '""'
       api_schema:
-        type: array
-        minItems: 1
-        maxItems: 1
-        example:
-          - 27836b79-e5b2-4d8f-932f-659724ea02c3
-        items:
-          description: HyP3 Job ID (granule) for a INSAR_ISCE job that has successfully completed the DockerizedTopsApp step
-          type: string
-          format: uuid
-          example: 27836b79-e5b2-4d8f-932f-659724ea02c3
+        description: HyP3 job ID for an INSAR_ISCE job that has successfully completed the DockerizedTopsApp step
+        type: string
+        format: uuid
+        example: 27836b79-e5b2-4d8f-932f-659724ea02c3
     weather_model:
       api_schema:
         description: Weather model used to generate tropospheric delay estimations.
@@ -46,7 +40,7 @@ ARIA_RAIDER:
         - --weather-model
         - Ref::weather_model
         - --input-bucket-prefix
-        - Ref::granules
+        - Ref::job_id
       timeout: 10800
       vcpu: 1
       memory: 7500

--- a/tests/test_api/test_util.py
+++ b/tests/test_api/test_util.py
@@ -6,6 +6,19 @@ import pytest
 from hyp3_api import util
 
 
+def test_get_granules():
+    assert util.get_granules(
+        [
+            {'job_parameters': {'granules': []}},
+            {'job_parameters': {'granules': ['A']}},
+            {'job_parameters': {'granules': ['B']}},
+            {'job_parameters': {'granules': ['C', 'D']}},
+            {'job_parameters': {'granules': ['C', 'D', 'E']}},
+            {'job_parameters': {'granules': ['F', 'F']}},
+        ]
+    ) == {'A', 'B', 'C', 'D', 'E', 'F'}
+
+
 def test_serialize_token():
     token = {'foo': 1, 'bar': 2}
     assert util.serialize(token) == 'eyJmb28iOiAxLCAiYmFyIjogMn0='

--- a/tests/test_api/test_util.py
+++ b/tests/test_api/test_util.py
@@ -15,6 +15,7 @@ def test_get_granules():
             {'job_parameters': {'granules': ['C', 'D']}},
             {'job_parameters': {'granules': ['C', 'D', 'E']}},
             {'job_parameters': {'granules': ['F', 'F']}},
+            {'job_parameters': {}},
         ]
     ) == {'A', 'B', 'C', 'D', 'E', 'F'}
 

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -266,6 +266,10 @@ def test_validate_jobs():
                 'granules': [granule_with_dem_coverage, granule_without_dem_coverage],
             }
         },
+        {
+            'job_type': 'ARIA_RAIDER',
+            'job_parameters': {}
+        },
     ]
     validation.validate_jobs(jobs)
 


### PR DESCRIPTION
This PR:

* Modifies `get_granules` to allow jobs with no `granules` parameter.
* Removes the unused `is_uuid` function altogether.
* Replaces the `granules` parameter with `job_id` in the `ARIA_RAIDER` job spec.

TODO:

- [x] Confirm that the API validates that the `job_id` parameter is a UUID, based on the `format: uuid` line
- [x] Does passing `Ref::job_id` to the `ghcr.io/dbekaert/raider` container work with the current CLI?