### PR TITLE
Reduce footprint of INSAR_GAMMA jobs

### DIFF
--- a/.github/workflows/deploy-edc-sandbox.yml
+++ b/.github/workflows/deploy-edc-sandbox.yml
@@ -31,7 +31,7 @@ jobs:
               job_spec/INSAR_ISCE_BURST.yml
               job_spec/INSAR_ISCE_MULTI_BURST.yml
               job_spec/ARIA_S1_GUNW.yml
-            instance_types: r8id.xlarge
+            instance_types: r8id.large
             default_max_vcpus: 640
             expanded_max_vcpus: 640
             required_surplus: 0

--- a/.github/workflows/deploy-edc-sandbox.yml
+++ b/.github/workflows/deploy-edc-sandbox.yml
@@ -31,7 +31,7 @@ jobs:
               job_spec/INSAR_ISCE_BURST.yml
               job_spec/INSAR_ISCE_MULTI_BURST.yml
               job_spec/ARIA_S1_GUNW.yml
-            instance_types: r8id.large
+            instance_types: r8id.xlarge,r8id.2xlarge,r8id.4xlarge,r8id.8xlarge,r8id.12xlarge,r8id.16xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640
             required_surplus: 0

--- a/.github/workflows/deploy-edc-sandbox.yml
+++ b/.github/workflows/deploy-edc-sandbox.yml
@@ -31,7 +31,7 @@ jobs:
               job_spec/INSAR_ISCE_BURST.yml
               job_spec/INSAR_ISCE_MULTI_BURST.yml
               job_spec/ARIA_S1_GUNW.yml
-            instance_types: r8id.xlarge
+            instance_types: r8id.xlarge,r8id.2xlarge,r8id.4xlarge,r8id.8xlarge,r8id.12xlarge,r8id.16xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640
             required_surplus: 0

--- a/.github/workflows/deploy-edc-sandbox.yml
+++ b/.github/workflows/deploy-edc-sandbox.yml
@@ -31,7 +31,7 @@ jobs:
               job_spec/INSAR_ISCE_BURST.yml
               job_spec/INSAR_ISCE_MULTI_BURST.yml
               job_spec/ARIA_S1_GUNW.yml
-            instance_types: r8id.xlarge,r8id.2xlarge,r8id.4xlarge,r8id.8xlarge,r8id.12xlarge,r8id.16xlarge
+            instance_types: r8id.large
             default_max_vcpus: 640
             expanded_max_vcpus: 640
             required_surplus: 0

--- a/.github/workflows/deploy-edc-sandbox.yml
+++ b/.github/workflows/deploy-edc-sandbox.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   push:
     branches:
-      - insar-patches
+      - hyp3-edc-sandbox
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -25,7 +25,12 @@ jobs:
             default_application_status: APPROVED
             cost_profile: EDC
             job_files: >-
+              job_spec/AUTORIFT.yml
               job_spec/INSAR_GAMMA.yml
+              job_spec/RTC_GAMMA.yml
+              job_spec/INSAR_ISCE_BURST.yml
+              job_spec/INSAR_ISCE_MULTI_BURST.yml
+              job_spec/ARIA_S1_GUNW.yml
             instance_types: r8id.xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640

--- a/.github/workflows/deploy-edc-sandbox.yml
+++ b/.github/workflows/deploy-edc-sandbox.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   push:
     branches:
-      - hyp3-edc-sandbox
+      - insar-patches
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -25,13 +25,8 @@ jobs:
             default_application_status: APPROVED
             cost_profile: EDC
             job_files: >-
-              job_spec/AUTORIFT.yml
               job_spec/INSAR_GAMMA.yml
-              job_spec/RTC_GAMMA.yml
-              job_spec/INSAR_ISCE_BURST.yml
-              job_spec/INSAR_ISCE_MULTI_BURST.yml
-              job_spec/ARIA_S1_GUNW.yml
-            instance_types: r8id.xlarge,r8id.2xlarge,r8id.4xlarge,r8id.8xlarge,r8id.12xlarge,r8id.16xlarge
+            instance_types: r8id.xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640
             required_surplus: 0

