### PR TITLE
Remove spaces from Compute Env Instance Types

### DIFF
--- a/job_spec/config/compute_environments.yml
+++ b/job_spec/config/compute_environments.yml
@@ -5,7 +5,7 @@ compute_environments:
   #   allocation_type
   #   allocation_strategy
   SrgGslc:
-    instance_types: g6.2xlarge, g6.4xlarge, g5.2xlarge, g5.4xlarge, g5.8xlarge, g4dn.2xlarge
+    instance_types: g6.2xlarge,g6.4xlarge,g5.2xlarge,g5.4xlarge,g5.8xlarge,g6e.xlarge,g6e.2xlarge,g4dn.2xlarge,g4dn.4xlarge
     ami_id: ami-0729c079aae647cb3  # /aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended/image_id
   AriaAutorift:
     instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge


### PR DESCRIPTION
Adding spaces after the commas may cause the deployment to fail.