### PR TITLE
Fix ITS_LIVE test ami and instance type missmatch

### DIFF
--- a/.github/workflows/deploy-custom-prod.yml
+++ b/.github/workflows/deploy-custom-prod.yml
@@ -24,6 +24,7 @@ jobs:
             cost_profile: DEFAULT
             job_files: >-
               job_spec/ITS_LIVE_AUTORIFT.yml
+              job_spec/ITS_LIVE_META.yml
             instance_types: r7gd.2xlarge,r7gd.4xlarge,r7gd.8xlarge
             default_max_vcpus: 2000  # Max: 10,406
             expanded_max_vcpus: 2000  # Max: 10,406

--- a/job_spec/ITS_LIVE_AUTORIFT.yml
+++ b/job_spec/ITS_LIVE_AUTORIFT.yml
@@ -172,7 +172,7 @@ AUTORIFT:
         - --publish-prefix
         - Ref::publish_stac_prefix
       timeout: 10800
-      compute_environment: AriaAutorift
+      compute_environment: ItsLiveMeta
       vcpu: 1
       memory: 7875
       secrets:

--- a/job_spec/ITS_LIVE_META.yml
+++ b/job_spec/ITS_LIVE_META.yml
@@ -41,7 +41,7 @@ ITS_LIVE_META:
         - --publish-prefix
         - Ref::publish_stac_prefix
       timeout: 10800
-      compute_environment: AriaAutorift
+      compute_environment: ItsLiveMeta
       vcpu: 1
       memory: 7875
       secrets:

--- a/job_spec/config/compute_environments.yml
+++ b/job_spec/config/compute_environments.yml
@@ -20,3 +20,6 @@ compute_environments:
     instance_types: m6id.xlarge,m6id.2xlarge,m6id.4xlarge,m6id.8xlarge
     allocation_type: EC2
     allocation_strategy: BEST_FIT_PROGRESSIVE
+  ItsLiveMeta:
+    instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge
+    ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id


### PR DESCRIPTION
For the ITS_LIVE deployments, the default environment uses linux-arm (graviton) instances. The metadata step in AUTORIFT jobs and the ITS_LIVE_METADATA job, however, use linux-x86 (intel) instances, but inherit an arm AMI id, so both job types are currently broken.

This adds a new compute environment which specifies the AMI id and intel instances for the ITS_LIVE metadata step/job. 


Also:
* adds the ITS_LIVE_METADATA job type to the ITS_LIVE prod deployment