### PR TITLE
Whitelisting sandbox initial implementation

### DIFF
--- a/.github/workflows/deploy-whitelisting-sandbox.yml
+++ b/.github/workflows/deploy-whitelisting-sandbox.yml
@@ -1,0 +1,83 @@
+name: Deploy Whitelisting Sandbox Stack to AWS
+
+on:
+  push:
+    branches:
+      - whitelisting-sandbox
+
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - environment: hyp3-whitelisting-sandbox
+            domain: hyp3-whitelisting-sandbox.asf.alaska.edu
+            template_bucket: cf-templates-1hz9ldhhl4ahu-us-west-2
+            image_tag: test
+            product_lifetime_in_days: 14
+            default_credits_per_user: 10
+            reset_credits_monthly: true
+            cost_profile: EDC
+            deploy_ref: refs/heads/whitelisting-sandbox
+            job_files: >-
+              job_spec/AUTORIFT.yml
+              job_spec/INSAR_GAMMA.yml
+              job_spec/RTC_GAMMA.yml
+              job_spec/INSAR_ISCE_BURST.yml
+            instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge
+            default_max_vcpus: 640
+            expanded_max_vcpus: 640
+            required_surplus: 0
+            security_environment: ASF
+            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
+            distribution_url: ''
+
+    environment:
+      name: ${{ matrix.environment }}
+      url: https://${{ matrix.domain }}
+
+    steps:
+      - uses: actions/checkout@v4.1.2
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.V2_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.V2_AWS_SECRET_ACCESS_KEY }}
+          aws-session-token: ${{ secrets.V2_AWS_SESSION_TOKEN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.9
+
+      - uses: ./.github/actions/deploy-hyp3
+        with:
+          TEMPLATE_BUCKET:  ${{ matrix.template_bucket }}
+          STACK_NAME: ${{ matrix.environment }}
+          DOMAIN_NAME: ${{ matrix.domain }}
+          API_NAME: ${{ matrix.environment }}
+          CERTIFICATE_ARN:  ${{ secrets.CERTIFICATE_ARN }}
+          IMAGE_TAG: ${{ matrix.image_tag }}
+          PRODUCT_LIFETIME: ${{ matrix.product_lifetime_in_days }}
+          VPC_ID: ${{ secrets.VPC_ID }}
+          SUBNET_IDS: ${{ secrets.SUBNET_IDS }}
+          SECRET_ARN: ${{ secrets.SECRET_ARN }}
+          CLOUDFORMATION_ROLE_ARN: ${{ secrets.CLOUDFORMATION_ROLE_ARN }}
+          DEFAULT_CREDITS_PER_USER: ${{ matrix.default_credits_per_user }}
+          RESET_CREDITS_MONTHLY: ${{ matrix.reset_credits_monthly }}
+          COST_PROFILE: ${{ matrix.cost_profile }}
+          JOB_FILES: ${{ matrix.job_files }}
+          DEFAULT_MAX_VCPUS: ${{ matrix.default_max_vcpus }}
+          EXPANDED_MAX_VCPUS: ${{ matrix.expanded_max_vcpus }}
+          MONTHLY_BUDGET: ${{ secrets.MONTHLY_BUDGET }}
+          REQUIRED_SURPLUS: ${{ matrix.required_surplus }}
+          ORIGIN_ACCESS_IDENTITY_ID: ${{ secrets.ORIGIN_ACCESS_IDENTITY_ID }}
+          SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
+          AMI_ID: ${{ matrix.ami_id }}
+          INSTANCE_TYPES: ${{ matrix.instance_types }}
+          DISTRIBUTION_URL: ${{ matrix.distribution_url }}
+          AUTH_PUBLIC_KEY: ${{ secrets.AUTH_PUBLIC_KEY }}

--- a/apps/api/src/hyp3_api/handlers.py
+++ b/apps/api/src/hyp3_api/handlers.py
@@ -31,17 +31,6 @@ def is_uuid(val):
     return True
 
 
-def register(body, user):
-    print(body)
-
-    try:
-        payload = dynamo.user.create_user(user, body)
-    except dynamo.user.UserAlreadyExistsError as e:
-        # TODO is there a more specific status code to use here?
-        abort(problem_format(400, str(e)))
-    return payload
-
-
 def post_jobs(body, user):
     print(body)
 
@@ -89,6 +78,17 @@ def get_names_for_user(user):
         jobs.extend(new_jobs)
     names = {job['name'] for job in jobs if 'name' in job}
     return sorted(list(names))
+
+
+def post_user(body, user):
+    print(body)
+
+    try:
+        payload = dynamo.user.create_user(user, body)
+    except dynamo.user.UserAlreadyExistsError as e:
+        # TODO is there a more specific status code to use here?
+        abort(problem_format(400, str(e)))
+    return payload
 
 
 def get_user(user):

--- a/apps/api/src/hyp3_api/handlers.py
+++ b/apps/api/src/hyp3_api/handlers.py
@@ -87,7 +87,8 @@ def get_user(user):
         abort(problem_format(403, str(e)))
     return {
         'user_id': user,
+        'application_status': user_record['application_status'],
         'remaining_credits': user_record['remaining_credits'],
         # TODO: count this as jobs are submitted, not every time `/user` is queried
-        'job_names': get_names_for_user(user)
+        'job_names': get_names_for_user(user),
     }

--- a/apps/api/src/hyp3_api/handlers.py
+++ b/apps/api/src/hyp3_api/handlers.py
@@ -31,6 +31,17 @@ def is_uuid(val):
     return True
 
 
+def register(body, user):
+    print(body)
+
+    try:
+        payload = dynamo.user.create_user(user, body)
+    except dynamo.user.UserAlreadyExistsError as e:
+        # TODO is there a more specific status code to use here?
+        abort(problem_format(400, str(e)))
+    return payload
+
+
 def post_jobs(body, user):
     print(body)
 

--- a/apps/api/src/hyp3_api/routes.py
+++ b/apps/api/src/hyp3_api/routes.py
@@ -148,11 +148,11 @@ def jobs_get_by_job_id(job_id):
     return jsonify(handlers.get_job_by_id(job_id))
 
 
-@app.route('/register', methods=['POST'])
+@app.route('/user', methods=['POST'])
 @openapi
-def register_post():
+def user_post():
     # TODO: add to API spec
-    return jsonify(handlers.register(request.get_json(), g.user))
+    return jsonify(handlers.post_user(request.get_json(), g.user))
 
 
 @app.route('/user', methods=['GET'])

--- a/apps/api/src/hyp3_api/routes.py
+++ b/apps/api/src/hyp3_api/routes.py
@@ -148,6 +148,13 @@ def jobs_get_by_job_id(job_id):
     return jsonify(handlers.get_job_by_id(job_id))
 
 
+@app.route('/register', methods=['POST'])
+@openapi
+def register_post():
+    # TODO: add to API spec
+    return jsonify(handlers.register(request.get_json(), g.user))
+
+
 @app.route('/user', methods=['GET'])
 @openapi
 def user_get():

--- a/lib/dynamo/dynamo/jobs.py
+++ b/lib/dynamo/dynamo/jobs.py
@@ -9,6 +9,7 @@ from uuid import uuid4
 from boto3.dynamodb.conditions import Attr, Key
 
 import dynamo.user
+from dynamo.user import APPLICATION_APPROVED, APPLICATION_PENDING, APPLICATION_REJECTED
 from dynamo.util import DYNAMODB_RESOURCE, convert_floats_to_decimals, format_time, get_request_time_expression
 
 costs_file = Path(__file__).parent / 'costs.json'
@@ -32,13 +33,16 @@ def put_jobs(user_id: str, jobs: List[dict], dry_run=False) -> List[dict]:
 
     user_record = dynamo.user.get_user(user_id)
 
-    if user_record['application_status'] == 'PENDING':
+    application_status = user_record['application_status']
+    if application_status == APPLICATION_PENDING:
         raise dynamo.user.UnapprovedUserError(f'User {user_id} has a pending application, please try again later.')
-    elif user_record['application_status'] == 'REJECTED':
+    elif application_status == APPLICATION_REJECTED:
         raise dynamo.user.UnapprovedUserError(
             f'Unfortunately, the application for user {user_id} has been rejected.'
             ' If you believe this was a mistake, please email ASF User Services at: uso@asf.alaska.edu'
         )
+    elif application_status != APPLICATION_APPROVED:
+        raise ValueError(f'User {user_id} has an invalid application status: {application_status}')
 
     remaining_credits = user_record['remaining_credits']
     priority_override = user_record.get('priority_override')

--- a/lib/dynamo/dynamo/user.py
+++ b/lib/dynamo/dynamo/user.py
@@ -7,6 +7,10 @@ import botocore.exceptions
 
 from dynamo.util import DYNAMODB_RESOURCE
 
+APPLICATION_APPROVED = 'APPROVED'
+APPLICATION_PENDING = 'PENDING'
+APPLICATION_REJECTED = 'REJECTED'
+
 
 class DatabaseConditionException(Exception):
     """Raised when a DynamoDB condition expression check fails."""

--- a/lib/dynamo/dynamo/user.py
+++ b/lib/dynamo/dynamo/user.py
@@ -46,19 +46,26 @@ def _get_current_month() -> str:
     return datetime.now(tz=timezone.utc).strftime('%Y-%m')
 
 
-# TODO: use this function somewhere or delete it
-def _create_user(user_id: str, default_credits: Decimal, current_month: str, users_table) -> dict:
-    user = {'user_id': user_id, 'remaining_credits': default_credits, 'month_of_last_credits_reset': current_month}
+# TODO: call this function for the user registration endpoint
+def create_user(user_id: str, users_table) -> dict:
+    user = {'user_id': user_id, 'remaining_credits': Decimal(0), 'month_of_last_credits_reset': '0'}
     try:
         users_table.put_item(Item=user, ConditionExpression='attribute_not_exists(user_id)')
     except botocore.exceptions.ClientError as e:
         if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
+            # TODO: replace this with a different exception and convert it to a client error
+            #  for the user registration endpoint
             raise DatabaseConditionException(f'Failed to create user {user_id}')
         raise
     return user
 
 
 def _reset_credits_if_needed(user: dict, default_credits: Decimal, current_month: str, users_table) -> dict:
+    # TODO:
+    #  if application_status is APPROVED:
+    #    take the current approach
+    #  elif application_status is PENDING or REJECTED:
+    #    set remaining_credits and month of last reset to 0 (like in create_user)
     if (
             os.environ['RESET_CREDITS_MONTHLY'] == 'true'
             and user['month_of_last_credits_reset'] < current_month  # noqa: W503

--- a/lib/dynamo/dynamo/user.py
+++ b/lib/dynamo/dynamo/user.py
@@ -48,7 +48,12 @@ def _get_current_month() -> str:
 
 # TODO: call this function for the user registration endpoint
 def create_user(user_id: str, users_table) -> dict:
-    user = {'user_id': user_id, 'remaining_credits': Decimal(0), 'month_of_last_credits_reset': '0'}
+    user = {
+        'user_id': user_id,
+        'remaining_credits': Decimal(0),
+        'month_of_last_credits_reset': '0',
+        'application_status': APPLICATION_PENDING,
+    }
     try:
         users_table.put_item(Item=user, ConditionExpression='attribute_not_exists(user_id)')
     except botocore.exceptions.ClientError as e:


### PR DESCRIPTION
My proposed implementation is as follows:
- Each user record has an `application_status` attribute that can be `PENDING`, `APPROVED`, or `REJECTED`.
- A user must hit the `POST /user` endpoint to create their user record.
- Each user record is created in `PENDING` status with `remaining_credits` equal to `0` and `month_of_last_credits_reset` equal to `"0"`.
- Changing the status of an application (regardless of the application's current status) is as easy as changing `application_status` to the desired value.
    - Whenever a record is fetched from the Users table, `_reset_credits_if_needed` is called for the given user (this is already the case).
    - The `_reset_credits_if_needed` function will continue to operate as it currently does for `APPROVED` users, but for `PENDING` and `REJECTED` users it will set `remaining_credits` to `0` and `month_of_last_credits_reset` to `"0"`, the same as when the user record was first created.

TODO:

- [x] Finish implementing the functionality outlined above
- [ ] Test changes in a sandbox deployment
- [ ] Add/update unit tests for all new/changed functionality
- [ ] `TODO` items in code