### PR TITLE
make weather model a required parameter for ARIA_RAIDER jobs

### DIFF
--- a/job_spec/ARIA_RAIDER.yml
+++ b/job_spec/ARIA_RAIDER.yml
@@ -1,6 +1,7 @@
 ARIA_RAIDER:
   required_parameters:
     - job_id
+    - weather_model
   parameters:
     job_id:
       api_schema:
@@ -11,10 +12,8 @@ ARIA_RAIDER:
     weather_model:
       api_schema:
         description: Weather model used to generate tropospheric delay estimations.
-        default: None
         type: string
         enum:
-          - None
           - ERA5
           - ERA5T
           - GMAO


### PR DESCRIPTION
It doesn't make sense to run RAiDER on its own without a weather model, especially since nothing is done and no output product is uploaded causing get_files to fail afterwards.