### PR TITLE
Revert the `r6id[n]` upgrade to `r8id` instances for spot compute environments

### DIFF
--- a/.github/workflows/deploy-custom-prod.yml
+++ b/.github/workflows/deploy-custom-prod.yml
@@ -242,6 +242,7 @@ jobs:
               job_spec/INSAR_GAMMA.yml
               job_spec/RTC_GAMMA.yml
               job_spec/INSAR_ISCE_BURST_SPOT.yml
+              job_spec/INSAR_ISCE_BURST_EC2.yml
               job_spec/INSAR_ISCE_MULTI_BURST.yml
             instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge
             default_max_vcpus: 6000  # Max: 6000

--- a/.github/workflows/deploy-custom-prod.yml
+++ b/.github/workflows/deploy-custom-prod.yml
@@ -243,7 +243,7 @@ jobs:
               job_spec/RTC_GAMMA.yml
               job_spec/INSAR_ISCE_BURST_SPOT.yml
               job_spec/INSAR_ISCE_MULTI_BURST.yml
-            instance_types: r8id.xlarge,r8id.2xlarge,r8id.4xlarge,r8id.8xlarge,r8id.12xlarge,r8id.16xlarge
+            instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge
             default_max_vcpus: 6000  # Max: 6000
             expanded_max_vcpus: 6000  # Max: 6000
             required_surplus: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The `ItsLiveSpotIntel` compute environment now has a maximum vCPUs of 1000 to prevent ITS_LIVE production from overwhelming the STAC catalog.
 
+### Added
+- Added an `INSAR_ISCE_BURST_EC2` job type, that will use the `Default` on-demand compute environment. This is intended to be paired with the `INSAR_ISCE_BURST` job type defined in the `INSAR_ISCE_BUSRT_SPOT.yml` job spec which uses the `DefaultSpot` compute environment and allows end-users to submit either spot or on-demand jobs.
+- Added the `INSAR_ISCE_BURST_EC2` job type to the Cargill custom HyP3 deployment.
+
 ### Fixed
 - Reverted the `r6id[n]` upgrade to `r8id` instances for spot compute environments due to lack of spot capacity. This includes the `Default` and `DefaultSpot` environments for `hyp3-cargill` and the `ItsLiveIntel` and `ItsLiveSpotIntel` compute environments.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The `ItsLiveSpotIntel` compute environment now has a maximum vCPUs of 1000 to prevent ITS_LIVE production from overwhelming the STAC catalog.
 
+### Fixed
+- Reverted the `r6id[n]` upgrade to `r8id` instances for spot compute environments due to lack of spot capacity. This includes the `Default` and `DefaultSpot` environments for `hyp3-cargill` and the `ItsLiveIntel` and `ItsLiveSpotIntel` compute environments.
+
 ## [10.14.5]
 
 ### Changed

--- a/job_spec/INSAR_ISCE_BURST_EC2.yml
+++ b/job_spec/INSAR_ISCE_BURST_EC2.yml
@@ -1,0 +1,67 @@
+INSAR_ISCE_BURST_EC2:
+  required_parameters:
+    - granules
+  parameters:
+    granules:
+      api_schema:
+        type: array
+        minItems: 2
+        maxItems: 2
+        example:
+          - S1_136231_IW2_20200604T022312_VV_7C85-BURST
+          - S1_136231_IW2_20200616T022313_VV_5D11-BURST
+        items:
+          description: Name of the Sentinel-1 SLC IW burst granule to process
+          type: string
+          pattern: "^S1_\\d{6}_IW.*-BURST"
+          minLength: 43
+          maxLength: 43
+          example: S1_136231_IW2_20200604T022312_VV_7C85-BURST
+    apply_water_mask:
+      api_schema:
+        description: Sets pixels over coastal and large inland waterbodies as invalid for phase unwrapping.
+        default: false
+        type: boolean
+    looks:
+      api_schema:
+        description: Number of looks to take in range and azimuth
+        type: string
+        default: 20x4
+        enum:
+          - 20x4
+          - 10x2
+          - 5x1
+  cost_profiles:
+    EDC:
+      cost: 1.0
+    DEFAULT:
+      cost: 1.0
+  validators:
+    - check_single_burst_pair
+    - check_dem_coverage
+    - check_not_antimeridian
+  steps:
+    - name: ''
+      image: ghcr.io/asfhyp3/hyp3-isce2
+      image_tag: 3.0.1
+      command:
+        - ++process
+        - insar_tops_burst
+        - ++omp-num-threads
+        - '1'
+        - --bucket
+        - '!Ref Bucket'
+        - --bucket-prefix
+        - Ref::job_id
+        - --apply-water-mask
+        - Ref::apply_water_mask
+        - --looks
+        - Ref::looks
+        - Ref::granules
+      timeout: 5400
+      compute_environment: Default
+      vcpu: 1
+      memory: 7600
+      secrets:
+        - EARTHDATA_USERNAME
+        - EARTHDATA_PASSWORD

--- a/job_spec/config/compute_environments.yml
+++ b/job_spec/config/compute_environments.yml
@@ -11,13 +11,13 @@ compute_environments:
   SrgTimeSeries:
     instance_types: c6id.16xlarge
   ItsLiveSpotIntel:
-    instance_types: r8id.xlarge,r8id.2xlarge,r8id.4xlarge,r8id.8xlarge,r8id.12xlarge,r8id.16xlarge
+    instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge
     ami_id: "'{{resolve:ssm:/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id}}'"
     allocation_type: SPOT
     allocation_strategy: SPOT_PRICE_CAPACITY_OPTIMIZED
     max_vcpus: 1000
   ItsLiveIntel:
-    instance_types: r8id.xlarge,r8id.2xlarge,r8id.4xlarge,r8id.8xlarge,r8id.12xlarge,r8id.16xlarge
+    instance_types: r6id.xlarge,r6id.2xlarge,r6id.4xlarge,r6id.8xlarge,r6idn.xlarge,r6idn.2xlarge,r6idn.4xlarge,r6idn.8xlarge
     ami_id: "'{{resolve:ssm:/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id}}'"
   SlimSAR:
     instance_types: g4dn.2xlarge,g4dn.4xlarge,g4dn.8xlarge,g4dn.16xlarge


### PR DESCRIPTION
Also, allow Cargill to select EC2 or SPOT instances.