### PR TITLE
increase memory for OPERA_DISP_TMS geotiff jobs to 32GB

### DIFF
--- a/job_spec/OPERA_DISP_TMS.yml
+++ b/job_spec/OPERA_DISP_TMS.yml
@@ -69,7 +69,7 @@ OPERA_DISP_TMS:
       timeout: 1800 # 30 min
       compute_environment: Default
       vcpu: 1
-      memory: 15500
+      memory: 31500
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD


### PR DESCRIPTION
displacement geotiff jobs all succeeded with 16 GB, but some velocity geotiff jobs are still failing