### PR TITLE
Fully separate single- and multi-burst InSAR job specs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [9.5.3]
 
 ### Fixed
-- When the API returns an error for a `INSAR_ISCE_BURST` job because the reference and secondary scenes have different polarizations, the error message now always includes the requested polarizations in the same order as the requested scenes (previously, the order of the polarizations was not guaranteed). For example, passing a reference scene with `VV` polarization and a secondary scene with `HH` polarization results in the error message `The requested scenes need to have the same polarization, got: VV, HH`.
-- The API validation behavior for the `INSAR_ISCE_MULTI_BURST` job type is now more closely aligned with that of the underlying [HyP3 ISCE2 v2.1.4](https://github.com/ASFHyP3/hyp3-isce2/releases/tag/v2.1.4) container. Currently, this only affects the `hyp3-multi-burst-sandbox` deployment.
+- When the API returns an error for an `INSAR_ISCE_BURST` job because the reference and secondary scenes have different polarizations, the error message now always includes the requested polarizations in the same order as the requested scenes (previously, the order of the polarizations was not guaranteed). For example, passing a reference scene with `VV` polarization and a secondary scene with `HH` polarization results in the error message `The requested scenes need to have the same polarization, got: VV, HH`.
+- The API validation behavior for the `INSAR_ISCE_MULTI_BURST` job type is now more closely aligned with that of the underlying [HyP3 ISCE2](https://github.com/ASFHyP3/hyp3-isce2/) container. Currently, this only affects the `hyp3-multi-burst-sandbox` deployment.
 - The reference and secondary scene names are now validated *before* DEM coverage for both `INSAR_ISCE_BURST` and `INSAR_ISCE_MULTI_BURST`.
 
 ## [9.5.2]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [9.5.3]
 
 ### Fixed
-- When the API returns an error for an `INSAR_ISCE_BURST` job because the reference and secondary scenes have different polarizations, the error message now always includes the requested polarizations in the same order as the requested scenes (previously, the order of the polarizations was not guaranteed). For example, passing a reference scene with `VV` polarization and a secondary scene with `HH` polarization results in the error message: `The requested scenes need to have the same polarization, got: VV, HH`
+- When the API returns an error for an `INSAR_ISCE_BURST` job because the requested scenes have different polarizations, the error message now always includes the requested polarizations in the same order as the requested scenes (previously, the order of the polarizations was not guaranteed). For example, passing two scenes with `VV` and `HH` polarizations, respectively, results in the error message: `The requested scenes need to have the same polarization, got: VV, HH`
 - The API validation behavior for the `INSAR_ISCE_MULTI_BURST` job type is now more closely aligned with the CLI validation for the underlying [HyP3 ISCE2](https://github.com/ASFHyP3/hyp3-isce2/) container. Currently, this only affects the `hyp3-multi-burst-sandbox` deployment.
-- The reference and secondary scene names are now validated before DEM coverage for both `INSAR_ISCE_BURST` and `INSAR_ISCE_MULTI_BURST`.
+- The requested scene names are now validated before DEM coverage for both `INSAR_ISCE_BURST` and `INSAR_ISCE_MULTI_BURST`.
 
 ## [9.5.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [9.5.3]
 
 ### Fixed
-- When the API returns an error for an `INSAR_ISCE_BURST` job because the reference and secondary scenes have different polarizations, the error message now always includes the requested polarizations in the same order as the requested scenes (previously, the order of the polarizations was not guaranteed). For example, passing a reference scene with `VV` polarization and a secondary scene with `HH` polarization results in the error message `The requested scenes need to have the same polarization, got: VV, HH`.
-- The API validation behavior for the `INSAR_ISCE_MULTI_BURST` job type is now more closely aligned with that of the underlying [HyP3 ISCE2](https://github.com/ASFHyP3/hyp3-isce2/) container. Currently, this only affects the `hyp3-multi-burst-sandbox` deployment.
-- The reference and secondary scene names are now validated *before* DEM coverage for both `INSAR_ISCE_BURST` and `INSAR_ISCE_MULTI_BURST`.
+- When the API returns an error for an `INSAR_ISCE_BURST` job because the reference and secondary scenes have different polarizations, the error message now always includes the requested polarizations in the same order as the requested scenes (previously, the order of the polarizations was not guaranteed). For example, passing a reference scene with `VV` polarization and a secondary scene with `HH` polarization results in the error message: `The requested scenes need to have the same polarization, got: VV, HH`
+- The API validation behavior for the `INSAR_ISCE_MULTI_BURST` job type is now more closely aligned with the CLI validation for the underlying [HyP3 ISCE2](https://github.com/ASFHyP3/hyp3-isce2/) container. Currently, this only affects the `hyp3-multi-burst-sandbox` deployment.
+- The reference and secondary scene names are now validated before DEM coverage for both `INSAR_ISCE_BURST` and `INSAR_ISCE_MULTI_BURST`.
 
 ## [9.5.2]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.5.3]
+
+### Fixed
+- When the API returns an error for a `INSAR_ISCE_BURST` job because the reference and secondary scenes have different polarizations, the error message now always includes the requested polarizations in the same order as the requested scenes (previously, the order of the polarizations was not guaranteed). For example, passing a reference scene with `VV` polarization and a secondary scene with `HH` polarization results in the error message `The requested scenes need to have the same polarization, got: VV, HH`.
+- The API validation behavior for the `INSAR_ISCE_MULTI_BURST` job type is now more closely aligned with that of the underlying [HyP3 ISCE2 v2.1.4](https://github.com/ASFHyP3/hyp3-isce2/releases/tag/v2.1.4) container. Currently, this only affects the `hyp3-multi-burst-sandbox` deployment.
+- The reference and secondary scene names are now validated *before* DEM coverage for both `INSAR_ISCE_BURST` and `INSAR_ISCE_MULTI_BURST`.
+
 ## [9.5.2]
 
-## Added
+### Added
 - The `ARIA_S1_GUNW` job type is now available in the hyp3-edc-prod deployment.
 
-## Changed
+### Changed
 - OPERA-DIST-S1 runtime increases from 3 to 6 hours for experimentation.
 - Updated the DIST-S1 entrypoint of the image and changed the job spec accordingly.
 
-## Fixed
+### Fixed
 - OPERA-DIST-S1 job spec had wrong CLI interface (e.g. --n-lookbacks should be --n_lookbacks).
 
 ## [9.5.1]

--- a/apps/api/src/hyp3_api/handlers.py
+++ b/apps/api/src/hyp3_api/handlers.py
@@ -6,6 +6,7 @@ from flask import Response, abort, jsonify, request
 import dynamo
 from dynamo.exceptions import AccessCodeError, InsufficientCreditsError, UnexpectedApplicationStatusError
 from hyp3_api import util
+from hyp3_api.multi_burst_validation import MultiBurstValidationError
 from hyp3_api.validation import BoundsValidationError, GranuleValidationError, validate_jobs
 
 
@@ -23,7 +24,7 @@ def post_jobs(body: dict, user: str) -> dict:
         validate_jobs(body['jobs'])
     except requests.HTTPError as e:
         print(f'WARN: CMR search failed: {e}')
-    except (BoundsValidationError, GranuleValidationError) as e:
+    except (BoundsValidationError, GranuleValidationError, MultiBurstValidationError) as e:
         abort(problem_format(400, str(e)))
 
     try:

--- a/apps/api/src/hyp3_api/multi_burst_validation.py
+++ b/apps/api/src/hyp3_api/multi_burst_validation.py
@@ -1,0 +1,69 @@
+from datetime import datetime, timedelta
+
+
+class MultiBurstValidationError(Exception):
+    pass
+
+
+def _num_swath_pol(scene: str) -> str:
+    parts = scene.split('_')
+    num = parts[1]
+    swath = parts[2]
+    pol = parts[4]
+    return '_'.join([num, swath, pol])
+
+
+def _burst_datetime(scene: str) -> datetime:
+    datetime_str = scene.split('_')[3]
+    return datetime.strptime(datetime_str, '%Y%m%dT%H%M%S')
+
+
+def validate_bursts(reference: list[str], secondary: list[str]) -> None:
+    """Check whether the reference and secondary bursts are valid.
+
+    Args:
+        reference: Reference granule(s)
+        secondary: Secondary granule(s)
+    """
+    # **WARNING:** Changes to this function must be kept in sync with the hyp3-isce2 function
+    # until https://github.com/ASFHyP3/hyp3-lib/issues/340 is done
+
+    if len(reference) < 1 or len(secondary) < 1:
+        raise MultiBurstValidationError('Must include at least 1 reference scene and 1 secondary scene')
+
+    if len(reference) != len(secondary):
+        raise MultiBurstValidationError(
+            f'Must provide the same number of reference and secondary scenes, got {len(reference)} reference and {len(secondary)} secondary'
+        )
+
+    for ref, sec in zip(reference, secondary):
+        if _num_swath_pol(ref) != _num_swath_pol(sec):
+            raise MultiBurstValidationError(
+                f'Number + swath + polarization identifier does not match for reference scene {ref} and secondary scene {sec}'
+            )
+
+    pols = list(set(g.split('_')[4] for g in reference))
+
+    if len(pols) > 1:
+        raise MultiBurstValidationError(
+            f'Scenes must have the same polarization. Polarizations present: {", ".join(sorted(pols))}'
+        )
+
+    if pols[0] not in ['VV', 'HH']:
+        raise MultiBurstValidationError(f'{pols[0]} polarization is not currently supported, only VV and HH')
+
+    ref_datetimes = sorted(_burst_datetime(g) for g in reference)
+    sec_datetimes = sorted(_burst_datetime(g) for g in secondary)
+
+    if ref_datetimes[-1] - ref_datetimes[0] > timedelta(minutes=2):
+        raise MultiBurstValidationError(
+            'Reference scenes must fall within a 2-minute window in order to ensure they were collected during the same pass'
+        )
+
+    if sec_datetimes[-1] - sec_datetimes[0] > timedelta(minutes=2):
+        raise MultiBurstValidationError(
+            'Secondary scenes must fall within a 2-minute window in order to ensure they were collected during the same pass'
+        )
+
+    if ref_datetimes[-1] >= sec_datetimes[0]:
+        raise MultiBurstValidationError('Reference scenes must be older than secondary scenes')

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -83,6 +83,7 @@ def check_dem_coverage(_, granule_metadata: list[dict]) -> None:
 
 
 def check_same_burst_ids(job: dict, _) -> None:
+    # TODO: allow for granules param or create a single-burst version of this validator
     refs = job['job_parameters']['reference']
     secs = job['job_parameters']['secondary']
     ref_ids = ['_'.join(ref.split('_')[1:3]) for ref in refs]
@@ -193,16 +194,6 @@ def check_same_relative_orbits(_, granule_metadata: list[dict]) -> None:
             )
 
 
-def _convert_single_burst_jobs(jobs: list[dict]) -> list[dict]:
-    jobs = deepcopy(jobs)
-    for job in jobs:
-        if job['job_type'] == 'INSAR_ISCE_BURST':
-            job_parameters = job['job_parameters']
-            ref, sec = job_parameters.pop('granules')
-            job_parameters['reference'], job_parameters['secondary'] = [ref], [sec]
-    return jobs
-
-
 def check_bounding_box_size(job: dict, _, max_bounds_area: float = 4.5) -> None:
     bounds = job['job_parameters']['bounds']
 
@@ -215,11 +206,8 @@ def check_bounding_box_size(job: dict, _, max_bounds_area: float = 4.5) -> None:
 
 
 def validate_jobs(jobs: list[dict]) -> None:
-    jobs = _convert_single_burst_jobs(jobs)
-
     granules = get_granules(jobs)
     granule_metadata = _get_cmr_metadata(granules)
-
     _make_sure_granules_exist(granules, granule_metadata)
     for job in jobs:
         for validator_name in JOB_VALIDATION_MAP[job['job_type']]:

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -7,7 +7,7 @@ import requests
 import yaml
 from shapely.geometry import MultiPolygon, Polygon, shape
 
-from hyp3_api import CMR_URL
+from hyp3_api import CMR_URL, multi_burst_validation
 from hyp3_api.util import get_granules
 
 
@@ -79,6 +79,11 @@ def check_dem_coverage(_, granule_metadata: list[dict]) -> None:
     bad_granules = [g['name'] for g in granule_metadata if not _has_sufficient_coverage(g['polygon'])]
     if bad_granules:
         raise GranuleValidationError(f'Some requested scenes do not have DEM coverage: {", ".join(bad_granules)}')
+
+
+def check_multi_burst_pairs(job: dict, _) -> None:
+    job_parameters = job['job_parameters']
+    multi_burst_validation.validate_bursts(job_parameters['reference'], job_parameters['secondary'])
 
 
 def check_single_burst_pair(job: dict, _) -> None:

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -88,7 +88,7 @@ def check_single_burst_pair(job: dict, _) -> None:
     granule2_id = '_'.join(granule2.split('_')[1:3])
 
     if granule1_id != granule2_id:
-        raise GranuleValidationError(f'Burst IDs do not match for {granule1_id} and {granule2_id}.')
+        raise GranuleValidationError(f'Burst IDs do not match for {granule1} and {granule2}.')
 
     granule1_pol = granule1.split('_')[4]
     granule2_pol = granule2.split('_')[4]
@@ -98,9 +98,7 @@ def check_single_burst_pair(job: dict, _) -> None:
             f'The requested scenes need to have the same polarization, got: {", ".join([granule1_pol, granule2_pol])}'
         )
     if granule1_pol not in ['VV', 'HH']:
-        raise GranuleValidationError(
-            f'Only VV and HH polarizations are currently supported, got: {granule1_pol}'
-        )
+        raise GranuleValidationError(f'Only VV and HH polarizations are currently supported, got: {granule1_pol}')
 
 
 def check_not_antimeridian(_, granule_metadata: list[dict]) -> None:

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -1,7 +1,6 @@
 import json
 import sys
 from collections.abc import Iterable
-from copy import deepcopy
 from pathlib import Path
 
 import requests

--- a/job_spec/INSAR_ISCE_BURST.yml
+++ b/job_spec/INSAR_ISCE_BURST.yml
@@ -37,10 +37,9 @@ INSAR_ISCE_BURST:
     DEFAULT:
       cost: 1.0
   validators:
+    - check_single_burst_pair
     - check_dem_coverage
-    - check_valid_polarizations
-    - check_same_burst_ids
-    - check_not_antimeridian 
+    - check_not_antimeridian
   steps:
     - name: ''
       image: ghcr.io/asfhyp3/hyp3-isce2

--- a/job_spec/INSAR_ISCE_MULTI_BURST.yml
+++ b/job_spec/INSAR_ISCE_MULTI_BURST.yml
@@ -52,7 +52,7 @@ INSAR_ISCE_MULTI_BURST:
     DEFAULT:
       cost: 1.0
   validators:
-    # TODO update
+    - check_multi_burst_pairs
     - check_dem_coverage
     - check_not_antimeridian
   steps:

--- a/job_spec/INSAR_ISCE_MULTI_BURST.yml
+++ b/job_spec/INSAR_ISCE_MULTI_BURST.yml
@@ -52,9 +52,8 @@ INSAR_ISCE_MULTI_BURST:
     DEFAULT:
       cost: 1.0
   validators:
+    # TODO update
     - check_dem_coverage
-    - check_valid_polarizations
-    - check_same_burst_ids
     - check_not_antimeridian
   steps:
     - name: ''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-requires-python = "==3.13"
+requires-python = "==3.13.*"
 
 [tool.ruff]
 line-length = 120

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -101,200 +101,60 @@ def test_check_dem_coverage():
     assert 'covered1' not in str(e)
 
 
-def test_check_same_burst_ids():
-    valid_jobs = [
-        {
-            'job_parameters': {
-                'reference': ['S1_136231_IW2_20200604T022312_VV_7C85-BURST'],
-                'secondary': ['S1_136231_IW2_20200616T022313_VV_5D11-BURST'],
-            }
-        },
-        {
-            'job_parameters': {
-                'reference': [
-                    'S1_136231_IW2_20200604T022312_VV_7C85-BURST',
-                    'S1_136232_IW2_20200616T022315_VV_5D11-BURST',
-                ],
-                'secondary': [
-                    'S1_136231_IW2_20200616T022313_VV_5411-BURST',
-                    'S1_136232_IW2_20200616T022345_VV_5D13-BURST',
-                ],
-            }
-        },
-        {
-            'job_parameters': {
-                'reference': [
-                    'S1_136231_IW2_20200604T022312_VV_7C85-BURST',
-                    'S1_136231_IW3_20200616T022315_VV_5D11-BURST',
-                ],
-                'secondary': [
-                    'S1_136231_IW2_20200616T022313_VV_5411-BURST',
-                    'S1_136231_IW3_20200616T022345_VV_5D13-BURST',
-                ],
-            }
-        },
-    ]
-    invalid_job_different_lengths = {
+def test_check_single_burst_pair():
+    valid_job = {
         'job_parameters': {
-            'reference': ['S1_136231_IW2_20200604T022312_VV_7C85-BURST'],
-            'secondary': ['S1_136232_IW2_20200616T022313_VV_5D11-BURST', 'S1_136233_IW2_20200616T022313_VV_5D11-BURST'],
+            'granules': [
+                'S1_136231_IW2_20200604T022312_VV_7C85-BURST',
+                'S1_136231_IW2_20200616T022313_VV_5D11-BURST',
+            ]
         }
     }
-    invalid_jobs_not_matching = [
-        {
-            'job_parameters': {
-                'reference': ['S1_136231_IW2_20200604T022312_VV_7C85-BURST'],
-                'secondary': ['S1_136232_IW2_20200616T022313_VV_5D11-BURST'],
-            }
-        },
-        {
-            'job_parameters': {
-                'reference': [
-                    'S1_136231_IW2_20200604T022312_VV_7C85-BURST',
-                    'S1_136232_IW2_20200604T123455_VV_ABC5-BURST',
-                ],
-                'secondary': [
-                    'S1_136231_IW2_20200617T022313_VV_5D11-BURST',
-                    'S1_136233_IW2_20200617T123213_VV_5E13-BURST',
-                ],
-            }
-        },
-        {
-            'job_parameters': {
-                'reference': [
-                    'S1_136232_IW2_20200604T022312_VV_7C85-BURST',
-                    'S1_136231_IW2_20200604T123455_VV_ABC5-BURST',
-                ],
-                'secondary': [
-                    'S1_136231_IW2_20200617T022313_VV_5D11-BURST',
-                    'S1_136233_IW2_20200617T123213_VV_5E13-BURST',
-                ],
-            }
-        },
-    ]
-    invalid_jobs_duplicate = [
-        {
-            'job_parameters': {
-                'reference': [
-                    'S1_136231_IW2_20200604T022312_VV_7C85-BURST',
-                    'S1_136231_IW2_20200604T123455_VV_ABC5-BURST',
-                ],
-                'secondary': [
-                    'S1_136231_IW2_20200617T022313_VV_5D11-BURST',
-                    'S1_136231_IW2_20200617T123213_VV_5E13-BURST',
-                ],
-            }
-        },
-        {
-            'job_parameters': {
-                'reference': [
-                    'S1_136231_IW2_20200604T022312_VV_7C85-BURST',
-                    'S1_136231_IW2_20200604T123455_VV_ABC5-BURST',
-                    'S1_136232_IW2_20200604T125455_VV_ABC6-BURST',
-                ],
-                'secondary': [
-                    'S1_136231_IW2_20200617T022313_VV_5D11-BURST',
-                    'S1_136231_IW2_20200617T123213_VV_5E13-BURST',
-                    'S1_136232_IW2_20200604T123475_VV_ABC7-BURST',
-                ],
-            }
-        },
-    ]
-    for valid_job in valid_jobs:
-        validation.check_same_burst_ids(valid_job, {})
-    with raises(validation.GranuleValidationError, match=r'.*Number of reference and secondary scenes must match*'):
-        validation.check_same_burst_ids(invalid_job_different_lengths, {})
-    for invalid_job in invalid_jobs_not_matching:
-        with raises(validation.GranuleValidationError, match=r'.*Burst IDs do not match*'):
-            validation.check_same_burst_ids(invalid_job, {})
-    for invalid_job in invalid_jobs_duplicate:
-        with raises(validation.GranuleValidationError, match=r'.*The requested scenes have more than 1 pair*'):
-            validation.check_same_burst_ids(invalid_job, {})
+    validation.check_single_burst_pair(valid_job, None)
 
+    invalid_job_different_number = {
+        'job_parameters': {
+            'granules': [
+                'S1_136231_IW2_20200604T022312_VV_7C85-BURST',
+                'S1_136232_IW2_20200616T022313_VV_5D11-BURST',
+            ]
+        }
+    }
+    with raises(validation.GranuleValidationError, match=r'^Burst IDs do not match for .*'):
+        validation.check_single_burst_pair(invalid_job_different_number, None)
 
-def test_check_valid_polarizations():
-    valid_jobs = [
-        {
-            'job_parameters': {
-                'reference': ['S1_136231_IW2_20200604T022312_VV_7C85-BURST'],
-                'secondary': ['S1_136231_IW2_20200616T022313_VV_5D11-BURST'],
-            }
-        },
-        {
-            'job_parameters': {
-                'reference': [
-                    'S1_136231_IW2_20200604T022312_HH_7C85-BURST',
-                    'S1_136232_IW2_20200616T022315_HH_5D11-BURST',
-                ],
-                'secondary': [
-                    'S1_136231_IW2_20200616T022313_HH_5411-BURST',
-                    'S1_136232_IW2_20200616T022345_HH_5D13-BURST',
-                ],
-            }
-        },
-    ]
-    invalid_jobs_not_matching = [
-        {
-            'job_parameters': {
-                'reference': ['S1_136231_IW2_20200604T022312_VV_7C85-BURST'],
-                'secondary': ['S1_136232_IW2_20200616T022313_HH_5D11-BURST'],
-            }
-        },
-        {
-            'job_parameters': {
-                'reference': [
-                    'S1_136231_IW2_20200604T022312_VV_7C85-BURST',
-                    'S1_136232_IW2_20200604T123455_VV_ABC5-BURST',
-                ],
-                'secondary': [
-                    'S1_136231_IW2_20200617T022313_VV_5D11-BURST',
-                    'S1_136233_IW2_20200617T123213_HH_5E13-BURST',
-                ],
-            }
-        },
-        {
-            'job_parameters': {
-                'reference': [
-                    'S1_136232_IW2_20200604T022312_VV_7C85-BURST',
-                    'S1_136231_IW2_20200604T123455_HH_ABC5-BURST',
-                ],
-                'secondary': [
-                    'S1_136231_IW2_20200617T022313_VV_5D11-BURST',
-                    'S1_136233_IW2_20200617T123213_HH_5E13-BURST',
-                ],
-            }
-        },
-    ]
-    invalid_jobs_unsupported = [
-        {
-            'job_parameters': {
-                'reference': ['S1_136231_IW2_20200604T022312_VH_7C85-BURST'],
-                'secondary': ['S1_136231_IW2_20200617T022313_VH_5D11-BURST'],
-            }
-        },
-        {
-            'job_parameters': {
-                'reference': [
-                    'S1_136231_IW2_20200604T022312_HV_7C85-BURST',
-                    'S1_136231_IW2_20200604T123455_HV_ABC5-BURST',
-                    'S1_136232_IW2_20200604T125455_HV_ABC6-BURST',
-                ],
-                'secondary': [
-                    'S1_136231_IW2_20200617T022313_HV_5D11-BURST',
-                    'S1_136231_IW2_20200617T123213_HV_5E13-BURST',
-                    'S1_136232_IW2_20200604T123475_HV_ABC7-BURST',
-                ],
-            }
-        },
-    ]
-    for valid_job in valid_jobs:
-        validation.check_valid_polarizations(valid_job, {})
-    for invalid_job in invalid_jobs_not_matching:
-        with raises(validation.GranuleValidationError, match=r'.*need to have the same polarization*'):
-            validation.check_valid_polarizations(invalid_job, {})
-    for invalid_job in invalid_jobs_unsupported:
-        with raises(validation.GranuleValidationError, match=r'.*currently supported*'):
-            validation.check_valid_polarizations(invalid_job, {})
+    invalid_job_different_swath = {
+        'job_parameters': {
+            'granules': [
+                'S1_136231_IW2_20200604T022312_VV_7C85-BURST',
+                'S1_136231_IW3_20200616T022313_VV_5D11-BURST',
+            ]
+        }
+    }
+    with raises(validation.GranuleValidationError, match=r'^Burst IDs do not match for .*'):
+        validation.check_single_burst_pair(invalid_job_different_swath, None)
+
+    invalid_job_different_pol = {
+        'job_parameters': {
+            'granules': [
+                'S1_136231_IW2_20200604T022312_VV_7C85-BURST',
+                'S1_136231_IW2_20200616T022313_HH_5D11-BURST',
+            ]
+        }
+    }
+    with raises(validation.GranuleValidationError, match=r'^The requested scenes need to have the same polarization, got: VV, HH$'):
+        validation.check_single_burst_pair(invalid_job_different_pol, None)
+
+    invalid_job_unsupported_pol = {
+        'job_parameters': {
+            'granules': [
+                'S1_136231_IW2_20200604T022312_VH_7C85-BURST',
+                'S1_136231_IW2_20200616T022313_VH_5D11-BURST',
+            ]
+        }
+    }
+    with raises(validation.GranuleValidationError, match=r'^Only VV and HH polarizations are currently supported, got: VH$'):
+        validation.check_single_burst_pair(invalid_job_unsupported_pol, None)
 
 
 def test_make_sure_granules_exist():

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -122,7 +122,7 @@ def test_check_single_burst_pair():
     }
     with raises(
         validation.GranuleValidationError,
-        match='Burst IDs do not match for S1_136231_IW2_20200604T022312_VV_7C85-BURST and S1_136232_IW2_20200616T022313_VV_5D11-BURST.',
+        match=r'^Burst IDs do not match for S1_136231_IW2_20200604T022312_VV_7C85-BURST and S1_136232_IW2_20200616T022313_VV_5D11-BURST\.$',
     ):
         validation.check_single_burst_pair(invalid_job_different_number, None)
 
@@ -136,7 +136,7 @@ def test_check_single_burst_pair():
     }
     with raises(
         validation.GranuleValidationError,
-        match='Burst IDs do not match for S1_136231_IW2_20200604T022312_VV_7C85-BURST and S1_136231_IW3_20200616T022313_VV_5D11-BURST.',
+        match=r'^Burst IDs do not match for S1_136231_IW2_20200604T022312_VV_7C85-BURST and S1_136231_IW3_20200616T022313_VV_5D11-BURST\.$',
     ):
         validation.check_single_burst_pair(invalid_job_different_swath, None)
 
@@ -150,7 +150,7 @@ def test_check_single_burst_pair():
     }
     with raises(
         validation.GranuleValidationError,
-        match='The requested scenes need to have the same polarization, got: VV, HH',
+        match=r'^The requested scenes need to have the same polarization, got: VV, HH$',
     ):
         validation.check_single_burst_pair(invalid_job_different_pol, None)
 
@@ -163,7 +163,7 @@ def test_check_single_burst_pair():
         }
     }
     with raises(
-        validation.GranuleValidationError, match='Only VV and HH polarizations are currently supported, got: VH'
+        validation.GranuleValidationError, match=r'^Only VV and HH polarizations are currently supported, got: VH$'
     ):
         validation.check_single_burst_pair(invalid_job_unsupported_pol, None)
 

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -4,7 +4,7 @@ import responses
 from pytest import raises
 from shapely.geometry import Polygon
 
