### PR TITLE
Diversify fleet for ITS_LIVE processing

### DIFF
--- a/.github/workflows/deploy-enterprise-test.yml
+++ b/.github/workflows/deploy-enterprise-test.yml
@@ -69,7 +69,7 @@ jobs:
             job_files: >-
               job_spec/AUTORIFT_ITS_LIVE.yml
               job_spec/S1_CORRECTION_ITS_LIVE.yml
-            instance_types: r6id.xlarge,r6idn.xlarge,r5dn.xlarge,r5d.xlarge
+            instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640
             required_surplus: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [7.9.0]
 
 ### Changed
-- The `INSAR_ISCE.yml` job spec now reserved 16 GB memory for running the DockerizedTopsApp task.
 - The `ARIA_AUTORIFT.yml` job spec now specifies the optimum number of OpenMP threads and uses a dedicated compute environment with `r6id[n]` spot instances.
-- The `hyp3-a19-jpl-test`, `hyp3-a19-jpl`, `hyp3-tibet-jpl`, and `hyp3-nisar-jpl` deployments now uses on-demand `m6id[n]` instances.
+- The `AUTORIFT_ITS_LIVE.yml` job spec now specifies the optimum number of OpenMP threads.
+- The `INSAR_ISCE.yml` job spec now reserved 16 GB memory for running the DockerizedTopsApp task.
+- The `hyp3-a19-jpl-test`, `hyp3-a19-jpl`, `hyp3-tibet-jpl`, and `hyp3-nisar-jpl` ARIA deployments now uses on-demand `m6id[n]` instances.
+- The `hyp3-its-live-test` deployment now uses a greater variety of `r6id[n]` instances.
 
 ## [7.8.1]
 

--- a/job_spec/AUTORIFT.yml
+++ b/job_spec/AUTORIFT.yml
@@ -46,7 +46,7 @@ AUTORIFT:
       image: ghcr.io/asfhyp3/hyp3-autorift
       command:
         - ++omp-num-threads
-        - '4'
+        - '4'  # 4 vCPUs per 32 GB RAM for the R instance family
         - --bucket
         - '!Ref Bucket'
         - --bucket-prefix

--- a/job_spec/AUTORIFT_ITS_LIVE.yml
+++ b/job_spec/AUTORIFT_ITS_LIVE.yml
@@ -57,6 +57,8 @@ AUTORIFT:
     - name: ''
       image: ghcr.io/asfhyp3/hyp3-autorift
       command:
+        - ++omp-num-threads
+        - '4'  # 4 vCPUs per 32 GB RAM for the R instance family
         - --bucket
         - '!Ref Bucket'
         - --bucket-prefix


### PR DESCRIPTION
We added the `++opt-num-thread` parameter to AUTORIFT jobs running in EDC and enterprise-test, but we never diversified the ITS_LIVE fleet.

This PR increases the number of instance types available to the ITS_LIVE test deployment and adds the `++opt-num-threads` parameter to the hyp3-autorift task.

Before releasing, we'll want to run a handful of jobs and make sure this works (golden test might be sufficient) and then monitor low latency jobs in production for a little while.