### PR TITLE
do not include cost offests from EC2 Savings Plans when computing month-to-date spending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.16.5]
+
+### Changed
+- Do not include cost offsets from EC2 Savings Plans when computing month-to-date spending in scale-cluster lambda
+
 ## [10.16.4]
 
 ### Added

--- a/apps/scale-cluster/src/scale_cluster.py
+++ b/apps/scale-cluster/src/scale_cluster.py
@@ -21,7 +21,7 @@ def get_month_to_date_spending(today: date) -> float:
         TimePeriod=get_time_period(today),
         Granularity='MONTHLY',
         Metrics=['UnblendedCost'],
-        Filter={'Not': {'Dimensions': {'Key': 'RECORD_TYPE', 'Values': ['SavingsPlanNegotiation']}}},
+        Filter={'Not': {'Dimensions': {'Key': 'RECORD_TYPE', 'Values': ['SavingsPlanNegation']}}},
     )
     return float(response['ResultsByTime'][0]['Total']['UnblendedCost']['Amount'])
 

--- a/apps/scale-cluster/src/scale_cluster.py
+++ b/apps/scale-cluster/src/scale_cluster.py
@@ -17,10 +17,12 @@ def get_time_period(today: date) -> dict:
 
 
 def get_month_to_date_spending(today: date) -> float:
-    time_period = get_time_period(today)
-    granularity = 'MONTHLY'
-    metrics = ['UnblendedCost']
-    response = COST_EXPLORER.get_cost_and_usage(TimePeriod=time_period, Granularity=granularity, Metrics=metrics)
+    response = COST_EXPLORER.get_cost_and_usage(
+        TimePeriod=get_time_period(today),
+        Granularity='MONTHLY',
+        Metrics=['UnblendedCost'],
+        Filter={'Not': {'Dimensions': {'Key': 'RECORD_TYPE', 'Values': ['SavingsPlanNegotiation']}}},
+    )
     return float(response['ResultsByTime'][0]['Total']['UnblendedCost']['Amount'])
 
 

--- a/tests/test_scale_cluster.py
+++ b/tests/test_scale_cluster.py
@@ -160,6 +160,14 @@ def test_get_month_to_date_spending(cost_explorer_stubber):
             'Start': '2022-07-01',
             'End': '2022-08-01',
         },
+        'Filter': {
+            'Not': {
+                'Dimensions': {
+                    'Key': 'RECORD_TYPE',
+                    'Values': ['SavingsPlanNegotiation'],
+                },
+            },
+        },
     }
     mock_service_response = {
         'ResultsByTime': [

--- a/tests/test_scale_cluster.py
+++ b/tests/test_scale_cluster.py
@@ -164,7 +164,7 @@ def test_get_month_to_date_spending(cost_explorer_stubber):
             'Not': {
                 'Dimensions': {
                     'Key': 'RECORD_TYPE',
-                    'Values': ['SavingsPlanNegotiation'],
+                    'Values': ['SavingsPlanNegation'],
                 },
             },
         },


### PR DESCRIPTION
The HyP3 Basic account began seeing cost offsets from a [Compute Savings Plan](https://aws.amazon.com/savingsplans/compute-pricing/) on 2026-05-11. Current guidance is to ignore those offsets when computing our month-to-date spending. The net effect is to continue providing the same level of service and quantity of compute, even if somewhat less is now being charged for that compute across the enterprise.