### PR TITLE
Revert the switch to Graviton instances for hyp3-its-live

### DIFF
--- a/.github/workflows/deploy-enterprise.yml
+++ b/.github/workflows/deploy-enterprise.yml
@@ -24,12 +24,12 @@ jobs:
             cost_profile: DEFAULT
             job_files: >-
               job_spec/AUTORIFT_ITS_LIVE.yml
-            instance_types: r7gd.2xlarge,r7gd.4xlarge,r7gd.8xlarge
+            instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge
             default_max_vcpus: 2000  # Max: 10,406
             expanded_max_vcpus: 2000  # Max: 10,406
             required_surplus: 0
             security_environment: JPL-public
-            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/arm64/recommended/image_id
+            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-ak-fire-safe
             domain: hyp3-ak-fire-safe.asf.alaska.edu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [10.10.3]
-
-### Changed
-
-- `AUTORIFT_ITS_LIVE` now uses `r7gd` memory-optimized Graviton3 instances.
-
 ## [10.10.2]
 
 ### Fixed


### PR DESCRIPTION
This reverts the switch to Graviton instances for hyp3-its-live, because Tools wants to merge `develop` to `main` but we don't want to trigger a production release for hyp3-its-live without @ASFHyP3/scidev.