### PR TITLE
Add bucket prefix for VolcSARvatory multiburst job spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.16.4]
+
+### Added
+- Bucket prefix for multiburst jobs in `VOLCSARVATORY_MULTI_BURST.yml`.
+
 ## [10.16.3]
 
 ### Changed

--- a/job_spec/VOLCSARVATORY_MULTI_BURST.yml
+++ b/job_spec/VOLCSARVATORY_MULTI_BURST.yml
@@ -43,6 +43,12 @@ INSAR_ISCE_MULTI_BURST:
           - "volcsarvatory-data"
           - "volcsarvatory-data-test"
         default: null
+    publish_prefix:
+      api_schema:
+        description: Prefix to store the resulting product.
+        type: string
+        nullable: true
+        default: null
     apply_water_mask:
       api_schema:
         description: Sets pixels over coastal and large inland waterbodies as invalid for phase unwrapping.
@@ -84,6 +90,8 @@ INSAR_ISCE_MULTI_BURST:
         - Ref::secondary
         - --publish-bucket
         - Ref::publish_bucket
+        - --publish-prefix
+        - Ref::publish_prefix
       timeout: 126000  # 35 hours
       compute_environment: Default
       vcpu: 1


### PR DESCRIPTION
This PR adds a `--publish-prefix` to the `VOLCSARVATORY_MULTI_BURST` job spec 