### PR TITLE
Revert "add r8id and m8id instance types to daac-managed deployments"

### DIFF
--- a/.github/workflows/deploy-daac-prod.yml
+++ b/.github/workflows/deploy-daac-prod.yml
@@ -30,7 +30,7 @@ jobs:
               job_spec/INSAR_ISCE_MULTI_BURST.yml
               job_spec/ARIA_S1_GUNW.yml
               job_spec/OPERA_DISP_TMS.yml
-            instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge,r8id.xlarge,r8id.2xlarge,r8id.4xlarge,r8id.8xlarge
+            instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge
             default_max_vcpus: 1200
             expanded_max_vcpus: 2400
             required_surplus: 2000

--- a/.github/workflows/deploy-daac-test.yml
+++ b/.github/workflows/deploy-daac-test.yml
@@ -32,7 +32,7 @@ jobs:
               job_spec/ARIA_S1_GUNW.yml
               job_spec/OPERA_RTC_S1.yml
               job_spec/OPERA_DISP_TMS.yml
-            instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge,r8id.xlarge,r8id.2xlarge,r8id.4xlarge,r8id.8xlarge
+            instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge
             default_max_vcpus: 1200
             expanded_max_vcpus: 2400
             required_surplus: 2000

--- a/.github/workflows/deploy-edc-sandbox.yml
+++ b/.github/workflows/deploy-edc-sandbox.yml
@@ -33,7 +33,7 @@ jobs:
               job_spec/INSAR_ISCE_MULTI_BURST.yml
               job_spec/ARIA_S1_GUNW.yml
               job_spec/OPERA_RTC_S1.yml
-            instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge,r8id.xlarge,r8id.2xlarge,r8id.4xlarge,r8id.8xlarge
+            instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640
             required_surplus: 0

--- a/.github/workflows/deploy-plus-prod.yml
+++ b/.github/workflows/deploy-plus-prod.yml
@@ -28,7 +28,7 @@ jobs:
               job_spec/RTC_GAMMA.yml
               job_spec/INSAR_ISCE_BURST.yml
               job_spec/INSAR_ISCE_MULTI_BURST.yml
-            instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge,r8id.xlarge,r8id.2xlarge,r8id.4xlarge,r8id.8xlarge
+            instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge
             default_max_vcpus: 10000
             expanded_max_vcpus: 10000
             required_surplus: 0

--- a/.github/workflows/deploy-plus-test.yml
+++ b/.github/workflows/deploy-plus-test.yml
@@ -29,7 +29,7 @@ jobs:
               job_spec/INSAR_ISCE_BURST.yml
               job_spec/INSAR_ISCE_MULTI_BURST.yml
               job_spec/ARIA_S1_GUNW.yml
-            instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge,r8id.xlarge,r8id.2xlarge,r8id.4xlarge,r8id.8xlarge
+            instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge
             default_max_vcpus: 10000
             expanded_max_vcpus: 10000
             required_surplus: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [10.13.1]
-
-### Added
-- `r8id` and `m8id` instance types to DAAC-managed deployments
-
 ## [10.13.0]
 
 ### Added

--- a/job_spec/config/compute_environments.yml
+++ b/job_spec/config/compute_environments.yml
@@ -17,7 +17,7 @@ compute_environments:
     allocation_type: EC2
     allocation_strategy: BEST_FIT_PROGRESSIVE
   AriaS1Gunw:
-    instance_types: m6id.xlarge,m6id.2xlarge,m6id.4xlarge,m6id.8xlarge,m8id.xlarge,m8id.2xlarge,m8id.4xlarge,m8id.8xlarge
+    instance_types: m6id.xlarge,m6id.2xlarge,m6id.4xlarge,m6id.8xlarge
     allocation_type: EC2
     allocation_strategy: BEST_FIT_PROGRESSIVE
   DistS1:


### PR DESCRIPTION
Reverts ASFHyP3/hyp3#3013

Batch does not support the new instance types.