### PR TITLE
remove ESA secrets from job specs that no longer require them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [7.7.1]
+
+### Removed
+- The `ESA_USERNAME` and `ESA_PASSWORD` secrets have been removed from the job specs that no longer require them (those that use the `hyp3-gamma`, `hyp3-isce2`, `hyp3-autorift`, or `hyp3-back-projection` images).
+
+
 ## [7.7.0]
 
 ### Added

--- a/job_spec/ARIA_AUTORIFT.yml
+++ b/job_spec/ARIA_AUTORIFT.yml
@@ -61,5 +61,3 @@ AUTORIFT:
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD
-        - ESA_USERNAME
-        - ESA_PASSWORD

--- a/job_spec/AUTORIFT.yml
+++ b/job_spec/AUTORIFT.yml
@@ -60,5 +60,3 @@ AUTORIFT:
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD
-        - ESA_USERNAME
-        - ESA_PASSWORD

--- a/job_spec/AUTORIFT_ITS_LIVE.yml
+++ b/job_spec/AUTORIFT_ITS_LIVE.yml
@@ -72,7 +72,5 @@ AUTORIFT:
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD
-        - ESA_USERNAME
-        - ESA_PASSWORD
         - PUBLISH_ACCESS_KEY_ID
         - PUBLISH_SECRET_ACCESS_KEY

--- a/job_spec/INSAR_GAMMA.yml
+++ b/job_spec/INSAR_GAMMA.yml
@@ -119,5 +119,3 @@ INSAR_GAMMA:
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD
-        - ESA_USERNAME
-        - ESA_PASSWORD

--- a/job_spec/INSAR_ISCE_BURST.yml
+++ b/job_spec/INSAR_ISCE_BURST.yml
@@ -67,5 +67,3 @@ INSAR_ISCE_BURST:
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD
-        - ESA_USERNAME
-        - ESA_PASSWORD

--- a/job_spec/RTC_GAMMA.yml
+++ b/job_spec/RTC_GAMMA.yml
@@ -142,5 +142,3 @@ RTC_GAMMA:
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD
-        - ESA_USERNAME
-        - ESA_PASSWORD

--- a/job_spec/S1_CORRECTION_ITS_LIVE.yml
+++ b/job_spec/S1_CORRECTION_ITS_LIVE.yml
@@ -52,5 +52,3 @@ S1_CORRECTION_TEST:
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD
-        - ESA_USERNAME
-        - ESA_PASSWORD

--- a/job_spec/SRG_GSLC_CPU.yml
+++ b/job_spec/SRG_GSLC_CPU.yml
@@ -41,5 +41,3 @@ SRG_GSLC_CPU:
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD
-        - ESA_USERNAME
-        - ESA_PASSWORD

--- a/job_spec/WATER_MAP.yml
+++ b/job_spec/WATER_MAP.yml
@@ -155,8 +155,6 @@ WATER_MAP:
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD
-        - ESA_USERNAME
-        - ESA_PASSWORD
     - name: ''
       image: ghcr.io/fjmeyer/hydrosar
       command:

--- a/job_spec/WATER_MAP_EQ.yml
+++ b/job_spec/WATER_MAP_EQ.yml
@@ -97,8 +97,6 @@ WATER_MAP_EQ:
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD
-        - ESA_USERNAME
-        - ESA_PASSWORD
     - name: ''
       image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/water-map-equal-percent-solution
       command:


### PR DESCRIPTION
The only job specs that still require these secrets are `ARIA_RAIDER` and `INSAR_ISCE`.

TODO:

- [x] Don't merge until `hyp3-gamma`, `hyp3-isce2`, `hyp3-autorift`, and `hyp3-back-projection` have all been released.