--- a/.github/workflows/deploy-edc-sandbox.yml
+++ b/.github/workflows/deploy-edc-sandbox.yml
@@ -31,7 +31,7 @@ jobs:
               job_spec/INSAR_ISCE_BURST.yml
               job_spec/INSAR_ISCE_MULTI_BURST.yml
               job_spec/ARIA_S1_GUNW.yml
-            instance_types: m8id.xlarge
+            instance_types: r8id.xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640
             required_surplus: 0

--- a/.github/workflows/deploy-edc-sandbox.yml
+++ b/.github/workflows/deploy-edc-sandbox.yml
@@ -31,7 +31,7 @@ jobs:
               job_spec/INSAR_ISCE_BURST.yml
               job_spec/INSAR_ISCE_MULTI_BURST.yml
               job_spec/ARIA_S1_GUNW.yml
-            instance_types: r8id.large
+            instance_types: m8id.xlarge
             default_max_vcpus: 640
             expanded_max_vcpus: 640
             required_surplus: 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.15.1]
+
+### Changed
+- Reduced memory requirement for INSAR_GAMMA jobs to 15,500 MB in to reflect reduced usage in hyp3-gamma v9.0.9.
+
 ## [10.15.0]
 
 ### Added

--- a/job_spec/INSAR_GAMMA.yml
+++ b/job_spec/INSAR_GAMMA.yml
@@ -85,7 +85,7 @@ INSAR_GAMMA:
         - ++process
         - insar
         - ++omp-num-threads
-        - '4'
+        - '2'
         - --bucket
         - '!Ref Bucket'
         - --bucket-prefix
@@ -112,7 +112,7 @@ INSAR_GAMMA:
       timeout: 10800
       compute_environment: Default
       vcpu: 1
-      memory: 31000
+      memory: 15500
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD

--- a/job_spec/INSAR_GAMMA.yml
+++ b/job_spec/INSAR_GAMMA.yml
@@ -85,7 +85,7 @@ INSAR_GAMMA:
         - ++process
         - insar
         - ++omp-num-threads
-        - '2'
+        - '4'
         - --bucket
         - '!Ref Bucket'
         - --bucket-prefix

--- a/job_spec/INSAR_GAMMA.yml
+++ b/job_spec/INSAR_GAMMA.yml
@@ -112,7 +112,7 @@ INSAR_GAMMA:
       timeout: 10800
       compute_environment: Default
       vcpu: 1
-      memory: 15500
+      memory: 31000
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD

--- a/job_spec/INSAR_GAMMA.yml
+++ b/job_spec/INSAR_GAMMA.yml
@@ -80,7 +80,7 @@ INSAR_GAMMA:
   steps:
     - name: ''
       image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma
-      image_tag: 9.0.9.dev6_gf2ce2cbbe
+      image_tag: 9.0.9.dev8_g77f55018d
       command:
         - ++process
         - insar

--- a/job_spec/INSAR_GAMMA.yml
+++ b/job_spec/INSAR_GAMMA.yml
@@ -80,11 +80,12 @@ INSAR_GAMMA:
   steps:
     - name: ''
       image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma
+      image_tag: 9.0.9.dev6_gf2ce2cbbe
       command:
         - ++process
         - insar
         - ++omp-num-threads
-        - '4'
+        - '2'
         - --bucket
         - '!Ref Bucket'
         - --bucket-prefix
@@ -111,7 +112,7 @@ INSAR_GAMMA:
       timeout: 10800
       compute_environment: Default
       vcpu: 1
-      memory: 31500
+      memory: 15500
       secrets:
         - EARTHDATA_USERNAME
         - EARTHDATA_PASSWORD

--- a/job_spec/INSAR_GAMMA.yml
+++ b/job_spec/INSAR_GAMMA.yml
@@ -80,7 +80,6 @@ INSAR_GAMMA:
   steps:
     - name: ''
       image: 845172464411.dkr.ecr.us-west-2.amazonaws.com/hyp3-gamma
-      image_tag: 9.0.9.dev8_g77f55018d
       command:
         - ++process
         - insar


### PR DESCRIPTION
Reduces resources allocated to INSAR_GAMMA jobs to reflect the reduced memory/disk requirement implemented in https://github.com/ASFHyP3/hyp3-gamma/pull/693

These jobs will run slower, but we'll be paying half as much per hour, which might make them 20-30% more cost efficient.