### PR TITLE
Release v10.17.2

### DIFF
--- a/.github/actions/deploy-hyp3/action.yml
+++ b/.github/actions/deploy-hyp3/action.yml
@@ -23,6 +23,9 @@ inputs:
   SECURITY_ENVIRONMENT:
     description: "Modify resources/configurations for ASF (default), EDC, or JPL security environments"
     required: true
+  SAME_ACCOUNT_PUBLISHING:
+    description: "Allow publishing products to any bucket within the containing AWS account, not just the HyP3 content bucket"
+    required: true
   PARAMETER_FILE:
     description: "JSON file containing parameter overrides for cloudformation stack"
     required: true
@@ -35,7 +38,7 @@ runs:
         run: |
           pip install --upgrade pip
           make install
-          make files='${{ inputs.JOB_FILES }}' security_environment='${{ inputs.SECURITY_ENVIRONMENT }}' api_name='${{ inputs.API_NAME }}' cost_profile='${{ inputs.COST_PROFILE }}' build
+          make files='${{ inputs.JOB_FILES }}' security_environment='${{ inputs.SECURITY_ENVIRONMENT }}' api_name='${{ inputs.API_NAME }}' cost_profile='${{ inputs.COST_PROFILE }}'  same_account_publishing='${{ inputs.SAME_ACCOUNT_PUBLISHING }}' build
       - name: Package and deploy
         shell: bash
         run: |

--- a/.github/workflows/deploy-custom-prod.yml
+++ b/.github/workflows/deploy-custom-prod.yml
@@ -32,6 +32,7 @@ jobs:
             expanded_max_vcpus: 2000  # Max: 10,406
             required_surplus: 0
             security_environment: JPL-public
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/arm64/recommended/image_id
 
           - environment: hyp3-ak-fire-safe
@@ -50,6 +51,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: true
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-pism-cloud
@@ -69,6 +71,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: true
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-volcsarvatory
@@ -88,6 +91,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: true
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-a19-jpl
@@ -108,6 +112,7 @@ jobs:
             expanded_max_vcpus: 4000  # Max: 13000
             required_surplus: 0
             security_environment: JPL-public
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-tibet-jpl
@@ -130,6 +135,7 @@ jobs:
             expanded_max_vcpus: 6400  # Max: 10316
             required_surplus: 0
             security_environment: JPL-public
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-nisar-jpl
@@ -151,6 +157,7 @@ jobs:
             expanded_max_vcpus: 1600  # Max: 1652
             required_surplus: 0
             security_environment: JPL-public
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-avo
@@ -170,6 +177,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-watermap
@@ -189,6 +197,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-streamflow
@@ -208,6 +217,7 @@ jobs:
             expanded_max_vcpus: 1600
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: true
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: azdwr-hyp3
@@ -227,6 +237,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-cargill
@@ -249,6 +260,7 @@ jobs:
             expanded_max_vcpus: 6000  # Max: 6000
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-bgc-engineering
@@ -270,6 +282,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-carter
@@ -291,6 +304,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-lavas
@@ -310,6 +324,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: true
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
     environment:
@@ -361,4 +376,5 @@ jobs:
           COST_PROFILE: ${{ matrix.cost_profile }}
           JOB_FILES: ${{ matrix.job_files }}
           SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
+          SAME_ACCOUNT_PUBLISHING: ${{ matrix.same_account_publishing }}
           PARAMETER_FILE: parameters.json

--- a/.github/workflows/deploy-custom-prod.yml
+++ b/.github/workflows/deploy-custom-prod.yml
@@ -317,7 +317,7 @@ jobs:
       url: https://${{ matrix.domain }}
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-custom-test.yml
+++ b/.github/workflows/deploy-custom-test.yml
@@ -174,7 +174,7 @@ jobs:
       url: https://${{ matrix.domain }}
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-custom-test.yml
+++ b/.github/workflows/deploy-custom-test.yml
@@ -32,6 +32,7 @@ jobs:
             expanded_max_vcpus: 640  # Max: 13000
             required_surplus: 0
             security_environment: JPL-public
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-tibet-jpl-test
@@ -54,6 +55,7 @@ jobs:
             expanded_max_vcpus: 6400  # Max: 10316
             required_surplus: 0
             security_environment: JPL-public
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-its-live-test
@@ -74,6 +76,7 @@ jobs:
             expanded_max_vcpus: 640  # Max: 10,406
             required_surplus: 0
             security_environment: JPL-public
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/arm64/recommended/image_id
 
           - environment: hyp3-ak-fire-safe-test
@@ -92,6 +95,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: true
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-pism-cloud-test
@@ -111,6 +115,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: true
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-volcsarvatory-test
@@ -130,6 +135,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: true
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-lavas-test
@@ -149,6 +155,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: true
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
           - environment: hyp3-slimsar-test
