### PR TITLE
Fix S1C validation for SRG_TIME_SERIES and SRG_GSLC 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.16.1]
+
+### Fixed
+- Resolved SRG_GSLC and SRG_TIME_SERIES issue related to Sentinel-1C validation.
+
 ## [10.16.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [10.16.1]
 
 ### Fixed
-- Resolved SRG_GSLC and SRG_TIME_SERIES issue related to Sentinel-1C validation.
+- Allow SRG_GSLC and SRG_TIME_SERIES jobs to process Sentinel-1 C and D granules.
 
 ## [10.16.0]
 

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -209,7 +209,7 @@ def check_same_relative_orbits(_, granule_metadata: list[dict]) -> None:
         name_split = granule['name'].split('_')
         absolute_orbit = name_split[7]
         # "Relationship between relative and absolute orbit numbers": https://sentiwiki.copernicus.eu/web/s1-products
-        offset = 73 if name_split[0] == 'S1A' else 27
+        offset = 73 if name_split[0] == 'S1A' else (172 if name_split[0] == 'S1C' else 27)
         relative_orbit = ((int(absolute_orbit) - offset) % 175) + 1
         if not previous_relative_orbit:
             previous_relative_orbit = relative_orbit

--- a/apps/api/src/hyp3_api/validation.py
+++ b/apps/api/src/hyp3_api/validation.py
@@ -209,7 +209,17 @@ def check_same_relative_orbits(_, granule_metadata: list[dict]) -> None:
         name_split = granule['name'].split('_')
         absolute_orbit = name_split[7]
         # "Relationship between relative and absolute orbit numbers": https://sentiwiki.copernicus.eu/web/s1-products
-        offset = 73 if name_split[0] == 'S1A' else (172 if name_split[0] == 'S1C' else 27)
+        mission = name_split[0]
+        if mission == 'S1A':
+            offset = 73
+        elif mission == 'S1B':
+            offset = 27
+        elif mission == 'S1C':
+            offset = 172
+        elif mission == 'S1D':
+            offset = 42
+        else:
+            raise ValueError(f'Encountered unknown Sentinel-1 mission: {mission}')
         relative_orbit = ((int(absolute_orbit) - offset) % 175) + 1
         if not previous_relative_orbit:
             previous_relative_orbit = relative_orbit


### PR DESCRIPTION
This PR is to fix a bug for `SRG_TIME_SERIES` and `SRG_GSLC` related to the S1C validation. The value for S1C is taken from https://sentiwiki.copernicus.eu/web/s1-products