### PR TITLE
Release v10.11.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.11.16]
+
+### Fixed
+- ScaleCluster now only disables the compute environment when a scale-down is necessary. Fixes https://github.com/ASFHyP3/hyp3/issues/2965
+
 ## [10.11.15]
 
 ### Added

--- a/apps/scale-cluster/src/scale_cluster.py
+++ b/apps/scale-cluster/src/scale_cluster.py
@@ -26,7 +26,8 @@ def get_month_to_date_spending(today: date) -> float:
 
 def get_current_desired_vcpus(compute_environment_arn: str) -> int:
     response = BATCH.describe_compute_environments(computeEnvironments=[compute_environment_arn])
-    return response['computeEnvironments'][0]['computeResources']['desiredvCpus']
+    compute_resources = response['computeEnvironments'][0]['computeResources']
+    return min(compute_resources['desiredvCpus'], compute_resources['maxvCpus'])
 
 
 def set_max_vcpus(compute_environment_arn: str, target_max_vcpus: int, current_desired_vcpus: int) -> None:

--- a/tests/test_scale_cluster.py
+++ b/tests/test_scale_cluster.py
@@ -126,8 +126,28 @@ def test_get_current_desired_vcpus(batch_stubber):
     batch_stubber.add_response(
         method='describe_compute_environments', expected_params=expected_params, service_response=service_response
     )
-
     assert scale_cluster.get_current_desired_vcpus('foo') == 5
+
+    expected_params = {'computeEnvironments': ['bar']}
+    service_response = {
+        'computeEnvironments': [
+            {
+                'computeEnvironmentName': 'environment name',
+                'computeEnvironmentArn': 'environment arn',
+                'ecsClusterArn': 'cluster arn',
+                'computeResources': {
+                    'type': 'MANAGED',
+                    'desiredvCpus': 8,
+                    'maxvCpus': 7,
+                    'subnets': ['subnet1', 'subnet2'],
+                },
+            },
+        ]
+    }
+    batch_stubber.add_response(
+        method='describe_compute_environments', expected_params=expected_params, service_response=service_response
+    )
+    assert scale_cluster.get_current_desired_vcpus('bar') == 7
 
 
 def test_set_max_vcpus(batch_stubber):


### PR DESCRIPTION
ScaleCluster continues to run successfully in the edc-uat deployment, but it would be difficult to exercise this particular edge case there since it requires running a cluster at full capacity for up to several hours.