### PR TITLE
Release v10.11.8

### DIFF
--- a/.github/workflows/deploy-daac-prod.yml
+++ b/.github/workflows/deploy-daac-prod.yml
@@ -42,15 +42,15 @@ jobs:
             api_name: hyp3-opera-prod
             template_bucket: cf-templates-118mtzosmrltk-us-west-2
             image_tag: latest
-            product_lifetime_in_days: 14
+            product_lifetime_in_days: 5
             default_credits_per_user: 0
             default_application_status: APPROVED
             cost_profile: EDC
             job_files: >-
               job_spec/OPERA_RTC_S1_SLC.yml
-            instance_types: c6i.2xlarge,c6id.2xlarge,c7i.2xlarge
-            default_max_vcpus: 12000
-            expanded_max_vcpus: 12000
+            instance_types: m6id.2xlarge
+            default_max_vcpus: 8000
+            expanded_max_vcpus: 8000
             required_surplus: 0
             security_environment: EDC
             ami_id: /ngap/amis/image_id_ecs_al2023_x86

--- a/.github/workflows/deploy-daac-test.yml
+++ b/.github/workflows/deploy-daac-test.yml
@@ -44,14 +44,14 @@ jobs:
             api_name: hyp3-opera-test
             template_bucket: cf-templates-118ylv0o6jp2n-us-west-2
             image_tag: test
-            product_lifetime_in_days: 14
+            product_lifetime_in_days: 5
             default_credits_per_user: 0
             default_application_status: APPROVED
             cost_profile: EDC
             opera_rtc_s1_end_date: Default
             job_files: >-
               job_spec/OPERA_RTC_S1_SLC.yml
-            instance_types: c6i.2xlarge,c6id.2xlarge,c7i.2xlarge
+            instance_types: m6id.2xlarge
             default_max_vcpus: 800
             expanded_max_vcpus: 800
             required_surplus: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.11.8]
+
+### Changed
+- Increased disk and memory available to OPERA_RTC_S1_SLC jobs in hyp3-opera-prod and hyp3-opera-test.
+- Run OPERA_RTC_S1_SLC jobs using on-demand instances in hyp3-opera-prod and hyp3-opera-test.
+
 ## [10.11.7]
 
 ### Added

--- a/job_spec/OPERA_RTC_S1_SLC.yml
+++ b/job_spec/OPERA_RTC_S1_SLC.yml
@@ -36,9 +36,9 @@ OPERA_RTC_S1_SLC:
         - --num-workers
         - '8'
       timeout: 7200 # 2 hr
-      compute_environment: Default
+      compute_environment: OperaRtcSlc
       vcpu: 8
-      memory: 15200
+      memory: 30000
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD
@@ -47,7 +47,7 @@ OPERA_RTC_S1_SLC:
       command:
         - Ref::job_id
       timeout: 600
-      compute_environment: Default
+      compute_environment: OperaRtcSlc
       vcpu: 1
       memory: 512
       secrets:

--- a/job_spec/config/compute_environments.yml
+++ b/job_spec/config/compute_environments.yml
@@ -27,3 +27,7 @@ compute_environments:
   ItsLiveMeta:
     instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge
     ami_id: ami-0aece254fc7c27a77  # /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
+  OperaRtcSlc:
+    instance_types: m6id.2xlarge
+    allocation_type: EC2
+    allocation_strategy: BEST_FIT_PROGRESSIVE


### PR DESCRIPTION
I've identified two repeatable error cases in the OPERA RTC workflow:

- jobs in the far north of greenland fail
- jobs near the antimeridian fail

Running ten of each failure case in UAT with the increased resources allowed the greenland jobs to succeed. The antimerdian jobs still fail, but with a more specific error message.

