### PR TITLE
OPERA RTC followup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new `OPERA_RTC_S1` job type to EDC prod deployment.
 
 ### Fixed
-- The `POST /jobs` endpoint now returns a `502 Bad Gateway` response if any of the CMR queries fail during job validation. Previously, jobs would still be submitted successfully and the CMR error would appear in the HyP3 API logs. This was a fine approach when jobs were only validated for DEM coverage, but is not strict enough now that some job types include additional validators. Fixes https://github.com/ASFHyP3/hyp3/issues/2742
+- The `POST /jobs` endpoint now returns a `503 Service Unavailable` response if any of the CMR queries fail during job validation. Previously, jobs would still be submitted successfully and the CMR error would appear in the HyP3 API logs. This was a fine approach when jobs were only validated for DEM coverage, but is not strict enough now that some job types include additional validators. Fixes https://github.com/ASFHyP3/hyp3/issues/2742
 
 ## [10.4.2]
 

--- a/apps/api/src/hyp3_api/handlers.py
+++ b/apps/api/src/hyp3_api/handlers.py
@@ -30,7 +30,7 @@ def post_jobs(body: dict, user: str) -> dict:
         validate_jobs(body['jobs'])
     except requests.HTTPError as e:
         print(f'CMR search failed: {e}')
-        abort(problem_format(502, 'Could not submit jobs due to a CMR error. Please try again later.'))
+        abort(problem_format(503, 'Could not submit jobs due to a CMR error. Please try again later.'))
     except (BoundsValidationError, GranuleValidationError, MultiBurstValidationError) as e:
         abort(problem_format(400, str(e)))
 

--- a/tests/test_api/test_opera_rtc_s1.py
+++ b/tests/test_api/test_opera_rtc_s1.py
@@ -103,6 +103,28 @@ def test_opera_rtc_s1_ew(client, tables, approved_user):
     assert len(tables.jobs_table.scan()['Items']) == 0
 
 
+def test_opera_rtc_s1_multi_burst(client, tables, approved_user):
+    login(client, username=approved_user)
+
+    response = client.post(
+        JOBS_URI,
+        json={
+            'jobs': [
+                {
+                    'job_type': 'OPERA_RTC_S1',
+                    'job_parameters': {'granules': [
+                        'S1_073251_IW2_20200128T020712_VV_2944-BURST',
+                        'S1_073251_IW2_20200128T020712_VV_2944-BURST',
+                    ]},
+                }
+            ],
+        },
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert 'is not valid under any of the given schemas' in response.json['detail']
+    assert len(tables.jobs_table.scan()['Items']) == 0
+
+
 @pytest.mark.network
 def test_opera_rtc_s1_validation_order(client, tables, approved_user, monkeypatch):
     """Test that the validators are applied in the expected order."""

--- a/tests/test_api/test_opera_rtc_s1.py
+++ b/tests/test_api/test_opera_rtc_s1.py
@@ -84,6 +84,25 @@ def test_opera_rtc_s1_hv(client, tables, approved_user):
     assert len(tables.jobs_table.scan()['Items']) == 0
 
 
+def test_opera_rtc_s1_ew(client, tables, approved_user):
+    login(client, username=approved_user)
+
+    response = client.post(
+        JOBS_URI,
+        json={
+            'jobs': [
+                {
+                    'job_type': 'OPERA_RTC_S1',
+                    'job_parameters': {'granules': ['S1_148167_EW5_20201225T230343_VV_BB1F-BURST']},
+                }
+            ],
+        },
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert 'is not valid under any of the given schemas' in response.json['detail']
+    assert len(tables.jobs_table.scan()['Items']) == 0
+
+
 @pytest.mark.network
 def test_opera_rtc_s1_validation_order(client, tables, approved_user, monkeypatch):
     """Test that the validators are applied in the expected order."""

--- a/tests/test_api/test_opera_rtc_s1.py
+++ b/tests/test_api/test_opera_rtc_s1.py
@@ -112,10 +112,12 @@ def test_opera_rtc_s1_multi_burst(client, tables, approved_user):
             'jobs': [
                 {
                     'job_type': 'OPERA_RTC_S1',
-                    'job_parameters': {'granules': [
-                        'S1_073251_IW2_20200128T020712_VV_2944-BURST',
-                        'S1_073251_IW2_20200128T020712_VV_2944-BURST',
-                    ]},
+                    'job_parameters': {
+                        'granules': [
+                            'S1_073251_IW2_20200128T020712_VV_2944-BURST',
+                            'S1_073251_IW2_20200128T020712_VV_2944-BURST',
+                        ]
+                    },
                 }
             ],
         },

--- a/tests/test_api/test_opera_rtc_s1.py
+++ b/tests/test_api/test_opera_rtc_s1.py
@@ -201,7 +201,7 @@ def test_opera_rtc_s1_static_coverage_cmr_error(client, tables, approved_user, m
     mock_make_sure_granules_exist.assert_called_once()
     mock_check_dem_coverage.assert_called_once()
 
-    assert response.status_code == HTTPStatus.BAD_GATEWAY
+    assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
     assert response.json['detail'] == 'Could not submit jobs due to a CMR error. Please try again later.'
     assert len(tables.jobs_table.scan()['Items']) == 0
 

--- a/tests/test_api/test_opera_rtc_s1.py
+++ b/tests/test_api/test_opera_rtc_s1.py
@@ -18,13 +18,32 @@ def test_opera_rtc_s1_vv(client, tables, approved_user):
             'jobs': [
                 {
                     'job_type': 'OPERA_RTC_S1',
-                    'job_parameters': {'granules': ['S1_118338_IW2_20170102T124017_VV_0675-BURST']},
+                    'job_parameters': {'granules': ['S1_073251_IW2_20200128T020712_VV_2944-BURST']},
                 }
             ],
         },
     )
     assert response.status_code == HTTPStatus.OK
     assert len(tables.jobs_table.scan()['Items']) == 1