-from hyp3_api import CMR_URL, validation
+from hyp3_api import CMR_URL, multi_burst_validation, validation
 from test_api.conftest import setup_requests_mock_with_given_polygons
 
 
@@ -333,7 +333,7 @@ def test_validate_jobs():
             'job_parameters': {'reference': [invalid_burst_pair[0]], 'secondary': [invalid_burst_pair[1]]},
         }
     ]
-    with raises(validation.GranuleValidationError):
+    with raises(multi_burst_validation.MultiBurstValidationError):
         validation.validate_jobs(jobs)
 
     jobs = [

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -120,7 +120,10 @@ def test_check_single_burst_pair():
             ]
         }
     }
-    with raises(validation.GranuleValidationError, match=r'^Burst IDs do not match for .*'):
+    with raises(
+        validation.GranuleValidationError,
+        match=r'^Burst IDs do not match for S1_136231_IW2_20200604T022312_VV_7C85-BURST and S1_136232_IW2_20200616T022313_VV_5D11-BURST\.$',
+    ):
         validation.check_single_burst_pair(invalid_job_different_number, None)
 
     invalid_job_different_swath = {
@@ -131,7 +134,10 @@ def test_check_single_burst_pair():
             ]
         }
     }
-    with raises(validation.GranuleValidationError, match=r'^Burst IDs do not match for .*'):
+    with raises(
+        validation.GranuleValidationError,
+        match=r'^Burst IDs do not match for S1_136231_IW2_20200604T022312_VV_7C85-BURST and S1_136231_IW3_20200616T022313_VV_5D11-BURST\.$',
+    ):
         validation.check_single_burst_pair(invalid_job_different_swath, None)
 
     invalid_job_different_pol = {
@@ -142,7 +148,10 @@ def test_check_single_burst_pair():
             ]
         }
     }
