### PR TITLE
adjusted memory requirements for opera-disp-tms jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.2.1]
+
+### Changed
+- Adjusted memory requirements for OPERA_DISP_TMS jobs.
+
 ## [10.2.0]
 
 ### Added

--- a/job_spec/OPERA_DISP_TMS.yml
+++ b/job_spec/OPERA_DISP_TMS.yml
@@ -40,7 +40,7 @@ OPERA_DISP_TMS:
       timeout: 1800 # 30 min
       compute_environment: Default
       vcpu: 1
-      memory: 31500
+      memory: 40000
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD
@@ -57,4 +57,4 @@ OPERA_DISP_TMS:
       timeout: 21600 # 6 hr
       compute_environment: Default
       vcpu: 1
-      memory: 31500
+      memory: 15500


### PR DESCRIPTION
For the data currently in CMR, `CREATE_MEASUREMENT_GEOTIFF` fails with `31500` MB but succeeds with `36864` MB, and `CREATE_TILE_MAP` succeeds with `8192` MB.