### PR TITLE
Use on-demand compute environment for raider step of ARIA_S1_GUNW

### DIFF
--- a/job_spec/ARIA_S1_GUNW.yml
+++ b/job_spec/ARIA_S1_GUNW.yml
@@ -87,7 +87,7 @@ ARIA_S1_GUNW:
         - --weather-model
         - HRRR
       timeout: 10800  # 3 hr
-      compute_environment: Default
+      compute_environment: AriaS1Gunw
       vcpu: 1
       memory: 7500
       secrets:


### PR DESCRIPTION
Confirmed that timeout, vcpu, and memory are identical to `INSAR_ISCE`.