### PR TITLE
Make CMR optional for API validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Increased disk and memory available to OPERA_RTC_S1_SLC jobs in hyp3-opera-prod and hyp3-opera-test.
 - Run OPERA_RTC_S1_SLC jobs using on-demand instances in hyp3-opera-prod and hyp3-opera-test.
 
+### Fixed
+- CMR outages no longer block jobs from being submitted, except for the `OPERA_RTC_S1` and `OPERA_RTC_S1_SLC` job types.
+
 ## [10.11.7]
 
 ### Added

--- a/apps/api/src/hyp3_api/handlers.py
+++ b/apps/api/src/hyp3_api/handlers.py
@@ -12,7 +12,7 @@ from dynamo.exceptions import (
 )
 from hyp3_api import util
 from hyp3_api.multi_burst_validation import MultiBurstValidationError
-from hyp3_api.validation import ValidationError, validate_jobs
+from hyp3_api.validation import ValidationError, validate_jobs, CmrError
 
 
 def problem_format(status: int, message: str) -> Response:
@@ -27,6 +27,8 @@ def post_jobs(body: dict, user: str) -> dict:
 
     try:
         validate_jobs(body['jobs'])
+    except CmrError as e:
+        abort(problem_format(503, str(e)))
     except (ValidationError, MultiBurstValidationError) as e:
         abort(problem_format(400, str(e)))
 

--- a/apps/api/src/hyp3_api/handlers.py
+++ b/apps/api/src/hyp3_api/handlers.py
@@ -1,6 +1,5 @@
 from http.client import responses
 
-import requests
 from flask import Response, abort, jsonify, request
 
 import dynamo
@@ -28,9 +27,6 @@ def post_jobs(body: dict, user: str) -> dict:
 
     try:
         validate_jobs(body['jobs'])
-    except requests.HTTPError as e:
-        print(f'CMR search failed: {e}')
-        abort(problem_format(503, 'Could not submit jobs due to a CMR error. Please try again later.'))
     except (ValidationError, MultiBurstValidationError) as e:
         abort(problem_format(400, str(e)))
 

--- a/apps/api/src/hyp3_api/handlers.py
+++ b/apps/api/src/hyp3_api/handlers.py
@@ -12,7 +12,7 @@ from dynamo.exceptions import (
 )
 from hyp3_api import util
 from hyp3_api.multi_burst_validation import MultiBurstValidationError
-from hyp3_api.validation import ValidationError, validate_jobs, CmrError
+from hyp3_api.validation import CmrError, ValidationError, validate_jobs
 
 
 def problem_format(status: int, message: str) -> Response:

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -26,6 +26,12 @@ class ValidationError(Exception):
     pass
 
 
+class CmrError(Exception):
+    """Raised when the CMR query has failed and the given validator function cannot be safely skipped."""
+
+    pass
+
+
 with (Path(__file__).parent / 'job_validation_map.yml').open() as job_validation_map_file:
     JOB_VALIDATION_MAP = yaml.safe_load(job_validation_map_file.read())
 
@@ -223,9 +229,9 @@ def check_bounding_box_size(job: dict, _, max_bounds_area: float = 4.5) -> None:
         )
 
 
-def check_opera_rtc_s1_bounds(_, granule_metadata: list[dict] | None) -> None:
+def check_opera_rtc_s1_bounds(job: dict, granule_metadata: list[dict] | None) -> None:
     if granule_metadata is None:
-        raise ValidationError('Could not validate job because CMR query failed. Please try again later.')
+        raise CmrError(f'Cannot validate job(s) of type {job["job_type"]} because CMR query failed. Please try again later.')
 
     opera_rtc_s1_bounds = box(-180, -60, 180, 90)
     for granule in granule_metadata:

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -131,15 +131,15 @@ def check_single_burst_pair(job: dict, _) -> None:
 
 
 def check_not_antimeridian(_, granule_metadata: list[dict] | None) -> None:
