### PR TITLE
increase vcpus to 900/1800 in DAAC deployments

### DIFF
--- a/.github/workflows/deploy-daac-prod.yml
+++ b/.github/workflows/deploy-daac-prod.yml
@@ -31,9 +31,9 @@ jobs:
               job_spec/ARIA_S1_GUNW.yml
               job_spec/OPERA_DISP_TMS.yml
             instance_types: r8id.xlarge,r8id.2xlarge,r8id.4xlarge,r8id.8xlarge,r8id.12xlarge,r8id.16xlarge
-            default_max_vcpus: 600
-            expanded_max_vcpus: 1200
-            required_surplus: 2000
+            default_max_vcpus: 900
+            expanded_max_vcpus: 1800
+            required_surplus: 2500
             security_environment: EDC
             ami_id: /ngap/amis/image_id_ecs_al2023_x86
             distribution_url: 'https://d3gm2hf49xd6jj.cloudfront.net'

--- a/.github/workflows/deploy-daac-test.yml
+++ b/.github/workflows/deploy-daac-test.yml
@@ -31,9 +31,9 @@ jobs:
               job_spec/ARIA_S1_GUNW.yml
               job_spec/OPERA_DISP_TMS.yml
             instance_types: r8id.xlarge,r8id.2xlarge,r8id.4xlarge,r8id.8xlarge,r8id.12xlarge,r8id.16xlarge
-            default_max_vcpus: 600
-            expanded_max_vcpus: 1200
-            required_surplus: 2000
+            default_max_vcpus: 900
+            expanded_max_vcpus: 1800
+            required_surplus: 2500
             security_environment: EDC
             ami_id: /ngap/amis/image_id_ecs_al2023_x86
             distribution_url: 'https://d1riv60tezqha9.cloudfront.net'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.16.2]
+
+### Changed
+- Increased default/expanded vCPUs to 900/1800 in hyp3-edc-uat and hyp3-edc-prod
+
 ## [10.16.1]
 
 ### Changed


### PR DESCRIPTION
I've also updated the `MONTHLY_BUDGET` secret in GitHub for the `hyp3-edc-uat` and `hyp3-edc-prod` environments.