### PR TITLE
Update OPERA-DIST-S1 Job Spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.5.2]
+
+## Fixed
+- OPERA-DIST-S1 job spec had wrong CLI interface (e.g. --n-lookbacks should be --n_lookbacks).
+
+## Changed
+- OPERA-DIST-S1 runtime increases from 3 to 6 hours for experimentation.
+
+
 ## [9.5.1]
 
 ### Added

--- a/job_spec/OPERA_DIST_S1.yml
+++ b/job_spec/OPERA_DIST_S1.yml
@@ -70,23 +70,23 @@ OPERA_DIST_S1:
         - dist-s1 run
         - --bucket
         - '!Ref Bucket'
-        - --bucket-prefix
+        - --bucket_prefix
         - Ref::job_id
-        - --mgrs-tile-id
+        - --mgrs_tile_id
         - Ref::mgrs_tile_id
-        - --track-number
+        - --track_number
         - Ref::track_number
-        - --post-date
+        - --post_date
         - Ref::post_date
-        - --memory-strategy
+        - --memory_strategy
         - Ref::memory_strategy
-        - --moderate-confidence-threshold
+        - --moderate_confidence_threshold
         - Ref::moderate_confidence_threshold
-        - --high-confidence-threshold
+        - --high_confidence_threshold
         - Ref::high_confidence_threshold
-        - --n-lookbacks
+        - --n_lookbacks
         - Ref::n_lookbacks
-      timeout: 10800  # 3 hr
+      timeout: 21600  # 6 hr
       compute_environment: Default
       vcpu: 1
       memory: 7500


### PR DESCRIPTION
- updates job spec so that it can properly be called (`-` --> `_`, my bad)
- increases runtime to 6 hours (for experimental purposes only)