### PR TITLE
Remove .cpu and .gpu Image Tags from the SRG job_specs

### DIFF
--- a/job_spec/SRG_GSLC.yml
+++ b/job_spec/SRG_GSLC.yml
@@ -43,7 +43,6 @@ SRG_GSLC:
   steps:
     - name: ''
       image: ghcr.io/asfhyp3/hyp3-srg
-      image_tag: latest.gpu
       command:
         - ++process
         - back_projection

--- a/job_spec/SRG_TIME_SERIES.yml
+++ b/job_spec/SRG_TIME_SERIES.yml
@@ -45,7 +45,6 @@ SRG_TIME_SERIES:
     - name: BACK_PROJECTION
       map: for granule in granules
       image: ghcr.io/asfhyp3/hyp3-srg
-      image_tag: test.gpu
       command:
         - ++process
         - back_projection
@@ -69,7 +68,6 @@ SRG_TIME_SERIES:
         - EARTHDATA_PASSWORD
     - name: ''
       image: ghcr.io/asfhyp3/hyp3-srg
-      image_tag: test.cpu
       command:
         - ++process
         - time_series


### PR DESCRIPTION
The GPU container gets the `test` and `latest` tags, and it should also support the CPU workflows. Removing these tags simplifies things.