### PR TITLE
Release v10.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.4.2]
+
+### Changed
+- Increased memory requirement for the `CREATE_MEASUREMENT_GEOTIFF` step of `OPERA_DISP_TMS` jobs.
+
 ## [10.4.1]
 
 ### Added

--- a/job_spec/OPERA_DISP_TMS.yml
+++ b/job_spec/OPERA_DISP_TMS.yml
@@ -40,7 +40,7 @@ OPERA_DISP_TMS:
       timeout: 1800 # 30 min
       compute_environment: Default
       vcpu: 1
-      memory: 40000
+      memory: 63500
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -12,7 +12,7 @@ PyYAML==6.0.2
 responses==0.25.7
 ruff==0.11.6
 mypy==1.15.0
-setuptools==79.0.0
+setuptools==80.0.0
 setuptools_scm==8.3.1
 openapi-spec-validator==0.7.1
 cfn-lint==1.34.1

--- a/requirements-all.txt
+++ b/requirements-all.txt
@@ -13,6 +13,6 @@ responses==0.25.7
 ruff==0.11.6
 mypy==1.15.0
 setuptools==79.0.0
-setuptools_scm==8.2.1
+setuptools_scm==8.3.1
 openapi-spec-validator==0.7.1
 cfn-lint==1.34.1


### PR DESCRIPTION
This job for frames 12908 and 38238 run before the change failed during CREATE_MEASUREMENT_GEOTIFF with an out of memory error: hyp3-test-api.asf.alaska.edu/jobs/e4b051e8-f5d2-4dc6-b77c-de07eb5115c2

The same job run after the change had both CREATE_MEASUREMENT_GEOTIFF steps succeed. The failure on the subsequent CREATE_TILE_MAP step is expected because I mixed ascending/descending frames for this test: https://hyp3-test-api.asf.alaska.edu/jobs/65aaee98-686b-40ae-a868-6d34fe24ab54