### PR TITLE
Add String Default for `bounds` for CloudFormation

### DIFF
--- a/job_spec/SRG_GSLC.yml
+++ b/job_spec/SRG_GSLC.yml
@@ -21,6 +21,7 @@ SRG_GSLC:
     bucket_prefix:
       default:  '""'
     bounds:
+      default:  '""'
       api_schema:
         type: array
         default: [0.0, 0.0, 0.0, 0.0]


### PR DESCRIPTION
The OpenAPI default `[0.0, 0.0, 0.0, 0.0]` is not valid when creating a step function, since it is not a string.  