### PR TITLE
Project buckets

### DIFF
--- a/.github/actions/deploy-hyp3/action.yml
+++ b/.github/actions/deploy-hyp3/action.yml
@@ -23,6 +23,9 @@ inputs:
   SECURITY_ENVIRONMENT:
     description: "Modify resources/configurations for ASF (default), EDC, or JPL security environments"
     required: true
+  SAME_ACCOUNT_PUBLISHING:
+    description: "Allow publishing products to any bucket within the containing AWS account, not just the HyP3 content bucket"
+    required: true
   PARAMETER_FILE:
     description: "JSON file containing parameter overrides for cloudformation stack"
     required: true
@@ -35,7 +38,7 @@ runs:
         run: |
           pip install --upgrade pip
           make install
-          make files='${{ inputs.JOB_FILES }}' security_environment='${{ inputs.SECURITY_ENVIRONMENT }}' api_name='${{ inputs.API_NAME }}' cost_profile='${{ inputs.COST_PROFILE }}' build
+          make files='${{ inputs.JOB_FILES }}' security_environment='${{ inputs.SECURITY_ENVIRONMENT }}' api_name='${{ inputs.API_NAME }}' cost_profile='${{ inputs.COST_PROFILE }}'  same_account_publishing='${{ inputs.SAME_ACCOUNT_PUBLISHING }}' build
       - name: Package and deploy
         shell: bash
         run: |

--- a/.github/workflows/deploy-custom-prod.yml
+++ b/.github/workflows/deploy-custom-prod.yml
@@ -32,6 +32,7 @@ jobs:
             expanded_max_vcpus: 2000  # Max: 10,406
             required_surplus: 0
             security_environment: JPL-public
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/arm64/recommended/image_id
 
           - environment: hyp3-ak-fire-safe
@@ -50,6 +51,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: true
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-pism-cloud
@@ -69,6 +71,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: true
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-volcsarvatory
@@ -88,6 +91,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: true
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-a19-jpl
@@ -108,6 +112,7 @@ jobs:
             expanded_max_vcpus: 4000  # Max: 13000
             required_surplus: 0
             security_environment: JPL-public
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-tibet-jpl
@@ -130,6 +135,7 @@ jobs:
             expanded_max_vcpus: 6400  # Max: 10316
             required_surplus: 0
             security_environment: JPL-public
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-nisar-jpl
@@ -151,6 +157,7 @@ jobs:
             expanded_max_vcpus: 1600  # Max: 1652
             required_surplus: 0
             security_environment: JPL-public
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-avo
@@ -170,6 +177,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-watermap
@@ -189,6 +197,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-streamflow
@@ -208,6 +217,7 @@ jobs:
             expanded_max_vcpus: 1600
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: true
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: azdwr-hyp3
@@ -227,6 +237,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-cargill
@@ -249,6 +260,7 @@ jobs:
             expanded_max_vcpus: 6000  # Max: 6000
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-bgc-engineering
@@ -270,6 +282,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-carter
@@ -291,6 +304,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-lavas
@@ -310,6 +324,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: true
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
     environment:
@@ -361,4 +376,5 @@ jobs:
           COST_PROFILE: ${{ matrix.cost_profile }}
           JOB_FILES: ${{ matrix.job_files }}
           SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
+          SAME_ACCOUNT_PUBLISHING: ${{ matrix.same_account_publishing }}
           PARAMETER_FILE: parameters.json

--- a/.github/workflows/deploy-custom-test.yml
+++ b/.github/workflows/deploy-custom-test.yml
@@ -32,6 +32,7 @@ jobs:
             expanded_max_vcpus: 640  # Max: 13000
             required_surplus: 0
             security_environment: JPL-public
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-tibet-jpl-test
@@ -54,6 +55,7 @@ jobs:
             expanded_max_vcpus: 6400  # Max: 10316
             required_surplus: 0
             security_environment: JPL-public
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-its-live-test
@@ -74,6 +76,7 @@ jobs:
             expanded_max_vcpus: 640  # Max: 10,406
             required_surplus: 0
             security_environment: JPL-public
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/arm64/recommended/image_id
 
           - environment: hyp3-ak-fire-safe-test
@@ -92,6 +95,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: true
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-pism-cloud-test
@@ -111,6 +115,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: true
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-volcsarvatory-test
@@ -130,6 +135,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: true
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-lavas-test
@@ -149,6 +155,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: true
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-slimsar-test
@@ -167,6 +174,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: true
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
     environment:
@@ -218,4 +226,5 @@ jobs:
           COST_PROFILE: ${{ matrix.cost_profile }}
           JOB_FILES: ${{ matrix.job_files }}
           SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
+          SAME_ACCOUNT_PUBLISHING: ${{ matrix.same_account_publishing }}
           PARAMETER_FILE: parameters.json

