### PR TITLE
Increase vcpus in hyp3-opera-prod

### DIFF
--- a/.github/workflows/deploy-daac-prod.yml
+++ b/.github/workflows/deploy-daac-prod.yml
@@ -49,8 +49,8 @@ jobs:
             job_files: >-
               job_spec/OPERA_RTC_S1_SLC.yml
             instance_types: c6i.2xlarge,c6id.2xlarge,c7i.2xlarge,c6i.4xlarge,c6id.4xlarge,c7i.4xlarge
-            default_max_vcpus: 10000
-            expanded_max_vcpus: 10000
+            default_max_vcpus: 12000
+            expanded_max_vcpus: 12000
             required_surplus: 0
             security_environment: EDC
             ami_id: /ngap/amis/image_id_ecs_al2023_x86

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `OPERA_DIST_S1` jobs now time out after 1 hour instead of 3 hours. 
 - `OPERA_DIST_S1` jobs utilize less workers for normal parameter estimation and despeckling due to RAM constraints.
+- Increased min/max vCPUs to 12,000 in the `hyp3-opera-prod` deployment
 
 ## [10.11.4]
 


### PR DESCRIPTION
I've already manually applied this change to 12,000 in the production environment, but this PR codifies it so it won't revert back to 10,000 with future HyP3 deployments.