### PR TITLE
Add tests for auth error cases

### DIFF
--- a/apps/api/src/hyp3_api/auth.py
+++ b/apps/api/src/hyp3_api/auth.py
@@ -1,4 +1,3 @@
-import time
 from os import environ
 
 import jwt
@@ -27,17 +26,3 @@ def decode_asf_cookie(cookie: str) -> tuple[str, str]:
 
 def get_jwks_client() -> jwt.PyJWKClient:
     return jwt.PyJWKClient('https://urs.earthdata.nasa.gov/.well-known/edl_ops_jwks.json')
-
-
-def get_mock_jwt_cookie(user: str, lifetime_in_seconds: int, access_token: str) -> str:
-    payload = {
-        'urs-user-id': user,
-        'urs-access-token': access_token,
-        'exp': int(time.time()) + lifetime_in_seconds,
-    }
-    value = jwt.encode(
-        payload=payload,
-        key=environ['AUTH_PUBLIC_KEY'],
-        algorithm=environ['AUTH_ALGORITHM'],
-    )
-    return value

--- a/tests/test_api/conftest.py
+++ b/tests/test_api/conftest.py
@@ -1,10 +1,13 @@
 import json
+import time
+import os
 import re
 
+import jwt
 import pytest
 import responses
 
-from hyp3_api import CMR_URL, app, auth
+from hyp3_api import CMR_URL, app
 
 
 AUTH_COOKIE = 'asf-urs'
@@ -28,7 +31,7 @@ def login(client, username=DEFAULT_USERNAME, access_token=DEFAULT_ACCESS_TOKEN):
     client.set_cookie(
         domain='localhost',
         key=AUTH_COOKIE,
-        value=auth.get_mock_jwt_cookie(username, lifetime_in_seconds=10_000, access_token=access_token),
+        value=get_mock_jwt_cookie(username, lifetime_in_seconds=10_000, access_token=access_token),
     )
 
 
@@ -79,3 +82,17 @@ def setup_mock_cmr_response_for_polygons(granule_polygon_pairs):
         }
     }
     responses.add(responses.POST, CMR_URL_RE, json.dumps(cmr_response))
+
+
+def get_mock_jwt_cookie(user: str, lifetime_in_seconds: int, access_token: str) -> str:
+    payload = {
+        'urs-user-id': user,
+        'urs-access-token': access_token,
+        'exp': int(time.time()) + lifetime_in_seconds,
+    }
+    value = jwt.encode(
+        payload=payload,
+        key=os.environ['AUTH_PUBLIC_KEY'],
+        algorithm=os.environ['AUTH_ALGORITHM'],
+    )
+    return value

--- a/tests/test_api/conftest.py
+++ b/tests/test_api/conftest.py
@@ -1,7 +1,7 @@
 import json
-import time
 import os
 import re
+import time
 
 import jwt
 import pytest

--- a/tests/test_api/test_api_spec.py
+++ b/tests/test_api/test_api_spec.py
@@ -1,6 +1,6 @@
 from http import HTTPStatus
 