--- a/.github/workflows/deploy-daac-prod.yml
+++ b/.github/workflows/deploy-daac-prod.yml
@@ -35,6 +35,7 @@ jobs:
             expanded_max_vcpus: 1800
             required_surplus: 2500
             security_environment: EDC
+            same_account_publishing: false
             ami_id: /ngap/amis/image_id_ecs_al2023_x86
             distribution_url: 'https://d3gm2hf49xd6jj.cloudfront.net'
 
@@ -86,4 +87,5 @@ jobs:
           COST_PROFILE: ${{ matrix.cost_profile }}
           JOB_FILES: ${{ matrix.job_files }}
           SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
+          SAME_ACCOUNT_PUBLISHING: ${{ matrix.same_account_publishing }}
           PARAMETER_FILE: parameters.json

--- a/.github/workflows/deploy-daac-test.yml
+++ b/.github/workflows/deploy-daac-test.yml
@@ -35,6 +35,7 @@ jobs:
             expanded_max_vcpus: 1800
             required_surplus: 2500
             security_environment: EDC
+            same_account_publishing: false
             ami_id: /ngap/amis/image_id_ecs_al2023_x86
             distribution_url: 'https://d1riv60tezqha9.cloudfront.net'
 
@@ -86,4 +87,5 @@ jobs:
           COST_PROFILE: ${{ matrix.cost_profile }}
           JOB_FILES: ${{ matrix.job_files }}
           SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
+          SAME_ACCOUNT_PUBLISHING: ${{ matrix.same_account_publishing }}
           PARAMETER_FILE: parameters.json

--- a/.github/workflows/deploy-edc-sandbox.yml
+++ b/.github/workflows/deploy-edc-sandbox.yml
@@ -36,6 +36,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: EDC
+            same_account_publishing: false
             ami_id: /ngap/amis/image_id_ecs_al2023_x86
             distribution_url: 'https://d3bvvghf83wjqc.cloudfront.net'
 
@@ -86,4 +87,5 @@ jobs:
           COST_PROFILE: ${{ matrix.cost_profile }}
           JOB_FILES: ${{ matrix.job_files }}
           SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
+          SAME_ACCOUNT_PUBLISHING: ${{ matrix.same_account_publishing }}
           PARAMETER_FILE: parameters.json

--- a/.github/workflows/deploy-plus-prod.yml
+++ b/.github/workflows/deploy-plus-prod.yml
@@ -33,6 +33,7 @@ jobs:
             expanded_max_vcpus: 10000
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
     environment:
@@ -84,4 +85,5 @@ jobs:
           COST_PROFILE: ${{ matrix.cost_profile }}
           JOB_FILES: ${{ matrix.job_files }}
           SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
+          SAME_ACCOUNT_PUBLISHING: ${{ matrix.same_account_publishing }}
           PARAMETER_FILE: parameters.json

--- a/.github/workflows/deploy-plus-test.yml
+++ b/.github/workflows/deploy-plus-test.yml
@@ -34,6 +34,7 @@ jobs:
             expanded_max_vcpus: 10000
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
     environment:
@@ -85,4 +86,5 @@ jobs:
           COST_PROFILE: ${{ matrix.cost_profile }}
           JOB_FILES: ${{ matrix.job_files }}
           SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
+          SAME_ACCOUNT_PUBLISHING: ${{ matrix.same_account_publishing }}
           PARAMETER_FILE: parameters.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added PS processing for `SRG_TIME_SERIES`, and new argument `process` to choose between `ps` and `sbas`.
 - Added new parameters `tbaseline` and `pbaseline` to customize temporal and perpendicular baselines.
+- Added a deployment parameter which will allow publishing products to any bucket within the containing AWS account, not just the HyP3 content bucket. This should only be allowed for projects that have a separate log-term archive bucket in the same account and have set the default user credits to 0. 
 
 ## [10.17.1]
 

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,9 @@ compute_env_file ?= job_spec/config/compute_environments.yml
 security_environment ?= ASF
 api_name ?= local
 cost_profile ?= DEFAULT
+same_account_publishing ?= False
 render:
-	@echo rendering $(files) for API $(api_name) and security environment $(security_environment); python apps/render_cf.py -j $(files) -e $(compute_env_file) -s $(security_environment) -n $(api_name) -c $(cost_profile)
+	@echo rendering $(files) for API $(api_name) and security environment $(security_environment); python apps/render_cf.py -j $(files) -e $(compute_env_file) -s $(security_environment) -n $(api_name) -c $(cost_profile) --same-account-publishing $(same_account_publishing)
 
 static: ruff mypy openapi-validate cfn-lint
 

