### PR TITLE
Add par

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added new deployment for AK-FIRE-SAFE.
 - The OpenAPI Specification version can now be specified in `render.py` via the `--openapi-spec` argument.
+- The `AUTORIFT_ITS_LIVE.yml` job spec has a new `use_static_files` parameter to specify wheather to use Sentinel-1 static geometries for processing or not.
+  - This parameter has been hard-coded to `False` in the `AUTORIFT.yml` and `ARIA_AUTORIFT.yml` to ensure there is no change in the workflow for those job types. 
 
 ### Fixed
 - The `openapi-spec.yml` and the `api-cf.yml` will now always specify the same OpenAPI Specification version.

--- a/job_spec/ARIA_AUTORIFT.yml
+++ b/job_spec/ARIA_AUTORIFT.yml
@@ -123,6 +123,8 @@ AUTORIFT:
         - Ref::parameter_file
         - --naming-scheme
         - ITS_LIVE_OD
+        - --use-static-files
+        - 'False'
         - --reference
         - Ref::reference
         - --secondary

--- a/job_spec/AUTORIFT.yml
+++ b/job_spec/AUTORIFT.yml
@@ -49,6 +49,8 @@ AUTORIFT:
         - '/vsicurl/https://its-live-data.s3.amazonaws.com/autorift_parameters/v001/autorift_landice_0120m.shp'
         - --naming-scheme
         - ITS_LIVE_OD
+        - --use-static-files
+        - 'False'
       timeout: 10800
       compute_environment: Default
       vcpu: 1

--- a/job_spec/AUTORIFT_ITS_LIVE.yml
+++ b/job_spec/AUTORIFT_ITS_LIVE.yml
@@ -116,6 +116,11 @@ AUTORIFT:
           - "its-live-data"
           - "its-live-data-test"
         default: null
+    use_static_files:
+      api_schema:
+        description:  Use static topographic correction files for ISCE3 processing if available (Sentinel-1 only)
+        default: true
+        type: boolean
   cost_profiles:
     DEFAULT:
       cost: 1.0
@@ -135,6 +140,8 @@ AUTORIFT:
         - Ref::publish_bucket
         - --naming-scheme
         - ITS_LIVE_PROD
+        - --use-static-files
+        - Ref::use_static_files
         - --reference
         - Ref::reference
         - --secondary


### PR DESCRIPTION
The `AUTORIFT_ITS_LIVE.yml` job spec has a new `use_static_files` parameter to specify whether to use Sentinel-1 static geometries for processing or not, which is available in the pending release of hyp3-autorift: https://github.com/ASFHyP3/hyp3-autorift/pull/364.

This parameter has been hard-coded to `False` in the `AUTORIFT.yml` and `ARIA_AUTORIFT.yml` to ensure there is no change in the workflow for those job types. 
