### PR TITLE
Test on demand m6id[n] instances using 16 GB RAM for DockerizedTopsApp

### DIFF
--- a/.github/workflows/deploy-enterprise-test.yml
+++ b/.github/workflows/deploy-enterprise-test.yml
@@ -50,7 +50,7 @@ jobs:
               job_spec/ARIA_AUTORIFT.yml
               job_spec/ARIA_RAIDER.yml
               job_spec/INSAR_ISCE.yml
-            instance_types: c6id.xlarge,c6id.2xlarge,c6id.4xlarge,c6id.8xlarge
+            instance_types: m6id.xlarge,m6id.2xlarge,m6id.4xlarge,m6id.8xlarge,m6idn.xlarge,m6idn.2xlarge,m6idn.4xlarge,m6idn.8xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640
             required_surplus: 0

--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -45,7 +45,7 @@ jobs:
               job_spec/ARIA_AUTORIFT.yml
               job_spec/ARIA_RAIDER.yml
               job_spec/INSAR_ISCE.yml
-            instance_types: c6id.xlarge,c6id.2xlarge,c6id.4xlarge,c6id.8xlarge
+            instance_types: m6id.xlarge,m6id.2xlarge,m6id.4xlarge,m6id.8xlarge,m6idn.xlarge,m6idn.2xlarge,m6idn.4xlarge,m6idn.8xlarge
             default_max_vcpus: 4000  # Max: 13000
             expanded_max_vcpus: 4000  # Max: 13000
             required_surplus: 0
@@ -65,7 +65,7 @@ jobs:
               job_spec/ARIA_AUTORIFT.yml
               job_spec/ARIA_RAIDER.yml
               job_spec/INSAR_ISCE.yml
-            instance_types: c6id.xlarge,c6id.2xlarge,c6id.4xlarge,c6id.8xlarge
+            instance_types: m6id.xlarge,m6id.2xlarge,m6id.4xlarge,m6id.8xlarge,m6idn.xlarge,m6idn.2xlarge,m6idn.4xlarge,m6idn.8xlarge
             default_max_vcpus: 1000  # Max: 10316
             expanded_max_vcpus: 1000  # Max: 10316
             required_surplus: 0
@@ -85,7 +85,7 @@ jobs:
               job_spec/ARIA_AUTORIFT.yml
               job_spec/ARIA_RAIDER.yml
               job_spec/INSAR_ISCE.yml
-            instance_types: c6id.xlarge,c6id.2xlarge,c6id.4xlarge,c6id.8xlarge
+            instance_types: m6id.xlarge,m6id.2xlarge,m6id.4xlarge,m6id.8xlarge,m6idn.xlarge,m6idn.2xlarge,m6idn.4xlarge,m6idn.8xlarge
             default_max_vcpus: 1600  # Max 1652
             expanded_max_vcpus: 1600  # Max 1652
             required_surplus: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The `INSAR_ISCE.yml` job spec now reserved 16 GB memory for running the DockerizedTopsApp task.
+- The `ARIA-AUTORIFT.yml` job spec now specifies the optimum number of OpenMP threads and uses a dedicated compute environment with `r6id[n]` spot instances.
 - The `hyp3-a19-jpl-test` deployment now uses on-demand `m6id[n]` instances.
 
 ## [7.8.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The `INSAR_ISCE.yml` job spec now reserved 16 GB memory for running the DockerizedTopsApp task.
 - The `ARIA-AUTORIFT.yml` job spec now specifies the optimum number of OpenMP threads and uses a dedicated compute environment with `r6id[n]` spot instances.
-- The `hyp3-a19-jpl-test` deployment now uses on-demand `m6id[n]` instances.
+- The `hyp3-a19-jpl-test`, `hyp3-a19-jpl`, `hyp3-tibet-jpl`, and `hyp3-nisar-jpl` deployments now uses on-demand `m6id[n]` instances.
 
 ## [7.8.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The `INSAR_ISCE.yml` job spec now reserved 16 GB memory for running the DockerizedTopsApp task.
 - The `hyp3-a19-jpl-test` deployment now uses on-demand `m6id[n]` instances.
 
-
 ## [7.8.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.9.0]
+
+### Changed
+- The `INSAR_ISCE.yml` job spec now reserved 16 GB memory for running the DockerizedTopsApp task.
+- The `hyp3-a19-jpl-test` deployment now uses on-demand `m6id[n]` instances.
+
+
 ## [7.8.1]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The `INSAR_ISCE.yml` job spec now reserved 16 GB memory for running the DockerizedTopsApp task.
-- The `ARIA-AUTORIFT.yml` job spec now specifies the optimum number of OpenMP threads and uses a dedicated compute environment with `r6id[n]` spot instances.
+- The `ARIA_AUTORIFT.yml` job spec now specifies the optimum number of OpenMP threads and uses a dedicated compute environment with `r6id[n]` spot instances.
 - The `hyp3-a19-jpl-test`, `hyp3-a19-jpl`, `hyp3-tibet-jpl`, and `hyp3-nisar-jpl` deployments now uses on-demand `m6id[n]` instances.
 
 ## [7.8.1]

--- a/job_spec/ARIA_AUTORIFT.yml
+++ b/job_spec/ARIA_AUTORIFT.yml
@@ -43,11 +43,14 @@ AUTORIFT:
       cost: 1.0
   validators: []
   compute_environment:
-    name: 'Default'
+    name: 'AriaAutorift'
+    instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge
   tasks:
     - name: ''
       image: ghcr.io/asfhyp3/hyp3-autorift
       command:
+        - ++omp-num-threads
+        - '4'  # 4 vCPUs per 32 GB RAM for the R instance family
         - --bucket
         - '!Ref Bucket'
         - --bucket-prefix

--- a/job_spec/INSAR_ISCE.yml
+++ b/job_spec/INSAR_ISCE.yml
@@ -101,7 +101,7 @@ INSAR_ISCE:
       image: ghcr.io/access-cloud-based-insar/dockerizedtopsapp
       command:
         - ++omp-num-threads
-        - '4'  # 2 for the m instance family; 4 for the c
+        - '4'  # 8 vCPUs per 16 GB RAM for the C instance family; 4 for M; 2 for R
         - --bucket
         - '!Ref Bucket'
         - --bucket-prefix
@@ -128,7 +128,7 @@ INSAR_ISCE:
         - Ref::unfiltered_coherence
       timeout: 21600
       vcpu: 1
-      memory: 7500
+      memory: 15500
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD


### PR DESCRIPTION
Note: the deployment changes are only reflected in the ARIA **test** deployment. The production deployments must be updated before a HyP3 release to have these changes in a production ARIA deployment.