### PR TITLE
Changed SRG_GSLC_CPU Job to Use the hyp3-srg Image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [7.7.2]
+
+### Change
+- Changed the `SRG_GSLC_CPU` job to use the `hyp3-srg` image, rather than `hyp3-back-projection` since the repository was renamed.
+
+
 ## [7.7.1]
 
 ### Removed

--- a/job_spec/SRG_GSLC_CPU.yml
+++ b/job_spec/SRG_GSLC_CPU.yml
@@ -26,7 +26,7 @@ SRG_GSLC_CPU:
       cost: 1.0
   tasks:
     - name: ''
-      image: ghcr.io/asfhyp3/hyp3-back-projection
+      image: ghcr.io/asfhyp3/hyp3-srg
       command:
         - ++process
         - back_projection


### PR DESCRIPTION
hyp3-back-projection is being renamed to hyp3-srg, so the image name will change.