### PR TITLE
upgrade to al2023 ami for edc deployments

### DIFF
--- a/.github/workflows/deploy-daac.yml
+++ b/.github/workflows/deploy-daac.yml
@@ -35,7 +35,7 @@ jobs:
             expanded_max_vcpus: 3000
             required_surplus: 2000
             security_environment: EDC
-            ami_id: image_id_ecs_amz2
+            ami_id: /ngap/amis/image_id_ecs_al2023_x86
             distribution_url: 'https://d3gm2hf49xd6jj.cloudfront.net'
 
           - environment: hyp3-edc-uat
@@ -58,7 +58,7 @@ jobs:
             expanded_max_vcpus: 3000
             required_surplus: 2000
             security_environment: EDC
-            ami_id: image_id_ecs_amz2
+            ami_id: /ngap/amis/image_id_ecs_al2023_x86
             distribution_url: 'https://d1riv60tezqha9.cloudfront.net'
 
     environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.0.1]
+
+### Changed
+- Upgrade to Amazon Linux 2023 AMI for Earthdata Cloud deployments
+
 ## [9.0.0]
 
 ### Changed


### PR DESCRIPTION
TODO once deployed to test:
- [ ] check that golden tests still run
- [ ] check whether the amount of memory available to tasks on the new AMI is any different than the old AMI