### PR TITLE
increase resources for time series step of SRG_TIME_SERIES jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.3.2]
+
+### Changed
+- Increased compute resources for the time series step of `SRG_TIME_SERIES` jobs.
+
 ## [10.3.1]
 
 ### Fixed

--- a/job_spec/SRG_TIME_SERIES.yml
+++ b/job_spec/SRG_TIME_SERIES.yml
@@ -78,7 +78,7 @@ SRG_TIME_SERIES:
         - --bucket-prefix
         - Ref::job_id
         - --use-gslc-prefix
-      timeout: 21600 # 6 hr
-      compute_environment: Default
+      timeout: 172800 # 48 hr
+      compute_environment: SrgTimeSeries
       vcpu: 1
-      memory: 30500
+      memory: 63500

--- a/job_spec/SRG_TIME_SERIES.yml
+++ b/job_spec/SRG_TIME_SERIES.yml
@@ -78,7 +78,7 @@ SRG_TIME_SERIES:
         - --bucket-prefix
         - Ref::job_id
         - --use-gslc-prefix
-      timeout: 172800 # 48 hr
+      timeout: 86400 # 24 hr
       compute_environment: SrgTimeSeries
       vcpu: 1
-      memory: 63500
+      memory: 125000

--- a/job_spec/config/compute_environments.yml
+++ b/job_spec/config/compute_environments.yml
@@ -8,7 +8,7 @@ compute_environments:
     instance_types: g6.2xlarge
     ami_id: ami-0729c079aae647cb3  # /aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended/image_id
   SrgTimeSeries:
-    instance_types: c6id.8xlarge
+    instance_types: c6id.16xlarge
     allocation_type: EC2
     allocation_strategy: BEST_FIT_PROGRESSIVE
   AriaAutorift:

--- a/job_spec/config/compute_environments.yml
+++ b/job_spec/config/compute_environments.yml
@@ -7,6 +7,10 @@ compute_environments:
   SrgGslc:
     instance_types: g6.2xlarge
     ami_id: ami-0729c079aae647cb3  # /aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended/image_id
+  SrgTimeSeries:
+    instance_types: c6id.8xlarge
+    allocation_type: EC2
+    allocation_strategy: BEST_FIT_PROGRESSIVE
   AriaAutorift:
     instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge
   InsarIsceAria:


### PR DESCRIPTION
On my 22 core Intel Core Ultra 7 laptop a full Hawaii stack used 318 GB of disk and took 12 hours 20 minutes.

The bulk of the processing time is phase unwrapping, which is done multi-threaded, so this throws 32 processors at it and errs on the side of "fast" over "cheap".

I'll evaluate these settings in a sandbox environment before merging.