### PR TITLE
Add NISAR GUNW job spec to VolcSARvatory

### DIFF
--- a/.github/workflows/deploy-custom-prod.yml
+++ b/.github/workflows/deploy-custom-prod.yml
@@ -84,6 +84,7 @@ jobs:
             cost_profile: DEFAULT
             job_files: >-
               job_spec/INSAR_GAMMA.yml
+              job_spec/NISAR_GUNW.yml
               job_spec/VOLCSARVATORY_MULTI_BURST.yml
               job_spec/VOLCSARVATORY_MINTPY.yml
             instance_types: r8id.xlarge,r8id.2xlarge,r8id.4xlarge,r8id.8xlarge,r8id.12xlarge,r8id.16xlarge

--- a/.github/workflows/deploy-custom-test.yml
+++ b/.github/workflows/deploy-custom-test.yml
@@ -128,6 +128,7 @@ jobs:
             cost_profile: DEFAULT
             job_files: >-
               job_spec/INSAR_GAMMA.yml
+              job_spec/NISAR_GUNW.yml
               job_spec/VOLCSARVATORY_MULTI_BURST.yml
               job_spec/VOLCSARVATORY_MINTPY.yml
             instance_types: r8id.xlarge,r8id.2xlarge,r8id.4xlarge,r8id.8xlarge,r8id.12xlarge,r8id.16xlarge

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added the `PISM_TERRA_RUN_FORWARD` and `PISM_TERRA_RUN_INERVERSE` jobs for preparing both forward and inverse model runs.
 - `ARTRAFF_RTC` job spec for RTCing commercial SAR data on a dev basis.
+- Added `NISAR_GUNW` job spec for VolcSARvatory
 
 ### Changed
 - The `PISM_TERRA_EXECUTE` jobs no longer requires or accepts an `ensemble_job_id` parameter, which was used to determine the S3 location to stage files from, and instead takes a full S3 URI for run_script.

--- a/job_spec/NISAR_GUNW.yml
+++ b/job_spec/NISAR_GUNW.yml
@@ -16,6 +16,8 @@ NISAR_GUNW:
     subset:
       api_schema:
         type: array
+        nullable: true
+        default: null
         description: Bounds for extent of processing, formatted like [min lon, min lat, max lon, max lat] in EPSG:4326.
         minItems: 4
         maxItems: 4

--- a/job_spec/NISAR_GUNW.yml
+++ b/job_spec/NISAR_GUNW.yml
@@ -13,6 +13,10 @@ NISAR_GUNW:
         description: Name of the NISAR RSLC to use as secondary.
         type: string
         example: "NISAR_L1_PR_RSLC_006_172_A_008_2005_DHDH_A_20251204T024618_20251204T024653_X05007_N_F_J_001"
+  cost_profiles:
+    DEFAULT:
+      cost: 1.0
+  validators: []
   steps:
     - name: ''
       image: ghcr.io/asfhyp3/hyp3-isce3

--- a/job_spec/NISAR_GUNW.yml
+++ b/job_spec/NISAR_GUNW.yml
@@ -1,0 +1,34 @@
+NISAR_GUNW:
+  required_parameters:
+    - reference
+    - secondary
+  parameters:
+    reference:
+      api_schema:
+        description: Name of the NISAR RSLC to use as reference.
+        type: string
+        example: "NISAR_L1_PR_RSLC_005_172_A_008_2005_DHDH_A_20251122T024618_20251122T024652_X05007_N_F_J_001"
+    secondary:
+      api_schema:
+        description: Name of the NISAR RSLC to use as secondary.
+        type: string
+        example: "NISAR_L1_PR_RSLC_006_172_A_008_2005_DHDH_A_20251204T024618_20251204T024653_X05007_N_F_J_001"
+  steps:
+    - name: ''
+      image: ghcr.io/asfhyp3/hyp3-isce3
+      command:
+        - --bucket
+        - Ref::bucket
+        - --bucket-prefix
+        - Ref::bucket_prefix
+        - --reference
+        - Ref::reference
+        - --secondary
+        - Ref::secondary
+      timeout: 126000  # 35 hours
+      compute_environment: Default
+      vcpu: 1
+      memory: 30500
+      secrets:
+        - EARTHDATA_USERNAME
+        - EARTHDATA_PASSWORD

--- a/job_spec/NISAR_GUNW.yml
+++ b/job_spec/NISAR_GUNW.yml
@@ -13,6 +13,20 @@ NISAR_GUNW:
         description: Name of the NISAR RSLC to use as secondary.
         type: string
         example: "NISAR_L1_PR_RSLC_006_172_A_008_2005_DHDH_A_20251204T024618_20251204T024653_X05007_N_F_J_001"
+    subset:
+      api_schema:
+        type: array
+        description: Bounds for extent of processing, formatted like [min lon, min lat, max lon, max lat] in EPSG:4326.
+        minItems: 4
+        maxItems: 4
+        example:
+          - 40.55
+          - 13.46
+          - 40.78
+          - 13.65
+        items:
+          type: number
+          example: 40.55
   cost_profiles:
     DEFAULT:
       cost: 1.0
@@ -29,6 +43,8 @@ NISAR_GUNW:
         - Ref::reference
         - --secondary
         - Ref::secondary
+        - --subset
+        - Ref::subset
       timeout: 126000  # 35 hours
       compute_environment: Default
       vcpu: 1


### PR DESCRIPTION
This PR adds a new job spec to use `hyp3-isce3` for NISAR GUNW production.