### PR TITLE
reduce default credits per user to 4,000 for daac deployments

### DIFF
--- a/.github/workflows/deploy-daac-prod.yml
+++ b/.github/workflows/deploy-daac-prod.yml
@@ -19,7 +19,7 @@ jobs:
             template_bucket: cf-templates-118mtzosmrltk-us-west-2
             image_tag: latest
             product_lifetime_in_days: 14
-            default_credits_per_user: 8000
+            default_credits_per_user: 4000
             default_application_status: APPROVED
             cost_profile: EDC
             job_files: >-

--- a/.github/workflows/deploy-daac-test.yml
+++ b/.github/workflows/deploy-daac-test.yml
@@ -19,7 +19,7 @@ jobs:
             template_bucket: cf-templates-118ylv0o6jp2n-us-west-2
             image_tag: test
             product_lifetime_in_days: 14
-            default_credits_per_user: 8000
+            default_credits_per_user: 4000
             default_application_status: NOT_STARTED
             cost_profile: EDC
             job_files: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [10.16.1]
 
+### Changed
+- Reduced default credits per user to 4,000 from 8,000 for the `hyp3-edc-prod` and `hyp3-edc-uat` deployments.
+
 ### Fixed
 - Allow SRG_GSLC and SRG_TIME_SERIES jobs to process Sentinel-1 C and D granules.
 


### PR DESCRIPTION
We'll need to coordinate delivery to production along with corresponding changes to hyp3-docs