### PR TITLE
OPERA-RTC-S1 remove dem check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.7.1]
+
+### Removed
+- DEM bounds check for OPERA_RTC_S1 job type since it uses a different DEM.
+
 ## [10.7.0]
 
 ### Added

--- a/job_spec/OPERA_RTC_S1.yml
+++ b/job_spec/OPERA_RTC_S1.yml
@@ -24,7 +24,6 @@ OPERA_RTC_S1:
       cost: 1.0
   validators:
     - check_opera_rtc_s1_date
-    - check_dem_coverage
     # Static coverage check is the slowest because it involves a CMR query, so should come last
     - check_opera_rtc_s1_static_coverage
   steps:


### PR DESCRIPTION
Don't need DEM check because this job type uses a different DEM source without holes. Spatial check comes via looking for associated static layers.