### PR TITLE
fix typo in slimsar job spec for bucket-prefix

### DIFF
--- a/job_spec/SLIMSAR_TDBP.yml
+++ b/job_spec/SLIMSAR_TDBP.yml
@@ -63,7 +63,7 @@ SLIMSAR_TDBP:
         - Ref:pols
         - --bucket
         - '!Ref Bucket'
-        - --bucket_prefix
+        - --bucket-prefix
         - Ref::job_id
       timeout: 126000  # 35 hours
       compute_environment: SlimSAR


### PR DESCRIPTION
Change `bucket_prefix` to `bucket-prefix` in slimsar job_spec.