### PR TITLE
Temporarily set NISAR as a third party granule

### DIFF
--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -91,7 +91,7 @@ def _get_cmr_metadata(granules: Iterable[str]) -> list[dict]:
 
 
 def _is_third_party_granule(granule: str) -> bool:
-    return granule.startswith('S2') or granule.startswith('L')
+    return granule.startswith('S2') or granule.startswith('L') or granule.startswith('NISAR')
 
 
 def _make_sure_granules_exist(granules: Iterable[str], granule_metadata: list[dict]) -> None:


### PR DESCRIPTION
Running NISAR pairs through HyP3 fails currently with:
> Some requested scenes could not be found: NISAR_L1_PR_RSLC_010_160_A_036_7700_SHNA_A_20260120T070339_20260120T070415_X05010_N_P_J_001, NISAR_L1_PR_RSLC_009_160_A_036_7700_SHNA_A_20260108T070338_20260108T070415_X05009_N_P_J_001, NISAR_L2_PR_GSLC_009_160_A_036_7700_SHNA_A_20260108T070338_20260108T070415_X05009_N_P_J_001, NISAR_L2_PR_GSLC_010_160_A_036_7700_SHNA_A_20260120T070339_20260120T070415_X05010_N_P_J_001

Because HyP3 ensures CMR granules exist as part of job validation, but only looks in Sentinel-1 collections currently:
https://github.com/ASFHyP3/hyp3/blob/develop/apps/api/src/hyp3_api/validation.py#L55-L69

Unless we specify it as a "third-party" granule:
https://github.com/ASFHyP3/hyp3/blob/develop/apps/api/src/hyp3_api/validation.py#L100

I haven't added the NISAR collections yet because NISAR data is uncalibrated and therefore in beta collections. Looking ahead, there may be a provisional collection, and eventually a production/calibrated collection. So this allows us to process any NISAR collection for the time being, and once the calibrated data is available, we can add the prod collections and enable existence validation in the API.