-    with raises(validation.GranuleValidationError, match=r'^The requested scenes need to have the same polarization, got: VV, HH$'):
+    with raises(
+        validation.GranuleValidationError,
+        match=r'^The requested scenes need to have the same polarization, got: VV, HH$',
+    ):
         validation.check_single_burst_pair(invalid_job_different_pol, None)
 
     invalid_job_unsupported_pol = {
@@ -153,7 +162,9 @@ def test_check_single_burst_pair():
             ]
         }
     }
-    with raises(validation.GranuleValidationError, match=r'^Only VV and HH polarizations are currently supported, got: VH$'):
+    with raises(
+        validation.GranuleValidationError, match=r'^Only VV and HH polarizations are currently supported, got: VH$'
+    ):
         validation.check_single_burst_pair(invalid_job_unsupported_pol, None)
 
 

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -122,7 +122,7 @@ def test_check_single_burst_pair():
     }
     with raises(
         validation.GranuleValidationError,
-        match=r'^Burst IDs do not match for S1_136231_IW2_20200604T022312_VV_7C85-BURST and S1_136232_IW2_20200616T022313_VV_5D11-BURST\.$',
+        match='Burst IDs do not match for S1_136231_IW2_20200604T022312_VV_7C85-BURST and S1_136232_IW2_20200616T022313_VV_5D11-BURST.',
     ):
         validation.check_single_burst_pair(invalid_job_different_number, None)
 