@@ -167,6 +174,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: true
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
     environment:
@@ -218,4 +226,5 @@ jobs:
           COST_PROFILE: ${{ matrix.cost_profile }}
           JOB_FILES: ${{ matrix.job_files }}
           SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
+          SAME_ACCOUNT_PUBLISHING: ${{ matrix.same_account_publishing }}
           PARAMETER_FILE: parameters.json

--- a/.github/workflows/deploy-daac-prod.yml
+++ b/.github/workflows/deploy-daac-prod.yml
@@ -42,7 +42,7 @@ jobs:
       name: ${{ matrix.environment }}
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-daac-prod.yml
+++ b/.github/workflows/deploy-daac-prod.yml
@@ -35,6 +35,7 @@ jobs:
             expanded_max_vcpus: 1800
             required_surplus: 2500
             security_environment: EDC
+            same_account_publishing: false
             ami_id: /ngap/amis/image_id_ecs_al2023_x86
             distribution_url: 'https://d3gm2hf49xd6jj.cloudfront.net'
 
@@ -86,4 +87,5 @@ jobs:
           COST_PROFILE: ${{ matrix.cost_profile }}
           JOB_FILES: ${{ matrix.job_files }}
           SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
+          SAME_ACCOUNT_PUBLISHING: ${{ matrix.same_account_publishing }}
           PARAMETER_FILE: parameters.json

--- a/.github/workflows/deploy-daac-test.yml
+++ b/.github/workflows/deploy-daac-test.yml
@@ -35,6 +35,7 @@ jobs:
             expanded_max_vcpus: 1800
             required_surplus: 2500
             security_environment: EDC
+            same_account_publishing: false
             ami_id: /ngap/amis/image_id_ecs_al2023_x86
             distribution_url: 'https://d1riv60tezqha9.cloudfront.net'
 
@@ -86,4 +87,5 @@ jobs:
           COST_PROFILE: ${{ matrix.cost_profile }}
           JOB_FILES: ${{ matrix.job_files }}
           SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
+          SAME_ACCOUNT_PUBLISHING: ${{ matrix.same_account_publishing }}
           PARAMETER_FILE: parameters.json

--- a/.github/workflows/deploy-daac-test.yml
+++ b/.github/workflows/deploy-daac-test.yml
@@ -42,7 +42,7 @@ jobs:
       name: ${{ matrix.environment }}
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-edc-sandbox.yml
+++ b/.github/workflows/deploy-edc-sandbox.yml
@@ -43,7 +43,7 @@ jobs:
       name: ${{ matrix.environment }}
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-edc-sandbox.yml
+++ b/.github/workflows/deploy-edc-sandbox.yml
@@ -36,6 +36,7 @@ jobs:
             expanded_max_vcpus: 640
             required_surplus: 0
             security_environment: EDC
+            same_account_publishing: false
             ami_id: /ngap/amis/image_id_ecs_al2023_x86
             distribution_url: 'https://d3bvvghf83wjqc.cloudfront.net'
 
@@ -86,4 +87,5 @@ jobs:
           COST_PROFILE: ${{ matrix.cost_profile }}
           JOB_FILES: ${{ matrix.job_files }}
           SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
+          SAME_ACCOUNT_PUBLISHING: ${{ matrix.same_account_publishing }}
           PARAMETER_FILE: parameters.json

--- a/.github/workflows/deploy-plus-prod.yml
+++ b/.github/workflows/deploy-plus-prod.yml
@@ -33,6 +33,7 @@ jobs:
             expanded_max_vcpus: 10000
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
     environment:
@@ -84,4 +85,5 @@ jobs:
           COST_PROFILE: ${{ matrix.cost_profile }}
           JOB_FILES: ${{ matrix.job_files }}
           SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
+          SAME_ACCOUNT_PUBLISHING: ${{ matrix.same_account_publishing }}
           PARAMETER_FILE: parameters.json

--- a/.github/workflows/deploy-plus-prod.yml
+++ b/.github/workflows/deploy-plus-prod.yml
@@ -40,7 +40,7 @@ jobs:
       url: https://${{ matrix.domain }}
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-plus-test.yml
+++ b/.github/workflows/deploy-plus-test.yml
@@ -41,7 +41,7 @@ jobs:
       url: https://${{ matrix.domain }}
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy-plus-test.yml
+++ b/.github/workflows/deploy-plus-test.yml
@@ -34,6 +34,7 @@ jobs:
             expanded_max_vcpus: 10000
             required_surplus: 0
             security_environment: ASF
+            same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
     environment:
