### PR TITLE
Restrict ITS_LIVE vCPUs to avoid throttling

### DIFF
--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -26,8 +26,8 @@ jobs:
               job_spec/AUTORIFT_ITS_LIVE.yml
               job_spec/S1_CORRECTION_ITS_LIVE.yml
             instance_types: r6id.xlarge,r6idn.xlarge,r5dn.xlarge,r5d.xlarge
-            default_max_vcpus: 10000
-            expanded_max_vcpus: 10000
+            default_max_vcpus: 2000
+            expanded_max_vcpus: 2000
             required_surplus: 0
             security_environment: JPL-public
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [7.6.0]
+
+### Changed
+- Reduced throughput for `hyp3-its-live` to prevent Sentinel-2 processing from being rate limited (10,000 -> 2,000 vCPUs).
+
 ## [7.5.0]
 
 ### Added


### PR DESCRIPTION
This should prevent us from being throttled by Google Cloud Storage.

I've manually done this for hyp3-its-live, so this is reflecting that. 