### PR TITLE
Support EDL token authentication

### DIFF
--- a/apps/api/src/hyp3_api/api-spec/openapi-spec.yml.j2
+++ b/apps/api/src/hyp3_api/api-spec/openapi-spec.yml.j2
@@ -5,7 +5,7 @@ info:
   version: {{ api_version }}
 
 security:
-  - EarthDataLogin: []
+  - BearerAuth: []
 
 {% if security_environment == 'EDC' %}
 # See https://github.com/ASFHyP3/hyp3/pull/2009 for context.
@@ -477,9 +477,9 @@ components:
       example: 50
 
   securitySchemes:
-    EarthDataLogin:
+    BearerAuth:
       description: |-
-        Authentication requires the user to have an account at urs.earthdata.nasa.gov and log in at auth.asf.alaska.edu
-      type: apiKey
-      in: cookie
-      name: asf-urs
+        Authentication via Earthdata Login Bearer Tokens; https://urs.earthdata.nasa.gov/documentation/for_users/user_token
+      type: http
+      scheme: bearer
+      bearerFormat: JWT

--- a/apps/api/src/hyp3_api/auth.py
+++ b/apps/api/src/hyp3_api/auth.py
@@ -8,7 +8,9 @@ def decode_token(token: str | None) -> dict | None:
     if token is None:
         return None
     try:
-        return jwt.decode(token, environ['AUTH_PUBLIC_KEY'], algorithms=environ['AUTH_ALGORITHM'])
+        jwks_client = jwt.PyJWKClient('https://urs.earthdata.nasa.gov/.well-known/edl_ops_jwks.json')
+        signing_key = jwks_client.get_signing_key('edljwtpubkey_ops')
+        return jwt.decode(token, signing_key, algorithms=['RS256'])
     except (jwt.ExpiredSignatureError, jwt.DecodeError):
         return None
 

--- a/apps/api/src/hyp3_api/routes.py
+++ b/apps/api/src/hyp3_api/routes.py
@@ -40,7 +40,7 @@ def check_system_available() -> Response | None:
 def authenticate_user() -> None:
     token = None
     payload = None
-    if request.authorization.type == 'Bearer':
+    if request.authorization and request.authorization.type == 'Bearer':
         token = request.authorization.token
         payload = auth.decode_token(token)
 

--- a/apps/api/src/hyp3_api/routes.py
+++ b/apps/api/src/hyp3_api/routes.py
@@ -38,11 +38,15 @@ def check_system_available() -> Response | None:
 
 @app.before_request
 def authenticate_user() -> None:
-    cookie = request.cookies.get('asf-urs')
-    payload = auth.decode_token(cookie)
+    token = None
+    payload = None
+    if request.authorization.type == 'Bearer':
+        token = request.authorization.token
+        payload = auth.decode_token(token)
+
     if payload is not None:
-        g.user = payload['urs-user-id']
-        g.edl_access_token = payload['urs-access-token']
+        g.user = payload['uid']
+        g.edl_access_token = token
     else:
         if any([request.path.startswith(route) for route in AUTHENTICATED_ROUTES]) and request.method != 'OPTIONS':
             abort(handlers.problem_format(401, 'No authorization token provided'))

--- a/apps/api/src/hyp3_api/routes.py
+++ b/apps/api/src/hyp3_api/routes.py
@@ -40,8 +40,8 @@ def check_system_available() -> Response | None:
 def authenticate_user() -> None:
     token = None
     payload = None
-    if request.authorization and request.authorization.type == 'Bearer':
-        token = request.authorization.token
+    if 'Authorization' in request.headers and request.headers['Authorization'].startswith('Bearer '):
+        token = request.headers['Authorization'].split(' ')[1]
         payload = auth.decode_token(token)
 
     if payload is not None:


### PR DESCRIPTION
# TODO
- [ ] support both cookie-based and token-based authentication
- [ ] avoid re-fetching the EDL signing key with every request
- [ ] figure out how `request.authorization` works so we don't have to parse the `Authorization` header ourselves
- [ ] add/update tests

