### PR TITLE
Add in missing an allocation strategy for the SlimSAR compute environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added a `model_context_length` parameter to the `OPERA_DIST_S1` job specification.
 - Added a new custom hyp3-slimsar-test deployment.
 - Added a new `SLIMSAR_TDBP` job_spec for slimsar time-domain backprojection processing.
+- Added a new `SlimSAR` compute environment for slimsar processing.
 - Added a new `ITS_LIVE_CROP_BULK` job spec which re-crops existing ITS_LIVE products which are specified in a parquet file to ensure they are chunk-aligned and have a time dimension, and then it generates STAC JSON and other metadata files.
 - Added a new `ITS_LIVE_META_BULK` job spec which generates STAC JSON and other metadata files for existing ITS_LIVE products which are specified in a parquet file.
 - Added the `ITS_LIVE_CROP_BULK` and `ITS_LIVE_META_BULK` job spec to the ITS_LIVE deployments.

--- a/job_spec/config/compute_environments.yml
+++ b/job_spec/config/compute_environments.yml
@@ -39,5 +39,6 @@ compute_environments:
     allocation_strategy: BEST_FIT_PROGRESSIVE
   SlimSAR:
     instance_types: g4dn.2xlarge,g4dn.4xlarge,g4dn.6xlarge,
-    allocation_type: EC2
     ami_id: ami-03aa99ddf5498ceb9  # /aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended/image_id
+    allocation_type: EC2
+    allocation_strategy: BEST_FIT_PROGRESSIVE


### PR DESCRIPTION
We are missing an allocation strategy for the SlimSAR compute environment. This adds one.