### PR TITLE
Tweaks for `validate_job_spec` and `test_validate_job_spec`

### DIFF
--- a/apps/render_cf.py
+++ b/apps/render_cf.py
@@ -234,11 +234,6 @@ def validate_job_spec(job_type: str, job_spec: dict) -> None:
         raise ValueError(f"{job_type} contains reserved parameter name 'job_id'")
 
     expected_param_fields = ['api_schema']
-
-    for step in job_spec['steps']:
-        if not step['image'].islower():
-            raise ValueError(f'{job_type} has image {step["image"]} and docker requires the image to be all lowercase')
-
     for param_name, param_dict in job_spec['parameters'].items():
         actual_param_fields = sorted(param_dict.keys())
         if actual_param_fields != expected_param_fields:
@@ -246,6 +241,10 @@ def validate_job_spec(job_type: str, job_spec: dict) -> None:
                 f"parameter '{param_name}' for {job_type} has fields {actual_param_fields} "
                 f'but should have {expected_param_fields}'
             )
+
+    for step in job_spec['steps']:
+        if not step['image'].islower():
+            raise ValueError(f'{job_type} has image {step["image"]} but docker requires the image to be all lowercase')
 
 
 def main():

--- a/tests/test_render_cf.py
+++ b/tests/test_render_cf.py
@@ -121,7 +121,7 @@ def test_validate_job_spec():
         'validators': [],
         'steps': [
             {
-                'image': 'reop/hyp3-gamma',
+                'image': 'repo/hyp3-gamma',
             },
             {
                 'image': 'repo/water-map-equal-percent-solution',
@@ -131,38 +131,54 @@ def test_validate_job_spec():
 
     render_cf.validate_job_spec(job_type, job_spec)
 
-    required_param_error = r'.*has fields.*but should have.*'
-    with pytest.raises(ValueError, match=required_param_error):
-        missing = {**job_spec}
-        del missing['required_parameters']
+    fields_error_message = r'^FOO has fields .* but should have .*'
+    with pytest.raises(ValueError, match=fields_error_message):
+        job_spec_missing_field = {**job_spec}
+        del job_spec_missing_field['required_parameters']
 
-        render_cf.validate_job_spec(job_type, missing)
+        render_cf.validate_job_spec(job_type, job_spec_missing_field)
 
-    with pytest.raises(ValueError, match=required_param_error):
-        missing = {**job_spec}
-        del missing['parameters']
+    with pytest.raises(ValueError, match=fields_error_message):
+        job_spec_missing_field = {**job_spec}
+        del job_spec_missing_field['parameters']
 
-        render_cf.validate_job_spec(job_type, missing)
+        render_cf.validate_job_spec(job_type, job_spec_missing_field)
 
-    with pytest.raises(ValueError, match=required_param_error):
-        missing = {**job_spec}
-        del missing['cost_profiles']
+    with pytest.raises(ValueError, match=fields_error_message):
+        job_spec_missing_field = {**job_spec}
+        del job_spec_missing_field['cost_profiles']
 
-        render_cf.validate_job_spec(job_type, missing)
+        render_cf.validate_job_spec(job_type, job_spec_missing_field)
 
-    with pytest.raises(ValueError, match=required_param_error):
-        missing = {**job_spec}
-        del missing['validators']
+    with pytest.raises(ValueError, match=fields_error_message):
+        job_spec_missing_field = {**job_spec}
+        del job_spec_missing_field['validators']
 
-        render_cf.validate_job_spec(job_type, missing)
+        render_cf.validate_job_spec(job_type, job_spec_missing_field)
 
-    with pytest.raises(ValueError, match=required_param_error):
-        missing = {**job_spec}
-        del missing['steps']
+    with pytest.raises(ValueError, match=fields_error_message):
+        job_spec_missing_field = {**job_spec}
+        del job_spec_missing_field['steps']
 
-        render_cf.validate_job_spec(job_type, missing)
+        render_cf.validate_job_spec(job_type, job_spec_missing_field)
 
-    uppercase_image_job_spec = {
+    with pytest.raises(ValueError, match=fields_error_message):
+        job_spec_bad_field = {**job_spec, 'bad_field': ''}
+        render_cf.validate_job_spec(job_type, job_spec_bad_field)
+
+    with pytest.raises(ValueError, match=r"^FOO contains reserved parameter name 'job_id'$"):
+        job_spec_with_job_id_param = {**job_spec, 'parameters': {'job_id': {'api_schema': {}}}}
+        render_cf.validate_job_spec(job_type, job_spec_with_job_id_param)
+
+    with pytest.raises(ValueError, match="^parameter 'foo' for FOO has fields .* but should have .*"):
+        job_spec_missing_param_field = {**job_spec, 'parameters': {'foo': {}}}
+        render_cf.validate_job_spec(job_type, job_spec_missing_param_field)
+
+    with pytest.raises(ValueError, match=r"^parameter 'foo' for FOO has fields .* but should have .*"):
+        job_spec_bad_param_field = {**job_spec, 'parameters': {'foo': {'api_schema': {}, 'bad_field': ''}}}
+        render_cf.validate_job_spec(job_type, job_spec_bad_param_field)
+
+    job_spec_uppercase_image = {
         **job_spec,
         'steps': [
             {
@@ -170,11 +186,7 @@ def test_validate_job_spec():
             },
         ],
     }
-
-    with pytest.raises(ValueError, match=r'.*and docker requires the image to be all lowercase.*'):
-        render_cf.validate_job_spec(job_type, uppercase_image_job_spec)
-
-    job_spec_with_job_id_param = {**job_spec, 'parameters': {'job_id': ''}}
-
-    with pytest.raises(ValueError, match=r'.*reserved parameter name.*'):
-        render_cf.validate_job_spec(job_type, job_spec_with_job_id_param)
+    with pytest.raises(
+        ValueError, match=r'^FOO has image repo/HyP3-gamma but docker requires the image to be all lowercase.*'
+    ):
+        render_cf.validate_job_spec(job_type, job_spec_uppercase_image)

--- a/tests/test_render_cf.py
+++ b/tests/test_render_cf.py
@@ -170,11 +170,12 @@ def test_validate_job_spec():
         job_spec_with_job_id_param = {**job_spec, 'parameters': {'job_id': {'api_schema': {}}}}
         render_cf.validate_job_spec(job_type, job_spec_with_job_id_param)
 
-    with pytest.raises(ValueError, match="^parameter 'foo' for FOO has fields .* but should have .*"):
+    param_fields_error_message = r"^parameter 'foo' for FOO has fields .* but should have .*"
+    with pytest.raises(ValueError, match=param_fields_error_message):
         job_spec_missing_param_field = {**job_spec, 'parameters': {'foo': {}}}
         render_cf.validate_job_spec(job_type, job_spec_missing_param_field)
 
-    with pytest.raises(ValueError, match=r"^parameter 'foo' for FOO has fields .* but should have .*"):
+    with pytest.raises(ValueError, match=param_fields_error_message):
         job_spec_bad_param_field = {**job_spec, 'parameters': {'foo': {'api_schema': {}, 'bad_field': ''}}}
         render_cf.validate_job_spec(job_type, job_spec_bad_param_field)
 


### PR DESCRIPTION
- Move image name check to end of `validate_job_spec` function, since I think it's more clear to validate job steps *after* validating the top-level fields and params
- Renamed some variables in `test_validate_job_spec`, e.g. `missing` -> `job_spec_missing_field` and `required_param_error` -> `fields_error_message`
- Added four more test cases
- Re-ordered the test cases to match the order of the function code
- Improved some of the expected error message patterns in the tests