### PR TITLE
quote -z expressions to allow for whitespace in variable values

### DIFF
--- a/.github/actions/deploy-hyp3/action.yml
+++ b/.github/actions/deploy-hyp3/action.yml
@@ -90,19 +90,19 @@ runs:
       - name: Package and deploy
         shell: bash
         run: |
-          [ -z ${{ inputs.CLOUDFORMATION_ROLE_ARN }} ] && export ROLE_STATEMENT="" \
+          [ -z "${{ inputs.CLOUDFORMATION_ROLE_ARN }}" ] && export ROLE_STATEMENT="" \
             || export ROLE_STATEMENT="--role-arn ${{ inputs.CLOUDFORMATION_ROLE_ARN }}"
 
-          [ -z ${{ inputs.DOMAIN_NAME }} ] && export DOMAIN_NAME="" \
+          [ -z "${{ inputs.DOMAIN_NAME }}" ] && export DOMAIN_NAME="" \
             || export DOMAIN_NAME="DomainName='${{ inputs.DOMAIN_NAME }}'"
 
-          [ -z ${{ inputs.CERTIFICATE_ARN }} ] && export CERTIFICATE_ARN="" \
+          [ -z "${{ inputs.CERTIFICATE_ARN }}" ] && export CERTIFICATE_ARN="" \
             || export CERTIFICATE_ARN="CertificateArn='${{ inputs.CERTIFICATE_ARN }}'"
 
-          [ -z ${{ inputs.BUCKET_READ_PRINCIPALS }} ] && export BUCKET_READ_PRINCIPALS="" \
+          [ -z "${{ inputs.BUCKET_READ_PRINCIPALS }}" ] && export BUCKET_READ_PRINCIPALS="" \
             || export BUCKET_READ_PRINCIPALS="BucketReadPrincipals='${{ inputs.BUCKET_READ_PRINCIPALS }}'"
 
-          [ -z ${{ inputs.DISTRIBUTION_URL }} ] && export DISTRIBUTION_URL="" \
+          [ -z "${{ inputs.DISTRIBUTION_URL }}" ] && export DISTRIBUTION_URL="" \
             || export DISTRIBUTION_URL="DistributionUrl='${{ inputs.DISTRIBUTION_URL }}'"
 
           aws cloudformation package \


### PR DESCRIPTION
previous run logged the error `/home/runner/work/_temp/50aade27-04ff-45f0-b409-bf5eb1f1d9e6.sh: line 10: [: too many arguments`

Here's the rendered commands that were run, with `***` being the masked parameter value in the case of secrets (which contains spaces for BUCKET_READ_PRINCIPALS"

```
  [ -z  ] && export ROLE_STATEMENT="" \
    || export ROLE_STATEMENT="--role-arn "
  
  [ -z  ] && export DOMAIN_NAME="" \
    || export DOMAIN_NAME="DomainName=''"
  
  [ -z  ] && export CERTIFICATE_ARN="" \
    || export CERTIFICATE_ARN="CertificateArn=''"
  
  [ -z *** ] && export BUCKET_READ_PRINCIPALS="" \
    || export BUCKET_READ_PRINCIPALS="BucketReadPrincipals='***'"
  
  [ -z https://d1riv60tezqha9.cloudfront.net/ ] && export DISTRIBUTION_URL="" \
    || export DISTRIBUTION_URL="DistributionUrl='https://d1riv60tezqha9.cloudfront.net/'"
```