-    # TODO: handle granule_metadata is None
-    for granule in granule_metadata:
-        bbox = granule['polygon'].bounds
-        if abs(bbox[0] - bbox[2]) > 180.0 and bbox[0] * bbox[2] < 0.0:
-            msg = (
-                f'Granule {granule["name"]} crosses the antimeridian.'
-                ' Processing across the antimeridian is not currently supported.'
-            )
-            raise ValidationError(msg)
+    if granule_metadata is not None:
+        for granule in granule_metadata:
+            bbox = granule['polygon'].bounds
+            if abs(bbox[0] - bbox[2]) > 180.0 and bbox[0] * bbox[2] < 0.0:
+                msg = (
+                    f'Granule {granule["name"]} crosses the antimeridian.'
+                    ' Processing across the antimeridian is not currently supported.'
+                )
+                raise ValidationError(msg)
 
 
 def _format_points(point_string: str) -> list:

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -231,7 +231,9 @@ def check_bounding_box_size(job: dict, _, max_bounds_area: float = 4.5) -> None:
 
 def check_opera_rtc_s1_bounds(job: dict, granule_metadata: list[dict] | None) -> None:
     if granule_metadata is None:
-        raise CmrError(f'Cannot validate job(s) of type {job["job_type"]} because CMR query failed. Please try again later.')
+        raise CmrError(
+            f'Cannot validate job(s) of type {job["job_type"]} because CMR query failed. Please try again later.'
+        )
 
     opera_rtc_s1_bounds = box(-180, -60, 180, 90)
     for granule in granule_metadata:

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -304,7 +304,6 @@ def validate_jobs(jobs: list[dict]) -> None:
     if granules:
         granule_metadata = _get_cmr_metadata(granules)
         if granule_metadata is not None:
-            # TODO: fine to make this optional?
             _make_sure_granules_exist(granules, granule_metadata)
     else:
         granule_metadata = []

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -224,7 +224,9 @@ def check_bounding_box_size(job: dict, _, max_bounds_area: float = 4.5) -> None:
 
 
 def check_opera_rtc_s1_bounds(_, granule_metadata: list[dict] | None) -> None:
-    # TODO: handle granule_metadata is None
+    if granule_metadata is None:
+        raise ValidationError('Could not validate job because CMR query failed. Please try again later.')
+
     opera_rtc_s1_bounds = box(-180, -60, 180, 90)
     for granule in granule_metadata:
         if not granule['polygon'].intersects(opera_rtc_s1_bounds):

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -179,19 +179,19 @@ def check_bounds_formatting(job: dict, _) -> None:
 
 
 def check_granules_intersecting_bounds(job: dict, granule_metadata: list[dict] | None) -> None:
-    # TODO: handle granule_metadata is None
     bounds = job['job_parameters']['bounds']
     if bounds == [0.0, 0.0, 0.0, 0.0]:
         raise ValidationError('Invalid bounds. Bounds cannot be [0, 0, 0, 0].')
 
