### PR TITLE
Minimal AUTORIFT update to support hyp3-autorift v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.6.0]
+
+### Changed
+- Updates to `AUTORIFT` jobs to support the hyp3-autorift plugin v0.22.0:
+  - All job specs allow Sentinel-1C granules to be submitted
+  - The default memory for all job specs has been bumped to 64 GB from 32 GB
+  - The credit cost in EDC/DAAC deployments has been doubled accordingly
+
 ## [10.5.2]
 
 ### Changed

--- a/job_spec/ARIA_AUTORIFT.yml
+++ b/job_spec/ARIA_AUTORIFT.yml
@@ -14,7 +14,7 @@ AUTORIFT:
           anyOf:
             - description: The name of the Sentinel-1 SLC granule to process
               type: string
-              pattern: "^S1[AB]_IW_SLC__1S[SD][VH]"
+              pattern: "^S1[ABC]_IW_SLC__1S[SD][VH]"
               minLength: 67
               maxLength: 67
               example: S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8
@@ -34,7 +34,7 @@ AUTORIFT:
       api_schema:
         description: Shapefile for determining the correct search parameters by geographic location. Path to shapefile must be understood by GDAL.
         type: string
-        default: '/vsicurl/http://its-live-data.s3.amazonaws.com/autorift_parameters/v001/autorift_solidearth_0120m.shp'
+        default: '/vsicurl/https://its-live-data.s3.amazonaws.com/autorift_parameters/v001/autorift_solidearth_0120m.shp'
   cost_profiles:
     DEFAULT:
       cost: 1.0
@@ -57,7 +57,7 @@ AUTORIFT:
       timeout: 10800
       compute_environment: AriaAutorift
       vcpu: 1
-      memory: 31500
+      memory: 63500
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD

--- a/job_spec/AUTORIFT.yml
+++ b/job_spec/AUTORIFT.yml
@@ -32,7 +32,7 @@ AUTORIFT:
               example: LC08_L1GT_118112_20210107_20210107_02_T2
   cost_profiles:
     EDC:
-      cost: 25.0
+      cost: 50.0
     DEFAULT:
       cost: 1.0
   validators: []

--- a/job_spec/AUTORIFT.yml
+++ b/job_spec/AUTORIFT.yml
@@ -14,7 +14,7 @@ AUTORIFT:
           anyOf:
             - description: The name of the Sentinel-1 SLC granule to process
               type: string
-              pattern: "^S1[AB]_IW_SLC__1S[SD][VH]"
+              pattern: "^S1[ABC]_IW_SLC__1S[SD][VH]"
               minLength: 67
               maxLength: 67
               example: S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8
@@ -47,14 +47,14 @@ AUTORIFT:
         - --bucket-prefix
         - Ref::job_id
         - --parameter-file
-        - '/vsicurl/http://its-live-data.s3.amazonaws.com/autorift_parameters/v001/autorift_landice_0120m.shp'
+        - '/vsicurl/https://its-live-data.s3.amazonaws.com/autorift_parameters/v001/autorift_landice_0120m.shp'
         - --naming-scheme
         - ITS_LIVE_OD
         - Ref::granules
       timeout: 10800
       compute_environment: Default
       vcpu: 1
-      memory: 31500
+      memory: 63500
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD

--- a/job_spec/AUTORIFT_ITS_LIVE.yml
+++ b/job_spec/AUTORIFT_ITS_LIVE.yml
@@ -14,7 +14,7 @@ AUTORIFT:
           anyOf:
             - description: The name of the Sentinel-1 SLC granule to process
               type: string
-              pattern: "^S1[AB]_IW_SLC__1S[SD][VH]"
+              pattern: "^S1[ABC]_IW_SLC__1S[SD][VH]"
               minLength: 67
               maxLength: 67
               example: S1A_IW_SLC__1SSV_20150621T120220_20150621T120232_006471_008934_72D8
@@ -30,17 +30,11 @@ AUTORIFT:
               minLength: 40
               maxLength: 40
               example: LC08_L1GT_118112_20210107_20210107_02_T2
-            - description: Name of the Sentinel-1 SLC IW burst granule to process
-              type: string
-              pattern: "^S1_\\d{6}_IW.*-BURST"
-              minLength: 43
-              maxLength: 43
-              example: S1_136231_IW2_20200604T022312_VV_7C85-BURST
     parameter_file:
       api_schema:
         description: Shapefile for determining the correct search parameters by geographic location. Path to shapefile must be understood by GDAL.
         type: string
-        default: '/vsicurl/http://its-live-data.s3.amazonaws.com/autorift_parameters/v001/autorift_landice_0120m.shp'
+        default: '/vsicurl/https://its-live-data.s3.amazonaws.com/autorift_parameters/v001/autorift_landice_0120m.shp'
     publish_bucket:
       api_schema:
         description: Publish the resulting product to the ITS_LIVE AWS Open Data (or test) S3 Bucket
@@ -74,7 +68,7 @@ AUTORIFT:
       timeout: 10800
       compute_environment: Default
       vcpu: 1
-      memory: 31500
+      memory: 63500
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD


### PR DESCRIPTION
This is an as-minimal-as-possible subset of #2789 to unblock ASFHyP3/hyp3-autorift#335. I'll circle back to the rest of the updates later.

This updates to `AUTORIFT` jobs to support the hyp3-autorift plugin v0.22.0:
  - All job specs allow Sentinel-1C granules to be submitted
  - The default memory for all job specs has been bumped to 64 GB from 32 GB
  - The credit cost in EDC/DAAC deployments has been doubled accordingly

Companion PR when this is released: https://github.com/ASFHyP3/hyp3-docs/pull/584