-from test_api.conftest import AUTH_COOKIE, JOBS_URI, USER_URI, login, get_mock_jwt_cookie
+from test_api.conftest import AUTH_COOKIE, JOBS_URI, USER_URI, get_mock_jwt_cookie, login
 
 
 ENDPOINTS = {

--- a/tests/test_api/test_api_spec.py
+++ b/tests/test_api/test_api_spec.py
@@ -39,8 +39,8 @@ def test_invalid_cookie(client):
     for uri in ENDPOINTS:
         client.set_cookie(domain='localhost', key=AUTH_COOKIE, value='garbage I say!!! GARGBAGE!!!')
         response = client.get(uri)
-        assert 'Invalid authorization cookie provided' in response.json['detail']
         assert response.status_code == HTTPStatus.UNAUTHORIZED
+        assert 'Invalid authorization cookie provided' in response.json['detail']
 
 
 def test_invalid_bearer(client):

--- a/tests/test_api/test_api_spec.py
+++ b/tests/test_api/test_api_spec.py
@@ -1,7 +1,6 @@
 from http import HTTPStatus
 
-from hyp3_api import auth
-from test_api.conftest import AUTH_COOKIE, JOBS_URI, USER_URI, login
+from test_api.conftest import AUTH_COOKIE, JOBS_URI, USER_URI, login, get_mock_jwt_cookie
 
 
 ENDPOINTS = {
@@ -48,7 +47,7 @@ def test_expired_cookie(client):
         client.set_cookie(
             domain='localhost',
             key=AUTH_COOKIE,
-            value=auth.get_mock_jwt_cookie('user', lifetime_in_seconds=-1, access_token='token'),
+            value=get_mock_jwt_cookie('user', lifetime_in_seconds=-1, access_token='token'),
         )
         response = client.get(uri)
         assert response.status_code == HTTPStatus.UNAUTHORIZED

--- a/tests/test_api/test_api_spec.py
+++ b/tests/test_api/test_api_spec.py
@@ -46,8 +46,8 @@ def test_invalid_cookie(client):
 def test_invalid_bearer(client):
     for uri in ENDPOINTS:
         response = client.get(uri, headers={'Authorization': 'Bearer BAD TOKEN'})
-        assert 'Invalid authorization token provided' in response.json['detail']
         assert response.status_code == HTTPStatus.UNAUTHORIZED
+        assert 'Invalid authorization token provided' in response.json['detail']
 
 
 def test_expired_cookie(client):

--- a/tests/test_api/test_api_spec.py
+++ b/tests/test_api/test_api_spec.py
@@ -39,6 +39,14 @@ def test_invalid_cookie(client):
     for uri in ENDPOINTS:
         client.set_cookie(domain='localhost', key=AUTH_COOKIE, value='garbage I say!!! GARGBAGE!!!')
         response = client.get(uri)
+        assert 'Invalid authorization cookie provided' in response.json['detail']
+        assert response.status_code == HTTPStatus.UNAUTHORIZED
+
+
+def test_invalid_bearer(client):
+    for uri in ENDPOINTS:
+        response = client.get(uri, headers={'Authorization': 'Bearer BAD TOKEN'})
+        assert 'Invalid authorization token provided' in response.json['detail']
         assert response.status_code == HTTPStatus.UNAUTHORIZED
 
 

--- a/tests/test_api/test_auth.py
+++ b/tests/test_api/test_auth.py
@@ -20,8 +20,10 @@ def test_decode_edl_bearer_token(jwks_client):
         user, token = auth.decode_edl_bearer_token('test-token', jwks_client)
 
         mock_decode.assert_called_once()
+        assert len(mock_decode.call_args.args) == 2
         assert mock_decode.call_args.args[0] == 'test-token'
-        assert mock_decode.call_args.kwargs['algorithms'] == ['RS256']
+        assert isinstance(mock_decode.call_args.args[1], jwt.api_jwk.PyJWK)
+        assert mock_decode.call_args.kwargs == {'algorithms': ['RS256']}
 
         assert user == 'test-user'
         assert token == 'test-token'

--- a/tests/test_api/test_auth.py
+++ b/tests/test_api/test_auth.py
@@ -41,7 +41,7 @@ def test_bad_bearer_token(jwks_client):
         auth.decode_edl_bearer_token('bad token', jwks_client)
 
 
-def test_bad_asf_cookie(monkeypatch):
+def test_bad_asf_cookie():
     with pytest.raises(auth.InvalidTokenException, match=r'^Invalid authorization cookie provided'):
         auth.decode_asf_cookie('bad token')
 

--- a/tests/test_api/test_auth.py
+++ b/tests/test_api/test_auth.py
@@ -1,0 +1,27 @@
+import pytest
+
+from hyp3_api import auth
+
+
+@pytest.mark.network
+def test_get_jwks_client(client):
+    assert 'urs.earthdata.nasa.gov' in client.uri
+
+
+@pytest.mark.network
+def test_bad_bearer_token(client):
+    with pytest.raises(auth.InvalidTokenException, match=r'.*Invalid authorization token provided.*'):
+        auth.decode_edl_bearer_token('bad token', client)
+
+
+def test_bad_asf_cookie(client, monkeypatch):
+    monkeypatch.setenv("AUTH_PUBLIC_KEY", "public key")
+    monkeypatch.setenv("AUTH_ALGORITHM", "RS256")
+
+    with pytest.raises(auth.InvalidTokenException, match=r'.*Invalid authorization cookie provided.*'):
+        auth.decode_asf_cookie('bad token')
+
+
+@pytest.fixture(scope='session')
+def client():
+    return auth.get_jwks_client()

--- a/tests/test_api/test_auth.py
+++ b/tests/test_api/test_auth.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import jwt
 import pytest
 
 from hyp3_api import auth

--- a/tests/test_api/test_auth.py
+++ b/tests/test_api/test_auth.py
@@ -41,7 +41,7 @@ def test_bad_bearer_token(jwks_client):
         auth.decode_edl_bearer_token('bad token', jwks_client)
 
 
-def test_bad_asf_cookie(jwks_client, monkeypatch):
+def test_bad_asf_cookie(monkeypatch):
     with pytest.raises(auth.InvalidTokenException, match=r'^Invalid authorization cookie provided'):
         auth.decode_asf_cookie('bad token')
 

--- a/tests/test_api/test_auth.py
+++ b/tests/test_api/test_auth.py
@@ -1,17 +1,15 @@
 import pytest
 
 from hyp3_api import auth
+from test_api import conftest
 
 
 def test_decode_asf_cookie(monkeypatch, jwks_client):
-    def mock_decode(*args, **kwargs):
-        return {'urs-user-id': 'test-user', 'urs-access-token': 'test-token'}
+    cookie = conftest.get_mock_jwt_cookie('user', lifetime_in_seconds=100, access_token='token')
 
-    monkeypatch.setattr(auth.jwt, 'decode', mock_decode)
-
-    user, token = auth.decode_asf_cookie('test-token')
-    assert user == 'test-user'
-    assert token == 'test-token'
+    user, token = auth.decode_asf_cookie(cookie)
+    assert user == 'user'
+    assert token == 'token'
 
 
 @pytest.mark.network

--- a/tests/test_api/test_auth.py
+++ b/tests/test_api/test_auth.py
@@ -37,12 +37,12 @@ def test_get_jwks_client(jwks_client):
 
 @pytest.mark.network
 def test_bad_bearer_token(jwks_client):
-    with pytest.raises(auth.InvalidTokenException, match=r'.*Invalid authorization token provided.*'):
+    with pytest.raises(auth.InvalidTokenException, match='Invalid authorization token provided'):
         auth.decode_edl_bearer_token('bad token', jwks_client)
 
 
 def test_bad_asf_cookie(jwks_client, monkeypatch):
-    with pytest.raises(auth.InvalidTokenException, match=r'.*Invalid authorization cookie provided.*'):
+    with pytest.raises(auth.InvalidTokenException, match='Invalid authorization cookie provided'):
         auth.decode_asf_cookie('bad token')
 
 

--- a/tests/test_api/test_auth.py
+++ b/tests/test_api/test_auth.py
@@ -37,7 +37,7 @@ def test_get_jwks_client(jwks_client):
 
 @pytest.mark.network
 def test_bad_bearer_token(jwks_client):
-    with pytest.raises(auth.InvalidTokenException, match='Invalid authorization token provided'):
+    with pytest.raises(auth.InvalidTokenException, match=r'^Invalid authorization token provided'):
         auth.decode_edl_bearer_token('bad token', jwks_client)
 
 

--- a/tests/test_api/test_auth.py
+++ b/tests/test_api/test_auth.py
@@ -36,9 +36,6 @@ def test_bad_bearer_token(jwks_client):
 
 
 def test_bad_asf_cookie(jwks_client, monkeypatch):
-    monkeypatch.setenv('AUTH_PUBLIC_KEY', 'public key')
-    monkeypatch.setenv('AUTH_ALGORITHM', 'RS256')
-
     with pytest.raises(auth.InvalidTokenException, match=r'.*Invalid authorization cookie provided.*'):
         auth.decode_asf_cookie('bad token')
 

--- a/tests/test_api/test_auth.py
+++ b/tests/test_api/test_auth.py
@@ -1,5 +1,6 @@
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 from hyp3_api import auth
 from test_api import conftest

--- a/tests/test_api/test_auth.py
+++ b/tests/test_api/test_auth.py
@@ -7,7 +7,7 @@ from hyp3_api import auth
 from test_api import conftest
 
 
-def test_decode_asf_cookie(monkeypatch, jwks_client):
+def test_decode_asf_cookie():
     cookie = conftest.get_mock_jwt_cookie('user', lifetime_in_seconds=100, access_token='token')
 
     user, token = auth.decode_asf_cookie(cookie)

--- a/tests/test_api/test_auth.py
+++ b/tests/test_api/test_auth.py
@@ -42,7 +42,7 @@ def test_bad_bearer_token(jwks_client):
 
 
 def test_bad_asf_cookie(jwks_client, monkeypatch):
-    with pytest.raises(auth.InvalidTokenException, match='Invalid authorization cookie provided'):
+    with pytest.raises(auth.InvalidTokenException, match=r'^Invalid authorization cookie provided'):
         auth.decode_asf_cookie('bad token')
 
 

--- a/tests/test_api/test_auth.py
+++ b/tests/test_api/test_auth.py
@@ -22,6 +22,7 @@ def test_decode_edl_bearer_token(jwks_client):
         mock_decode.assert_called_once()
         assert mock_decode.call_args.args[0] == 'test-token'
         assert mock_decode.call_args.kwargs['algorithms'] == ['RS256']
+
         assert user == 'test-user'
         assert token == 'test-token'
 


### PR DESCRIPTION
TODO: 
- [x] Use magicmock and check called with correct params ([example](https://github.com/ASFHyP3/hyp3/blob/develop/tests/test_start_execution.py#L184))
- [x] refactor `get_mock_jwt_cookie` into conftest
- [x] Test for `route.py` (maybe)?