### PR TITLE
Update ARIA_AUTORIFT schema to support Sentinel-2 L2A STAC IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Added
+- Added support for Element84 Sentinel-2 L2A STAC IDs to the `ARIA_AUTORIFT` job spec.
+
 ## [10.15.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.16.5]
+
+### Added
+- Added support for Element84 Sentinel-2 L2A STAC IDs to the `ARIA_AUTORIFT` job spec.
+
 ## [10.16.4]
 
 ### Added

--- a/job_spec/ARIA_AUTORIFT.yml
+++ b/job_spec/ARIA_AUTORIFT.yml
@@ -36,6 +36,12 @@ AUTORIFT:
               minLength: 60
               maxLength: 60
               example: S2A_MSIL1C_20200627T150921_N0209_R025_T22WEB_20200627T170912
+            - description: The name of the Sentinel-2 L2A STAC granule to process (Element84 naming convention)
+              type: string
+              pattern: "^S2[ABCD]_T[A-Z0-9]{5}_[0-9]{8}T[0-9]{6}_L2A$"
+              minLength: 30
+              maxLength: 30
+              example: S2A_T52JFR_20260226T012311_L2A
             - description: The name of the Landsat 4, 5, 7, 8 or 9 Collection 2 granule to process
               type: string
               pattern: "^L([CO]0[89]|E07|T0[45])_L1"
@@ -77,6 +83,12 @@ AUTORIFT:
               minLength: 60
               maxLength: 60
               example: S2A_MSIL1C_20200627T150921_N0209_R025_T22WEB_20200627T170912
+            - description: The name of the Sentinel-2 L2A STAC granule to process (Element84 naming convention)
+              type: string
+              pattern: "^S2[ABCD]_T[A-Z0-9]{5}_[0-9]{8}T[0-9]{6}_L2A$"
+              minLength: 30
+              maxLength: 30
+              example: S2A_T52JFR_20260226T012311_L2A
             - description: The name of the Landsat 4, 5, 7, 8 or 9 Collection 2 granule to process
               type: string
               pattern: "^L([CO]0[89]|E07|T0[45])_L1"
@@ -113,6 +125,12 @@ AUTORIFT:
               minLength: 60
               maxLength: 60
               example: S2A_MSIL1C_20200627T150921_N0209_R025_T22WEB_20200627T170912
+            - description: The name of the Sentinel-2 L2A STAC granule to process (Element84 naming convention)
+              type: string
+              pattern: "^S2[ABCD]_T[A-Z0-9]{5}_[0-9]{8}T[0-9]{6}_L2A$"
+              minLength: 30
+              maxLength: 30
+              example: S2A_T52JFR_20260226T012311_L2A
             - description: The name of the Landsat 4, 5, 7, 8 or 9 Collection 2 granule to process
               type: string
               pattern: "^L([CO]0[89]|E07|T0[45])_L1"


### PR DESCRIPTION
This PR updates the API validation schema in `ARIA_AUTORIFT.yml` to accept Element84 Sentinel-2 L2A STAC granule IDs. This update is needed for deploying `hyp3-autorift` jobs using Sentinel-2 L2A scenes from the Element84 SATC instead of L1C scenes from Google cloud storage.

### Changes

- Added the `^S2[ABCD]_T[A-Z0-9]{5}_[0-9]{8}T[0-9]{6}_L2A$` regex pattern to the `reference`, `secondary`, and `granules` parameters with `minLength` / `maxLength` of 30 characters to match Element84 Sentinel-2 L2A filenames.