### PR TITLE
Release v10.11.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.11.13]
+
+### Changed
+- The `INSAR_ISCE_MULTI_BURST` job type has been temporarily pinned to [HyP3 ISCE2 v3.0.1](https://github.com/ASFHyP3/hyp3-isce2/releases/tag/v3.0.1) in preparation for removing the `insar_tops_burst` entrypoint in the upcoming HyP3 ISCE2 v4.0.0 release.
+
 ## [10.11.12]
 
 ### Changed

--- a/job_spec/INSAR_ISCE_MULTI_BURST.yml
+++ b/job_spec/INSAR_ISCE_MULTI_BURST.yml
@@ -105,6 +105,7 @@ INSAR_ISCE_MULTI_BURST:
   steps:
     - name: ''
       image: ghcr.io/asfhyp3/hyp3-isce2
+      image_tag: 3.0.1
       command:
         - ++process
         - insar_tops_burst


### PR DESCRIPTION
Multi-burst golden test still passes as expected. I confirmed edc-test is pulling `ghcr.io/asfhyp3/hyp3-isce2:3.0.1` and edc-prod is still pulling `ghcr.io/asfhyp3/hyp3-isce2:latest`, as expected.