-    bounds = Polygon.from_bounds(*bounds)
-    bad_granules = []
-    for granule in granule_metadata:
-        bbox = granule['polygon']
-        if not bbox.intersection(bounds):
-            bad_granules.append(granule['name'])
-    if bad_granules:
-        raise ValidationError(f'The following granules do not intersect the provided bounds: {bad_granules}.')
+    if granule_metadata is not None:
+        bounds = Polygon.from_bounds(*bounds)
+        bad_granules = []
+        for granule in granule_metadata:
+            bbox = granule['polygon']
+            if not bbox.intersection(bounds):
+                bad_granules.append(granule['name'])
+        if bad_granules:
+            raise ValidationError(f'The following granules do not intersect the provided bounds: {bad_granules}.')
 
 
 def check_same_relative_orbits(_, granule_metadata: list[dict] | None) -> None:

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -90,10 +90,10 @@ def _make_sure_granules_exist(granules: Iterable[str], granule_metadata: list[di
 
 
 def check_dem_coverage(_, granule_metadata: list[dict] | None) -> None:
-    # TODO: handle granule_metadata is None
-    bad_granules = [g['name'] for g in granule_metadata if not _has_sufficient_coverage(g['polygon'])]
-    if bad_granules:
-        raise ValidationError(f'Some requested scenes do not have DEM coverage: {", ".join(bad_granules)}')
+    if granule_metadata is not None:
+        bad_granules = [g['name'] for g in granule_metadata if not _has_sufficient_coverage(g['polygon'])]
+        if bad_granules:
+            raise ValidationError(f'Some requested scenes do not have DEM coverage: {", ".join(bad_granules)}')
 
 
 def check_multi_burst_pairs(job: dict, _) -> None:

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -195,21 +195,21 @@ def check_granules_intersecting_bounds(job: dict, granule_metadata: list[dict] |
 
 
 def check_same_relative_orbits(_, granule_metadata: list[dict] | None) -> None:
-    # TODO: handle granule_metadata is None
-    previous_relative_orbit = None
-    for granule in granule_metadata:
-        name_split = granule['name'].split('_')
-        absolute_orbit = name_split[7]
-        # "Relationship between relative and absolute orbit numbers": https://sentiwiki.copernicus.eu/web/s1-products
-        offset = 73 if name_split[0] == 'S1A' else 27
-        relative_orbit = ((int(absolute_orbit) - offset) % 175) + 1
-        if not previous_relative_orbit:
-            previous_relative_orbit = relative_orbit
-        if relative_orbit != previous_relative_orbit:
-            raise ValidationError(
-                f'Relative orbit number for {granule["name"]} does not match that of the previous granules: '
-                f'{relative_orbit} is not {previous_relative_orbit}.'
-            )
+    if granule_metadata is not None:
+        previous_relative_orbit = None
+        for granule in granule_metadata:
+            name_split = granule['name'].split('_')
+            absolute_orbit = name_split[7]
+            # "Relationship between relative and absolute orbit numbers": https://sentiwiki.copernicus.eu/web/s1-products
+            offset = 73 if name_split[0] == 'S1A' else 27
+            relative_orbit = ((int(absolute_orbit) - offset) % 175) + 1
+            if not previous_relative_orbit:
+                previous_relative_orbit = relative_orbit
+            if relative_orbit != previous_relative_orbit:
+                raise ValidationError(
+                    f'Relative orbit number for {granule["name"]} does not match that of the previous granules: '
+                    f'{relative_orbit} is not {previous_relative_orbit}.'
+                )
 
 
 def check_bounding_box_size(job: dict, _, max_bounds_area: float = 4.5) -> None:

--- a/tests/test_api/test_opera_rtc_s1.py
+++ b/tests/test_api/test_opera_rtc_s1.py
@@ -2,9 +2,10 @@ from http import HTTPStatus
 from unittest.mock import MagicMock
 
 import pytest
+import responses
 
 import hyp3_api.validation
-from test_api.conftest import JOBS_URI, login
+from test_api.conftest import CMR_URL_RE, JOBS_URI, login
 
 
 @pytest.mark.network
@@ -259,6 +260,29 @@ def test_opera_rtc_s1_bounds(client, tables, approved_user):
         response.json['detail'] == 'Granule S1_018641_IW1_20180307T081710_HH_20C9-BURST is south of -60 degrees '
         'latitude and outside the valid processing extent for OPERA RTC-S1 products.'
     )
+    assert len(tables.jobs_table.scan()['Items']) == 0
+
+
+@responses.activate
+def test_opera_rtc_s1_bounds_cmr_error(client, tables, approved_user):
+    login(client, username=approved_user)
+
+    responses.post(url=CMR_URL_RE, status=500)
+
+    response = client.post(
+        JOBS_URI,
+        json={
+            'jobs': [
+                {
+                    'job_type': 'OPERA_RTC_S1',
+                    'job_parameters': {'granules': ['S1_018641_IW1_20180307T081710_HH_20C9-BURST']},
+                }
+            ],
+        },
+    )
+
+    assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+    assert response.json['detail'] == 'Cannot validate job(s) of type OPERA_RTC_S1 because CMR query failed. Please try again later.'
     assert len(tables.jobs_table.scan()['Items']) == 0
 
 

--- a/tests/test_api/test_opera_rtc_s1.py
+++ b/tests/test_api/test_opera_rtc_s1.py
@@ -282,7 +282,10 @@ def test_opera_rtc_s1_bounds_cmr_error(client, tables, approved_user):
     )
 
     assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
-    assert response.json['detail'] == 'Cannot validate job(s) of type OPERA_RTC_S1 because CMR query failed. Please try again later.'
+    assert (
+        response.json['detail']
+        == 'Cannot validate job(s) of type OPERA_RTC_S1 because CMR query failed. Please try again later.'
+    )
     assert len(tables.jobs_table.scan()['Items']) == 0
 
 

--- a/tests/test_api/test_submit_job.py
+++ b/tests/test_api/test_submit_job.py
@@ -485,14 +485,3 @@ def test_submit_validate_only(client, tables, approved_user):
     assert response.status_code == HTTPStatus.OK
     jobs = tables.jobs_table.scan()['Items']
     assert len(jobs) == 2
-
-
-@responses.activate
-def test_cmr_error(client, tables, approved_user):
-    login(client, username=approved_user)
-    responses.post(url=CMR_URL_RE, status=500)
-
-    response = submit_batch(client, [make_job()])
-    assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
-    assert response.json['detail'] == 'Could not submit jobs due to a CMR error. Please try again later.'
-    assert len(tables.jobs_table.scan()['Items']) == 0

--- a/tests/test_api/test_submit_job.py
+++ b/tests/test_api/test_submit_job.py
@@ -6,7 +6,7 @@ import responses
 import hyp3_api.util
 from dynamo.user import APPLICATION_PENDING
 from dynamo.util import current_utc_time
-from test_api.conftest import CMR_URL_RE, JOBS_URI, login, setup_mock_cmr_response_for_polygons
+from test_api.conftest import JOBS_URI, login, setup_mock_cmr_response_for_polygons
 
 
 def make_job(granules=None, name='someName', job_type='RTC_GAMMA', parameters=None):

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -424,12 +424,17 @@ def test_check_granules_intersecting_bounds():
     ]
     validation.check_granules_intersecting_bounds(job_with_specified_bounds, valid_granule_metadata)
 
