### PR TITLE
use dedicated on-demand compute environment for INSAR_ISCE jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
 ## [7.8.0]
 
 ### Added
@@ -13,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The `SRG_GSLC` job type now runs within a GPU environment.
 - Revert ARIA hyp3 deployments back to C-instance family - including the job-spec CLI parameter `omp-num-threads` to ensure multiple jobs fit on single instance.
-
+- Deployments with INSAR_ISCE.yml job specs will now use a dedicated compute environment with on-demand instances instead of spot instances for INSAR_ISCE jobs.
 
 ## [7.7.2]
 

--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -109,7 +109,7 @@ Resources:
   {% for job_type, job_spec in job_types.items() if 'Default' != job_spec['compute_environment']['name'] %}
   {% set env = job_spec['compute_environment'] %}
   {% set name = env['name'] %}
-  {% set instance_types = env['instance_types'] if 'instance_types' in env else '!Ref InstanceTypes' %}
+  {% set instance_types = env['instance_types'].split(',') if 'instance_types' in env else '!Ref InstanceTypes' %}
   {% set ami_id = env['ami_id'] if 'ami_id' in env else '!Ref AmiId' %}
   {% set type = env['allocation_type'] if 'allocation_type' in env else 'SPOT' %}
   {% set strategy = env['allocation_strategy'] if 'allocation_strategy' in env else 'SPOT_PRICE_CAPACITY_OPTIMIZED' %}

--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -123,7 +123,7 @@ Resources:
         AllocationStrategy: {{ strategy }}
         MinvCpus: 0
         MaxvCpus: !Ref MaxvCpus
-        InstanceTypes: {{ instance_type }}
+        InstanceTypes: {{ instance_types }}
         ImageId: {{ ami_id }}
         Subnets: !Ref SubnetIds
         InstanceRole: !Ref InstanceProfile

--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -109,7 +109,7 @@ Resources:
   {% for job_type, job_spec in job_types.items() if 'Default' != job_spec['compute_environment']['name'] %}
   {% set env = job_spec['compute_environment'] %}
   {% set name = env['name'] %}
-  {% set instance_types = env['instance_types'] if 'instance_types' in env else ['!Ref InstanceTypes'] %}
+  {% set instance_types = env['instance_types'] if 'instance_types' in env else '!Ref InstanceTypes' %}
   {% set ami_id = env['ami_id'] if 'ami_id' in env else '!Ref AmiId' %}
   {% set type = env['allocation_type'] if 'allocation_type' in env else 'SPOT' %}
   {% set strategy = env['allocation_strategy'] if 'allocation_strategy' in env else 'SPOT_PRICE_CAPACITY_OPTIMIZED' %}

--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -123,10 +123,7 @@ Resources:
         AllocationStrategy: {{ strategy }}
         MinvCpus: 0
         MaxvCpus: !Ref MaxvCpus
-        InstanceTypes:
-        {% for instance_type in instance_types %}
-          - {{ instance_type }}
-        {% endfor %}
+        InstanceTypes: {{ instance_type }}
         ImageId: {{ ami_id }}
         Subnets: !Ref SubnetIds
         InstanceRole: !Ref InstanceProfile
@@ -146,7 +143,7 @@ Resources:
         - ComputeEnvironment: !Ref {{ name }}ComputeEnvironment
           Order: 1
       SchedulingPolicyArn: !Ref SchedulingPolicy
-  
+
   {% endfor %}
 
   TaskRole:

--- a/job_spec/INSAR_ISCE.yml
+++ b/job_spec/INSAR_ISCE.yml
@@ -93,7 +93,9 @@ INSAR_ISCE:
       cost: 1.0
   validators: []
   compute_environment:
-    name: 'Default'
+    name: 'Aria'
+    allocation_type: EC2
+    allocation_strategy: BEST_FIT_PROGRESSIVE
   tasks:
     - name: ''
       image: ghcr.io/access-cloud-based-insar/dockerizedtopsapp

--- a/job_spec/INSAR_ISCE.yml
+++ b/job_spec/INSAR_ISCE.yml
@@ -93,7 +93,7 @@ INSAR_ISCE:
       cost: 1.0
   validators: []
   compute_environment:
-    name: 'Aria'
+    name: 'InsarIsceAria'
     allocation_type: EC2
     allocation_strategy: BEST_FIT_PROGRESSIVE
   tasks:

--- a/job_spec/SRG_GSLC.yml
+++ b/job_spec/SRG_GSLC.yml
@@ -26,8 +26,7 @@ SRG_GSLC:
       cost: 1.0
   compute_environment:
     name: SrgGslc
-    instance_types:
-      - g6.2xlarge
+    instance_types: g6.2xlarge
     # Image ID for: /aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended/image_id
     ami_id: ami-0729c079aae647cb3
   tasks:


### PR DESCRIPTION
This causes any deployment that includes the `INSAR_ISCE.yml` job spec to use a dedicated `Aria` compute environment with on-demand instead of spot instances. Notably, this currently effects:
* hyp3-a19-jpl
* hyp3-a19-jpl-test
* hyp3-tibet-jpl
* hyp3-nisar-jpl

In these deployments, other job specs (ARIA_AUTORIFT.yml and ARIA_RAIDER.yml) will use the default compute environment with spot instances.