@@ -85,4 +86,5 @@ jobs:
           COST_PROFILE: ${{ matrix.cost_profile }}
           JOB_FILES: ${{ matrix.job_files }}
           SECURITY_ENVIRONMENT: ${{ matrix.security_environment }}
+          SAME_ACCOUNT_PUBLISHING: ${{ matrix.same_account_publishing }}
           PARAMETER_FILE: parameters.json

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         security_environment: [ASF, EDC, JPL, JPL-public]
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
       - uses: actions/setup-python@v6
         with:
           python-version: 3.13
@@ -43,7 +43,7 @@ jobs:
   openapi-spec-validator:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
       - uses: actions/setup-python@v6
         with:
           python-version: 3.13
@@ -56,7 +56,7 @@ jobs:
   statelint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ ! github.event.pull_request.head.repo.fork }}
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
       - uses: snyk/actions/setup@v1.0.0
       - uses: actions/setup-python@v6
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
 
       - uses: actions/setup-python@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.17.1]
+
+### Changed
+- Upgraded PyJWT to 2.13.0; resolves CVE-2026-48526.
+
 ## [10.17.0]
 
 ### Added
@@ -96,11 +101,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `OPERA_RTC_S1` job type from edc-uat and edc-sandbox environments
   - `OperaRtcS1EndDate` stack parameter
   - `check_opera_rtc_s1_bounds` and `check_opera_rtc_s1_date` validators and associated tests
-
-## [10.14.2]
-
-### Changed
-- Upgraded PyJWT to 2.13.0; resolves CVE-2026-48526.
 
 ## [10.14.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added PS processing for `SRG_TIME_SERIES`, and new argument `process` to choose between `ps` and `sbas`.
 - Added new parameters `tbaseline` and `pbaseline` to customize temporal and perpendicular baselines.
+- Added a deployment parameter which will allow publishing products to any bucket within the containing AWS account, not just the HyP3 content bucket. This should only be allowed for projects that have a separate log-term archive bucket in the same account and have set the default user credits to 0. 
 
 ## [10.17.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.17.2]
+
+### Added
+- Added PS processing for `SRG_TIME_SERIES`, and new argument `process` to choose between `ps` and `sbas`.
+- Added new parameters `tbaseline` and `pbaseline` to customize temporal and perpendicular baselines.
+
 ## [10.17.1]
 
 ### Changed

--- a/Makefile
+++ b/Makefile
@@ -49,8 +49,9 @@ compute_env_file ?= job_spec/config/compute_environments.yml
 security_environment ?= ASF
 api_name ?= local
 cost_profile ?= DEFAULT
+same_account_publishing ?= False
 render:
-	@echo rendering $(files) for API $(api_name) and security environment $(security_environment); python apps/render_cf.py -j $(files) -e $(compute_env_file) -s $(security_environment) -n $(api_name) -c $(cost_profile)
+	@echo rendering $(files) for API $(api_name) and security environment $(security_environment); python apps/render_cf.py -j $(files) -e $(compute_env_file) -s $(security_environment) -n $(api_name) -c $(cost_profile) --same-account-publishing $(same_account_publishing)
 
 static: ruff mypy openapi-validate cfn-lint
 

--- a/apps/compute-cf.yml.j2
+++ b/apps/compute-cf.yml.j2
@@ -180,9 +180,11 @@ Resources:
               - s3:PutObject
               - s3:PutObjectTagging
             Resource: "*"
+            {% if not same_account_publishing %}
             Condition:
               StringNotEquals:
                 s3:ResourceAccount: !Ref "AWS::AccountId"
+            {% endif %}
           - Effect: Allow
             Action:
               - s3:PutObject

--- a/apps/get-files/get-files-cf.yml.j2
+++ b/apps/get-files/get-files-cf.yml.j2
@@ -84,9 +84,11 @@ Resources:
               - s3:GetObject
               - s3:GetObjectTagging
             Resource: "*"
+            {% if not same_account_publishing %}
             Condition:
               StringNotEquals:
                 s3:ResourceAccount: !Ref "AWS::AccountId"
+            {% endif %}
           - Effect: Allow
             Action: dynamodb:UpdateItem
             Resource: !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${JobsTable}*"

--- a/apps/render_cf.py
+++ b/apps/render_cf.py
@@ -155,6 +155,7 @@ def render_templates(
     api_name: str,
     api_version: str,
     openapi_spec: str,
+    same_account_publishing: bool,
 ) -> None:
     job_states = get_states_for_jobs(job_types)
 
@@ -177,6 +178,7 @@ def render_templates(
             api_name=api_name,
             api_version=api_version,
             openapi_spec=openapi_spec,
+            same_account_publishing=same_account_publishing,
             json=json,
             snake_to_pascal_case=snake_to_pascal_case,
             job_states=job_states,
@@ -292,6 +294,10 @@ def validate_cost_table(cost_table: dict | float, job_type: str) -> None:
         )
 
 