+    validation.check_granules_intersecting_bounds(job_with_specified_bounds, None)
+
     error_pattern = r'.*Bounds cannot be.*'
     with pytest.raises(validation.ValidationError, match=error_pattern):
         validation.check_granules_intersecting_bounds(job_with_bad_bounds, valid_granule_metadata)
 
     with pytest.raises(validation.ValidationError, match=error_pattern):
         validation.check_granules_intersecting_bounds(job_with_bad_bounds, invalid_granule_metadata)
+
+    with pytest.raises(validation.ValidationError, match=error_pattern):
+        validation.check_granules_intersecting_bounds(job_with_bad_bounds, None)
 
     error_pattern = r".*bounds: \['does_not_intersect1', 'does_not_intersect2', 'does_not_intersect3'\]*"
 

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -493,10 +493,10 @@ def test_check_opera_rtc_s1_bounds():
         validation.check_opera_rtc_s1_bounds(None, granule_metadata)
 
     with pytest.raises(
-        validation.ValidationError,
-        match=r'^Could not validate job because CMR query failed\. Please try again later\.$',
+        validation.CmrError,
+        match=r'^Cannot validate job\(s\) of type OPERA_JOB_TYPE because CMR query failed\. Please try again later\.$',
     ):
-        validation.check_opera_rtc_s1_bounds(None, None)
+        validation.check_opera_rtc_s1_bounds({'job_type': 'OPERA_JOB_TYPE'}, None)
 
 
 def test_check_opera_rtc_s1_date_1_granule():

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -451,7 +451,10 @@ def test_check_same_relative_orbits():
     ]
     invalid_granule_metadata = valid_granule_metadata.copy()
     invalid_granule_metadata.append({'name': 'S1B_IW_RAW__0SDV_20200623T161535_20200623T161607_012345_02A10F_7FD6'})