@@ -136,7 +136,7 @@ def test_check_single_burst_pair():
     }
     with raises(
         validation.GranuleValidationError,
-        match=r'^Burst IDs do not match for S1_136231_IW2_20200604T022312_VV_7C85-BURST and S1_136231_IW3_20200616T022313_VV_5D11-BURST\.$',
+        match='Burst IDs do not match for S1_136231_IW2_20200604T022312_VV_7C85-BURST and S1_136231_IW3_20200616T022313_VV_5D11-BURST.',
     ):
         validation.check_single_burst_pair(invalid_job_different_swath, None)
 
@@ -150,7 +150,7 @@ def test_check_single_burst_pair():
     }
     with raises(
         validation.GranuleValidationError,
-        match=r'^The requested scenes need to have the same polarization, got: VV, HH$',
+        match='The requested scenes need to have the same polarization, got: VV, HH',
     ):
         validation.check_single_burst_pair(invalid_job_different_pol, None)
 
@@ -163,7 +163,7 @@ def test_check_single_burst_pair():
         }
     }
     with raises(
-        validation.GranuleValidationError, match=r'^Only VV and HH polarizations are currently supported, got: VH$'
+        validation.GranuleValidationError, match='Only VV and HH polarizations are currently supported, got: VH'
     ):
         validation.check_single_burst_pair(invalid_job_unsupported_pol, None)
 


### PR DESCRIPTION
See https://github.com/ASFHyP3/hyp3/issues/2448

TODO:

- [x] Currently the `validate_jobs` function calls `convert_single_burst_jobs` to convert the parameters for all `INSAR_ISCE_BURST` jobs from `granules` to `reference` and `secondary` in [`validation.py`](https://github.com/ASFHyP3/hyp3/blob/develop/apps/api/src/hyp3_api/validation.py). This can be removed.
- [x] Refactor existing validators to be specific to single-burst while preserving backwards compatibility, including error messages
- [x] Add multi-burst validation to match [`validate_bursts`](https://github.com/ASFHyP3/hyp3-isce2/blob/develop/src/hyp3_isce2/burst.py#L395) in hyp3-isce2, including reference older than secondary, or just move the common validation code to hyp3lib; if not using hyp3lib, then add a comment to the validation function in both repos reminding us to keep them up-to-date with each other
- [x] `TODO` items in code
- [x] Add/update tests
- [x] Changelog
- [x] Validate all changes:
    - [x] Confirm same validation behavior for single-burst in https://hyp3-api.asf.alaska.edu and https://hyp3-multi-burst-sandbox.asf.alaska.edu
    - [x] Multi-burst validation error messages