+def _string_is_true(s: str) -> bool:
+    return s.lower() == 'true'
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument('-j', '--job-spec-files', required=True, nargs='+', type=Path)
@@ -300,6 +306,7 @@ def main() -> None:
     parser.add_argument('-n', '--api-name', required=True)
     parser.add_argument('-c', '--cost-profile', default='DEFAULT', choices=['DEFAULT', 'EDC'])
     parser.add_argument('--openapi-spec', default='3.0.4')
+    parser.add_argument('--same-account-publishing', type=_string_is_true, default=False)
     args = parser.parse_args()
 
     api_version = get_version(root='..', relative_to=__file__)
@@ -320,7 +327,7 @@ def main() -> None:
     render_batch_params_by_job_type(job_types)
     render_default_params_by_job_type(job_types)
     render_costs(job_types, args.cost_profile)
-    render_templates(job_types, compute_envs, args.security_environment, args.api_name, api_version, args.openapi_spec)
+    render_templates(job_types, compute_envs, args.security_environment, args.api_name, api_version, args.openapi_spec, args.same_account_publishing)
 
 
 if __name__ == '__main__':

--- a/apps/render_cf.py
+++ b/apps/render_cf.py
@@ -327,7 +327,15 @@ def main() -> None:
     render_batch_params_by_job_type(job_types)
     render_default_params_by_job_type(job_types)
     render_costs(job_types, args.cost_profile)
-    render_templates(job_types, compute_envs, args.security_environment, args.api_name, api_version, args.openapi_spec, args.same_account_publishing)
+    render_templates(
+        job_types,
+        compute_envs,
+        args.security_environment,
+        args.api_name,
+        api_version,
+        args.openapi_spec,
+        args.same_account_publishing,
+    )
 
 
 if __name__ == '__main__':

--- a/apps/upload-log/upload-log-cf.yml.j2
+++ b/apps/upload-log/upload-log-cf.yml.j2
@@ -71,9 +71,11 @@ Resources:
               - s3:PutObject
               - s3:PutObjectTagging
             Resource: "*"
+            {% if not same_account_publishing %}
             Condition:
               StringNotEquals:
                 s3:ResourceAccount: !Ref "AWS::AccountId"
+            {% endif %}
           - Effect: Allow
             Action: logs:GetLogEvents
             Resource: !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/batch/job*"

--- a/job_spec/SRG_TIME_SERIES.yml
+++ b/job_spec/SRG_TIME_SERIES.yml
@@ -33,6 +33,21 @@ SRG_TIME_SERIES:
         items:
           type: number
           example: -122.53
+    process:
+      api_schema:
+        description: SBAS or PS processing.
+        type: string
+        default: 'sbas'
+    tbaseline:
+      api_schema:
+        description: Temporal baseline.
+        type: integer
+        default: 60
+    pbaseline:
+      api_schema:
+        description: Perpendicular baseline.
+        type: integer
+        default: 1000
   validators: [
     check_bounds_formatting,
     check_granules_intersecting_bounds,
@@ -73,6 +88,12 @@ SRG_TIME_SERIES:
         - time_series
         - --bounds
         - Ref::bounds
+        - --process
+        - Ref::process
+        - --tbaseline
+        - Ref::tbaseline
+        - --pbaseline
+        - Ref::pbaseline
         - --bucket
         - Ref::bucket
         - --bucket-prefix


### PR DESCRIPTION
Releases fix for user-bucket publishing to project buckets and updates to lavas srg jobs.

### user-bucket publishing

"Project" archive bucket publishing (e.g., archive bucket in the same account as the hyp3 deployment) succeeded in LAVAs test:
https://hyp3-lavas-test.asf.alaska.edu/jobs/a0cc7466-b3da-4a90-b6c4-7b839451d135
which has the `same_account_publishing: true` deployment parameter:
https://github.com/ASFHyP3/hyp3/blob/7d26231f08cdd0e4bf4ce755fc562dd331127e92/.github/workflows/deploy-custom-test.yml#L158

and failed in a19 test (with no logs as expected):
https://hyp3-a19-jpl-test.asf.alaska.edu/jobs/2d973241-8c81-4480-9875-53d378595208
which has the `same_account_publishing: false` deployment parameter:
https://github.com/ASFHyP3/hyp3/blob/7d26231f08cdd0e4bf4ce755fc562dd331127e92/.github/workflows/deploy-custom-test.yml#L35

### lavas srg jobs

It works! https://hyp3-lavas-test.asf.alaska.edu/jobs/ae640a70-3b8f-4dcd-89d6-f1622dc88cdc