### PR TITLE
reduce vcpus in hyp3-edc-prod deployment

### DIFF
--- a/.github/workflows/deploy-daac-prod.yml
+++ b/.github/workflows/deploy-daac-prod.yml
@@ -31,9 +31,9 @@ jobs:
               job_spec/ARIA_S1_GUNW.yml
               job_spec/OPERA_DISP_TMS.yml
             instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge
-            default_max_vcpus: 3000
-            expanded_max_vcpus: 5600
-            required_surplus: 3500
+            default_max_vcpus: 1500
+            expanded_max_vcpus: 3000
+            required_surplus: 2000
             security_environment: EDC
             ami_id: /ngap/amis/image_id_ecs_al2023_x86
             distribution_url: 'https://d3gm2hf49xd6jj.cloudfront.net'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.11.11]
+
+### Changed
+- Reduced default/max vCPUs for hyp3-edc-prod deployment to 1500/3000, reverting the increase from v10.5.1.
+
 ## [10.11.10]
 
 ### Removed


### PR DESCRIPTION
Reverts the increase in [v10.5.1](https://github.com/ASFHyP3/hyp3/compare/v10.5.0...v10.5.1)

TODO:
- [x] update the `MonthlyBudget` secret of the `hyp3-edc-prod` environment