### PR TITLE
Add cloudformation:DeleteStack to JPL deployment policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [10.8.0]
 
+### Added
+- `cloudformation:DeleteStack` permissions to the [HyP3 deployment policy](cicd-stacks/JPL-deployment-policy-cf.yml) for JPL accounts
+
 ### Changed
 - `ARIA_S1_GUNW` now takes `reference_date` and `secondary_date` as inputs instead of `reference` and `secondary` granule lists
 - `ARIA_S1_GUNW` jobs now enforce minimum frame coverage of `0.9`.

--- a/cicd-stacks/JPL-deployment-policy-cf.yml
+++ b/cicd-stacks/JPL-deployment-policy-cf.yml
@@ -51,6 +51,7 @@ Resources:
               - cloudformation:SetStackPolicy
               - cloudformation:CreateStack
               - cloudformation:UpdateStack
+              - cloudformation:DeleteStack
               - cloudformation:CreateChangeSet
               - cloudformation:DescribeChangeSet
               - cloudformation:ExecuteChangeSet


### PR DESCRIPTION
Fixes orphaned stacks being left behind when we restructure the CloudFormation stacks.

See: https://chat.asf.alaska.edu/asf/pl/yfahnog6tfgqmrxhwqehetcc1y