### PR TITLE
Test spot r6id[n] instances using 16 GB RAM for DockerizedTopsApp

### DIFF
--- a/.github/workflows/deploy-enterprise-test.yml
+++ b/.github/workflows/deploy-enterprise-test.yml
@@ -50,7 +50,7 @@ jobs:
               job_spec/ARIA_AUTORIFT.yml
               job_spec/ARIA_RAIDER.yml
               job_spec/INSAR_ISCE.yml
-            instance_types: c6id.xlarge,c6id.2xlarge,c6id.4xlarge,c6id.8xlarge
+            instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640
             required_surplus: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The `INSAR_ISCE.yml` job spec now reserved 16 GB memory for running the DockerizedTopsApp task.
-- The `ARIA-AUTORIFT.yml` job spec now specifies the optimum number of OpenMP threads.
+- The `ARIA_AUTORIFT.yml` job spec now specifies the optimum number of OpenMP threads.
 - The `hyp3-a19-jpl-test` deployment now uses spot `r6id[n]` instances in the default compute environment.
 
 ## [7.8.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.9.0]
+
+### Changed
+- The `INSAR_ISCE.yml` job spec now reserved 16 GB memory for running the DockerizedTopsApp task.
+- The `ARIA-AUTORIFT.yml` job spec now specifies the optimum number of OpenMP threads.
+- The `hyp3-a19-jpl-test` deployment now uses spot `r6id[n]` instances in the default compute environment.
+
 ## [7.8.1]
 
 ### Fixed

--- a/job_spec/ARIA_AUTORIFT.yml
+++ b/job_spec/ARIA_AUTORIFT.yml
@@ -49,7 +49,7 @@ AUTORIFT:
       image: ghcr.io/asfhyp3/hyp3-autorift
       command:
         - ++omp-num-threads
-        - '4'
+        - '4'  # 4 vCPUs per 32 GB RAM for the R instance family
         - --bucket
         - '!Ref Bucket'
         - --bucket-prefix

--- a/job_spec/ARIA_AUTORIFT.yml
+++ b/job_spec/ARIA_AUTORIFT.yml
@@ -48,6 +48,8 @@ AUTORIFT:
     - name: ''
       image: ghcr.io/asfhyp3/hyp3-autorift
       command:
+        - ++omp-num-threads
+        - '4'
         - --bucket
         - '!Ref Bucket'
         - --bucket-prefix

--- a/job_spec/INSAR_ISCE.yml
+++ b/job_spec/INSAR_ISCE.yml
@@ -92,6 +92,8 @@ INSAR_ISCE:
     DEFAULT:
       cost: 1.0
   validators: []
+  compute_environment:
+    name: 'Default'
   tasks:
     - name: ''
       image: ghcr.io/access-cloud-based-insar/dockerizedtopsapp

--- a/job_spec/INSAR_ISCE.yml
+++ b/job_spec/INSAR_ISCE.yml
@@ -92,16 +92,12 @@ INSAR_ISCE:
     DEFAULT:
       cost: 1.0
   validators: []
-  compute_environment:
-    name: 'InsarIsceAria'
-    allocation_type: EC2
-    allocation_strategy: BEST_FIT_PROGRESSIVE
   tasks:
     - name: ''
       image: ghcr.io/access-cloud-based-insar/dockerizedtopsapp
       command:
         - ++omp-num-threads
-        - '4'  # 2 for the m instance family; 4 for the c
+        - '2'  # 8 vCPUs per 16 GB RAM for the C instance family; 4 for M; 2 for R
         - --bucket
         - '!Ref Bucket'
         - --bucket-prefix
@@ -128,7 +124,7 @@ INSAR_ISCE:
         - Ref::unfiltered_coherence
       timeout: 21600
       vcpu: 1
-      memory: 7500
+      memory: 15500
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD


### PR DESCRIPTION
Note: the deployment changes are *only* reflected in the ARIA **test** deployment. The production deployments must be updated before a HyP3 release to have these changes in a production ARIA deployment.