### PR TITLE
correctly increase vcpus for hyp3-tibet-jpl-test rather than hyp3-a19-jpl-test

### DIFF
--- a/.github/workflows/deploy-custom-test.yml
+++ b/.github/workflows/deploy-custom-test.yml
@@ -28,8 +28,8 @@ jobs:
               job_spec/ARIA_S1_COSEIS.yml
               job_spec/INSAR_ISCE.yml
             instance_types: m6id.xlarge,m6id.2xlarge,m6id.4xlarge,m6id.8xlarge,m6idn.xlarge,m6idn.2xlarge,m6idn.4xlarge,m6idn.8xlarge
-            default_max_vcpus: 6400
-            expanded_max_vcpus: 6400
+            default_max_vcpus: 640
+            expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: JPL-public
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
@@ -49,8 +49,8 @@ jobs:
               job_spec/INSAR_ISCE.yml
               job_spec/OPERA_DIST_S1.yml
             instance_types: m6id.xlarge,m6id.2xlarge,m6id.4xlarge,m6id.8xlarge,m6idn.xlarge,m6idn.2xlarge,m6idn.4xlarge,m6idn.8xlarge
-            default_max_vcpus: 640
-            expanded_max_vcpus: 640
+            default_max_vcpus: 6400
+            expanded_max_vcpus: 6400
             required_surplus: 0
             security_environment: JPL-public
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id


### PR DESCRIPTION
correctly implements this change in the 10.11.14 changelog:

> Increased hyp3-tibet-jpl and hyp3-tibet-jpl-test throughput to 6400 VCPUs.