### PR TITLE
Increase memory and timeout params for coseis-sar

### DIFF
--- a/job_spec/ARIA_S1_COSEIS.yml
+++ b/job_spec/ARIA_S1_COSEIS.yml
@@ -129,10 +129,10 @@ ARIA_S1_COSEIS:
         - Ref::goldstein_filter_power
         - --unfiltered-coherence
         - Ref::unfiltered_coherence
-      timeout: 21600
+      timeout: 43200
       compute_environment: InsarIsceAria
       vcpu: 1
-      memory: 15500
+      memory: 63500
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD
@@ -147,10 +147,10 @@ ARIA_S1_COSEIS:
         - Ref::job_id
         - --weather-model
         - Ref::weather_model
-      timeout: 10800
+      timeout: 21600
       compute_environment: InsarIsceAria
       vcpu: 1
-      memory: 7500
+      memory: 15000
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD

--- a/job_spec/ARIA_S1_COSEIS.yml
+++ b/job_spec/ARIA_S1_COSEIS.yml
@@ -150,7 +150,7 @@ ARIA_S1_COSEIS:
       timeout: 21600
       compute_environment: InsarIsceAria
       vcpu: 1
-      memory: 15000
+      memory: 15500
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD


### PR DESCRIPTION
Additional memory and runtime is needed to generate the `COSEIS_SAR` product with `HYP3`. Testing and deployment of the `coseis-sar` workflow will utilize `m6id.4xlarge` instances. This PR increases the `memory` and `timeout` parameters in `ARIA_S1_COSEIS.yml` to accommodate the additional memory/time requirements.