+
     validation.check_same_relative_orbits({}, valid_granule_metadata)
+    validation.check_same_relative_orbits({}, None)
+
     error_pattern = r'.*69 is not 87.*'
     with pytest.raises(validation.ValidationError, match=error_pattern):
         validation.check_same_relative_orbits({}, invalid_granule_metadata)

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -492,6 +492,9 @@ def test_check_opera_rtc_s1_bounds():
     with pytest.raises(validation.ValidationError, match=r'Granule invalid is south of -60 degrees latitude'):
         validation.check_opera_rtc_s1_bounds(None, granule_metadata)
 
+    with pytest.raises(validation.ValidationError, match=r'^Could not validate job because CMR query failed\. Please try again later\.$'):
+        validation.check_opera_rtc_s1_bounds(None, None)
+
 
 def test_check_opera_rtc_s1_date_1_granule():
     with pytest.raises(validation.InternalValidationError, match=r'^Expected 1 granule.*'):

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -492,7 +492,10 @@ def test_check_opera_rtc_s1_bounds():
     with pytest.raises(validation.ValidationError, match=r'Granule invalid is south of -60 degrees latitude'):
         validation.check_opera_rtc_s1_bounds(None, granule_metadata)
 
-    with pytest.raises(validation.ValidationError, match=r'^Could not validate job because CMR query failed\. Please try again later\.$'):
+    with pytest.raises(
+        validation.ValidationError,
+        match=r'^Could not validate job because CMR query failed\. Please try again later\.$',
+    ):
         validation.check_opera_rtc_s1_bounds(None, None)
 
 

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -365,6 +365,17 @@ def test_validate_jobs():
     with pytest.raises(validation.ValidationError):
         validation.validate_jobs(jobs)
 
+    responses.post(CMR_URL, status=500)
+    jobs = [
+        {
+            'job_type': 'RTC_GAMMA',
+            'job_parameters': {
+                'granules': [granule_without_dem_coverage],
+            },
+        }
+    ]
+    validation.validate_jobs(jobs)
+
 
 def test_all_validators_have_correct_signature():
     validators = [getattr(validation, attr) for attr in dir(validation) if attr.startswith('check_')]

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -24,6 +24,8 @@ def test_not_antimeridian():
     good_granules = [{'polygon': good_rect, 'name': 'good'}, {'polygon': good_rect, 'name': 'good'}]
     validation.check_not_antimeridian({}, good_granules)
 
+    validation.check_not_antimeridian({}, None)
+
     bad_granules = [{'polygon': good_rect, 'name': 'good'}, {'polygon': bad_rect, 'name': 'bad'}]
     with pytest.raises(validation.ValidationError, match=r'.*crosses the antimeridian.*'):
         validation.check_not_antimeridian({}, bad_granules)

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -481,7 +481,7 @@ def test_check_opera_rtc_s1_bounds():
             'polygon': rectangle(0, 1, 0, 1),
         },
     ]
-    validation.check_opera_rtc_s1_bounds(None, granule_metadata)
+    validation.check_opera_rtc_s1_bounds({}, granule_metadata)
 
     granule_metadata.append(
         {
@@ -490,7 +490,7 @@ def test_check_opera_rtc_s1_bounds():
         }
     )
     with pytest.raises(validation.ValidationError, match=r'Granule invalid is south of -60 degrees latitude'):