--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -180,9 +180,11 @@ Resources:
               - s3:PutObject
               - s3:PutObjectTagging
             Resource: "*"
+            {% if not same_account_publishing %}
             Condition:
               StringNotEquals:
                 s3:ResourceAccount: !Ref "AWS::AccountId"
+            {% endif %}
           - Effect: Allow
             Action:
               - s3:PutObject

--- a/apps/get-files/get-files-cf.yml.j2
+++ b/apps/get-files/get-files-cf.yml.j2
@@ -84,9 +84,11 @@ Resources:
               - s3:GetObject
               - s3:GetObjectTagging
             Resource: "*"
+            {% if not same_account_publishing %}
             Condition:
               StringNotEquals:
                 s3:ResourceAccount: !Ref "AWS::AccountId"
+            {% endif %}
           - Effect: Allow
             Action: dynamodb:UpdateItem
             Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${JobsTable}*"

--- a/apps/render_cf.py
+++ b/apps/render_cf.py
@@ -155,6 +155,7 @@ def render_templates(
     api_name: str,
     api_version: str,
     openapi_spec: str,
+    same_account_publishing: bool,
 ) -> None:
     job_states = get_states_for_jobs(job_types)
 
@@ -177,6 +178,7 @@ def render_templates(
             api_name=api_name,
             api_version=api_version,
             openapi_spec=openapi_spec,
+            same_account_publishing=same_account_publishing,
             json=json,
             snake_to_pascal_case=snake_to_pascal_case,
             job_states=job_states,
@@ -292,6 +294,10 @@ def validate_cost_table(cost_table: dict | float, job_type: str) -> None:
         )
 
 
+def _string_is_true(s: str) -> bool:
+    return s.lower() == 'true'
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument('-j', '--job-spec-files', required=True, nargs='+', type=Path)
@@ -300,6 +306,7 @@ def main() -> None:
     parser.add_argument('-n', '--api-name', required=True)
     parser.add_argument('-c', '--cost-profile', default='DEFAULT', choices=['DEFAULT', 'EDC'])
     parser.add_argument('--openapi-spec', default='3.0.4')
+    parser.add_argument('--same-account-publishing', type=_string_is_true, default=False)
     args = parser.parse_args()
 
     api_version = get_version(root='..', relative_to=__file__)
@@ -320,7 +327,7 @@ def main() -> None:
     render_batch_params_by_job_type(job_types)
     render_default_params_by_job_type(job_types)
     render_costs(job_types, args.cost_profile)
-    render_templates(job_types, compute_envs, args.security_environment, args.api_name, api_version, args.openapi_spec)
+    render_templates(job_types, compute_envs, args.security_environment, args.api_name, api_version, args.openapi_spec, args.same_account_publishing)
 
 
 if __name__ == '__main__':

--- a/apps/render_cf.py
+++ b/apps/render_cf.py
@@ -327,7 +327,15 @@ def main() -> None:
     render_batch_params_by_job_type(job_types)
     render_default_params_by_job_type(job_types)
     render_costs(job_types, args.cost_profile)
-    render_templates(job_types, compute_envs, args.security_environment, args.api_name, api_version, args.openapi_spec, args.same_account_publishing)
+    render_templates(
+        job_types,
+        compute_envs,
+        args.security_environment,
+        args.api_name,
+        api_version,
+        args.openapi_spec,
+        args.same_account_publishing,
+    )
 
 
 if __name__ == '__main__':

--- a/apps/upload-log/upload-log-cf.yml.j2
+++ b/apps/upload-log/upload-log-cf.yml.j2
@@ -71,9 +71,11 @@ Resources:
               - s3:PutObject
               - s3:PutObjectTagging
             Resource: "*"
+            {% if not same_account_publishing %}
             Condition:
               StringNotEquals:
                 s3:ResourceAccount: !Ref "AWS::AccountId"
+            {% endif %}
           - Effect: Allow
             Action: logs:GetLogEvents
             Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/batch/job*"


### PR DESCRIPTION
In v10.17.0, we released the ability for users to specify an external bucket to publish HyP3 products to, but due to security concerns, we disallowed writing to any bucket within the AWS containing the HyP3 deployment except the hyp3 content (product) bucket, since those buckets are generally used for other purposes.

However, some of our project deployments also have a long-term archive bucket within the same account, and this condition disallowed the new bucket feature from writing to the archive buckets. 

This PR adds a deployment parameter that removes this condition and allows writing to *any* bucket within the account. Notably, I've enabled same-account-publishing for 10/28 deployments (~1/3 of hyp3 deployments).

Since all these project deployments are strictly controlled and largely managed internally by ASF, there isn't enough risk to require explicitly listing the allowed buckets and requiring redeployment (releases) to update the list, so I think this setup is the best of the available options.