### PR TITLE
Group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,17 @@ updates:
       interval: weekly
     labels:
       - bumpless
+    groups:
+      pip-deps:
+        patterns:
+          - "*"
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     labels:
       - bumpless
+    groups:
+      github-actions-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
I also considered grouping by minor/patch and major using the `update-types` field as explained [here](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--), but decided to start with the simpler config and add complexity as needed.