-        validation.check_opera_rtc_s1_bounds(None, granule_metadata)
+        validation.check_opera_rtc_s1_bounds({}, granule_metadata)
 
     with pytest.raises(
         validation.CmrError,

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -92,6 +92,7 @@ def test_check_dem_coverage():
     validation.check_dem_coverage({}, [covered1])
     validation.check_dem_coverage({}, [covered2])
     validation.check_dem_coverage({}, [covered1, covered2])
+    validation.check_dem_coverage({}, None)
 
     with pytest.raises(validation.ValidationError) as e:
         validation.check_dem_coverage({}, [not_covered])

--- a/tests/test_api/test_validation.py
+++ b/tests/test_api/test_validation.py
@@ -280,6 +280,10 @@ def test_get_cmr_metadata():
         },
     ]
 
+    responses.post(CMR_URL, status=500)
+
+    assert validation._get_cmr_metadata([]) is None
+
 
 @responses.activate
 def test_validate_jobs():


### PR DESCRIPTION
See https://github.com/ASFHyP3/hyp3/issues/2761

TODO:

- [x] Decide which validators can be optional
- [x] Tests
- [x] Revert all unwanted changes from https://github.com/ASFHyP3/hyp3/commit/0dd8fd03de9fbcb1ed32bf861212fa91643e73ce
- [x] Confirm the hyp3-sdk changes that were made to support the 503 error code are still up-to-date
- [x] TODOs in code
- [ ] Rework implementation to check for CMR error once per job type, not per validator?
- [ ] Update changelog for latest release

---

Inventory of CMR-dependent validators:

- [`check_dem_coverage`](https://github.com/ASFHyP3/hyp3/blob/6bdc0eee438a9572b82c13ecb808a1e7d9df2f31/apps/api/src/hyp3_api/validation.py#L86): `INSAR_GAMMA`, `INSAR_ISCE_BURST`, `INSAR_ISCE_MULTI_BURST`, `RTC_GAMMA`, `WATER_MAP`, `WATER_MAP_EQ`
  - This is the one that we definitely want to skip during CMR outages (at least for the two GAMMA job types, I assume the others as well).

- [`check_not_antimeridian`](https://github.com/ASFHyP3/hyp3/blob/6bdc0eee438a9572b82c13ecb808a1e7d9df2f31/apps/api/src/hyp3_api/validation.py#L126): `INSAR_ISCE_BURST`, `INSAR_ISCE_MULTI_BURST`
  - Results in a runtime failure, see https://github.com/ASFHyP3/hyp3-isce2/issues/105

- [`check_granules_intersecting_bounds`](https://github.com/ASFHyP3/hyp3/blob/6bdc0eee438a9572b82c13ecb808a1e7d9df2f31/apps/api/src/hyp3_api/validation.py#L173): `SRG_GSLC`, `SRG_TIME_SERIES`
  - Making this check optional, per @forrestfwilliams [in Mattermost](https://chat.asf.alaska.edu/asf/pl/5aqukwk8ztf65esqdn9t4d4bsh)

- [`check_same_relative_orbits`](https://github.com/ASFHyP3/hyp3/blob/6bdc0eee438a9572b82c13ecb808a1e7d9df2f31/apps/api/src/hyp3_api/validation.py#L188): `SRG_GSLC`, `SRG_TIME_SERIES`
  - Making this check optional, per @forrestfwilliams [in Mattermost](https://chat.asf.alaska.edu/asf/pl/5aqukwk8ztf65esqdn9t4d4bsh)

- [`check_opera_rtc_s1_bounds`](https://github.com/ASFHyP3/hyp3/blob/6bdc0eee438a9572b82c13ecb808a1e7d9df2f31/apps/api/src/hyp3_api/validation.py#L216): `OPERA_RTC_S1`, `OPERA_RTC_S1_SLC`
  - Keeping this a hard requirement for now, per @forrestfwilliams [in Mattermost](https://chat.asf.alaska.edu/asf/pl/1b5e8ducx3b7fkaoeu6tzstade)