+
+
+def test_opera_rtc_s1_vh(client, tables, approved_user):
+    login(client, username=approved_user)
+
+    response = client.post(
+        JOBS_URI,
+        json={
+            'jobs': [
+                {
+                    'job_type': 'OPERA_RTC_S1',
+                    'job_parameters': {'granules': ['S1_073251_IW2_20200128T020712_VH_2944-BURST']},
+                }
+            ],
+        },
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert 'is not valid under any of the given schemas' in response.json['detail']
+    assert len(tables.jobs_table.scan()['Items']) == 0
 
 
 @pytest.mark.network
@@ -44,6 +63,25 @@ def test_opera_rtc_s1_hh(client, tables, approved_user):
     )
     assert response.status_code == HTTPStatus.OK
     assert len(tables.jobs_table.scan()['Items']) == 1
+
+
+def test_opera_rtc_s1_hv(client, tables, approved_user):
+    login(client, username=approved_user)
+
+    response = client.post(
+        JOBS_URI,
+        json={
+            'jobs': [
+                {
+                    'job_type': 'OPERA_RTC_S1',
+                    'job_parameters': {'granules': ['S1_011394_IW2_20200102T024334_HV_86EB-BURST']},
+                }
+            ],
+        },
+    )
+    assert response.status_code == HTTPStatus.BAD_REQUEST
+    assert 'is not valid under any of the given schemas' in response.json['detail']
+    assert len(tables.jobs_table.scan()['Items']) == 0
 
 
 @pytest.mark.network

--- a/tests/test_api/test_submit_job.py
+++ b/tests/test_api/test_submit_job.py
@@ -493,6 +493,6 @@ def test_cmr_error(client, tables, approved_user):
     responses.post(url=CMR_URL_RE, status=500)
 
     response = submit_batch(client, [make_job()])
-    assert response.status_code == HTTPStatus.BAD_GATEWAY
+    assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
     assert response.json['detail'] == 'Could not submit jobs due to a CMR error. Please try again later.'
     assert len(tables.jobs_table.scan()['Items']) == 0


### PR DESCRIPTION
A followup PR to the recent OPERA RTC changes:
- Return [503 Service Unavailable](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/503) rather than [502 Bad Gateway](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/502) for CMR errors because I think the description fits better.
- Add more test cases.