### PR TITLE
Ensure OpenAPI Specification version is specified consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added new deployment for AK-FIRE-SAFE.
+- The OpenAPI Specification version can now be specified in `render.py` via the `--openapi-spec` argument.
+
+### Fixed
+- The `openapi-spec.yml` and the `api-cf.yml` will now always specify the same OpenAPI Specification version.
 
 ## [10.9.2]
 

--- a/apps/api/api-cf.yml.j2
+++ b/apps/api/api-cf.yml.j2
@@ -59,7 +59,7 @@ Resources:
         Types:
           - {{ 'PRIVATE' if security_environment == 'EDC' else 'REGIONAL' }}
       Body:
-        openapi: 3.0.3
+        openapi: {{ openapi_spec }}
         paths:
           /:
             x-amazon-apigateway-any-method:

--- a/apps/api/src/hyp3_api/api-spec/openapi-spec.yml.j2
+++ b/apps/api/src/hyp3_api/api-spec/openapi-spec.yml.j2
@@ -1,4 +1,4 @@
-openapi: 3.0.1
+openapi: {{ openapi_spec }}
 
 info:
   title: {{ api_name }}-api

--- a/apps/render_cf.py
+++ b/apps/render_cf.py
@@ -145,7 +145,7 @@ def get_batch_param_names_for_job_step(step: dict) -> set[str]:
 
 
 def render_templates(
-    job_types: dict, compute_envs: dict, security_environment: str, api_name: str, api_version: str
+    job_types: dict, compute_envs: dict, security_environment: str, api_name: str, api_version: str, openapi_spec: str,
 ) -> None:
     job_states = get_states_for_jobs(job_types)
 
@@ -167,6 +167,7 @@ def render_templates(
             security_environment=security_environment,
             api_name=api_name,
             api_version=api_version,
+            openapi_spec=openapi_spec,
             json=json,
             snake_to_pascal_case=snake_to_pascal_case,
             job_states=job_states,
@@ -289,6 +290,7 @@ def main() -> None:
     parser.add_argument('-s', '--security-environment', default='ASF', choices=['ASF', 'EDC', 'JPL', 'JPL-public'])
     parser.add_argument('-n', '--api-name', required=True)
     parser.add_argument('-c', '--cost-profile', default='DEFAULT', choices=['DEFAULT', 'EDC'])
+    parser.add_argument('--openapi-spec', default='3.0.4')
     args = parser.parse_args()
 
     api_version = get_version(root='..', relative_to=__file__)
@@ -309,7 +311,7 @@ def main() -> None:
     render_batch_params_by_job_type(job_types)
     render_default_params_by_job_type(job_types)
     render_costs(job_types, args.cost_profile)
-    render_templates(job_types, compute_envs, args.security_environment, args.api_name, api_version)
+    render_templates(job_types, compute_envs, args.security_environment, args.api_name, api_version, args.openapi_spec)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Since both places where we specify which version of the OpenAPI Specification we use are already Jinja templates, I've added an argument to `render.py` to specify the version and use that in the templates to ensure consistency.

I've also set the default version to v3.0.4, the current 3.0 series version.