### PR TITLE
only add ARIA_S1_GUNW jobs to plus-test deployment, not plus-prod

### DIFF
--- a/.github/workflows/deploy-plus-prod.yml
+++ b/.github/workflows/deploy-plus-prod.yml
@@ -28,7 +28,6 @@ jobs:
               job_spec/RTC_GAMMA.yml
               job_spec/INSAR_ISCE_BURST.yml
               job_spec/INSAR_ISCE_MULTI_BURST.yml
-              job_spec/ARIA_S1_GUNW.yml
             instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge
             default_max_vcpus: 10000
             expanded_max_vcpus: 10000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [10.11.14]
 
 ### Added
-- Added ARIA_S1_GUNW job type to the `plus-test` and `plus-prod` deployments.
+- Added ARIA_S1_GUNW job type to the `plus-test` deployment.
 - Added `VOLCSARVATORY_MULTI_BURST` job type to run multiburst jobs for `hyp3-volcsarvatory` increasing the max length burst limit.
 
 ### Removed


### PR DESCRIPTION
Per @mattp0 , we're not yet ready to enable ARIA_S1_GUNW Ingest from the plus-prod deployment, pending further configuration and testing in the plus-test deployment.