### PR TITLE
Release v10.17.4

### DIFF
--- a/.github/workflows/deploy-daac-prod.yml
+++ b/.github/workflows/deploy-daac-prod.yml
@@ -49,9 +49,7 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.V2_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.V2_AWS_SECRET_ACCESS_KEY }}
-          aws-session-token: ${{ secrets.V2_AWS_SESSION_TOKEN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - uses: actions/setup-python@v6

--- a/.github/workflows/deploy-daac-prod.yml
+++ b/.github/workflows/deploy-daac-prod.yml
@@ -1,5 +1,9 @@
 name: Deploy DAAC prod to AWS
 
+permissions:
+  contents: read
+  id-token: write
+
 on:
   push:
     tags:

--- a/.github/workflows/deploy-daac-test.yml
+++ b/.github/workflows/deploy-daac-test.yml
@@ -49,9 +49,7 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.V2_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.V2_AWS_SECRET_ACCESS_KEY }}
-          aws-session-token: ${{ secrets.V2_AWS_SESSION_TOKEN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - uses: actions/setup-python@v6

--- a/.github/workflows/deploy-daac-test.yml
+++ b/.github/workflows/deploy-daac-test.yml
@@ -1,5 +1,9 @@
 name: Deploy DAAC test to AWS
 
+permissions:
+  contents: read
+  id-token: write
+
 on:
   push:
     branches:

--- a/.github/workflows/deploy-edc-sandbox.yml
+++ b/.github/workflows/deploy-edc-sandbox.yml
@@ -2,6 +2,7 @@ name: Deploy HyP3 EDC Sandbox to AWS
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   push:

--- a/.github/workflows/deploy-edc-sandbox.yml
+++ b/.github/workflows/deploy-edc-sandbox.yml
@@ -50,9 +50,7 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.V2_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.V2_AWS_SECRET_ACCESS_KEY }}
-          aws-session-token: ${{ secrets.V2_AWS_SESSION_TOKEN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - uses: actions/setup-python@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.17.4]
+
+### Changed
+- Deploy EDC deployments using OpenID Connect (OIDC) with Amazon Web Services.
+
 ## [10.17.3]
 
 ### Added

--- a/cicd-stacks/ASF-deployment-ci-cf.yml
+++ b/cicd-stacks/ASF-deployment-ci-cf.yml
@@ -5,10 +5,6 @@ Parameters:
     Description: AWS S3 bucket name for uploading CloudFormation templates
     Type: String
 
-  SourceRepositories:
-    Type: CommaDelimitedList
-    Default: repo:ASFHyP3/*
-
 Resources:
   CloudformationDeploymentRole:
     Type: AWS::IAM::Role
@@ -16,19 +12,10 @@ Resources:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
-          - Effect: Allow
-            Principal:
-              Service: cloudformation.amazonaws.com
-            Action: sts:AssumeRole
-          - Effect: Allow
-            Principal:
-              Federated: !Sub arn:aws:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com
-            Action: sts:AssumeRoleWithWebIdentity
-            Condition:
-              StringLike:
-                'token.actions.githubusercontent.com:sub': !Ref SourceRepositories
-              StringEqualsIgnoreCase:
-                'token.actions.githubusercontent.com:aud': sts.amazonaws.com
+          Action: sts:AssumeRole
+          Principal:
+            Service: cloudformation.amazonaws.com
+          Effect: Allow
       Policies:
         - PolicyName: cloud-formation-deployment-policy
           PolicyDocument:
@@ -124,12 +111,3 @@ Resources:
     Type: AWS::ApiGateway::Account
     Properties:
       CloudWatchRoleArn: !GetAtt ApiGatewayLoggingRole.Arn
-
-  GitHubActionsOidcProvider:
-    Type: AWS::IAM::OIDCProvider
-    Properties:
-      ClientIdList:
-        - sts.amazonaws.com
-      ThumbprintList:
-        - 6938fd4d98bab03faadb97b34396831e3780aea1
-      Url: https://token.actions.githubusercontent.com

--- a/cicd-stacks/ASF-deployment-ci-cf.yml
+++ b/cicd-stacks/ASF-deployment-ci-cf.yml
@@ -5,6 +5,10 @@ Parameters:
     Description: AWS S3 bucket name for uploading CloudFormation templates
     Type: String
 
+  SourceRepositories:
+    Type: CommaDelimitedList
+    Default: repo:ASFHyP3/*
+
 Resources:
   CloudformationDeploymentRole:
     Type: AWS::IAM::Role
@@ -12,10 +16,19 @@ Resources:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
-          Action: sts:AssumeRole
-          Principal:
-            Service: cloudformation.amazonaws.com
-          Effect: Allow
+          - Effect: Allow
+            Principal:
+              Service: cloudformation.amazonaws.com
+            Action: sts:AssumeRole
+          - Effect: Allow
+            Principal:
+              Federated: !Sub arn:aws:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringLike:
+                'token.actions.githubusercontent.com:sub': !Ref SourceRepositories
+              StringEqualsIgnoreCase:
+                'token.actions.githubusercontent.com:aud': sts.amazonaws.com
       Policies:
         - PolicyName: cloud-formation-deployment-policy
           PolicyDocument:
@@ -111,3 +124,12 @@ Resources:
     Type: AWS::ApiGateway::Account
     Properties:
       CloudWatchRoleArn: !GetAtt ApiGatewayLoggingRole.Arn
+
+  GitHubActionsOidcProvider:
+    Type: AWS::IAM::OIDCProvider
+    Properties:
+      ClientIdList:
+        - sts.amazonaws.com
+      ThumbprintList:
+        - 6938fd4d98bab03faadb97b34396831e3780aea1
+      Url: https://token.actions.githubusercontent.com

--- a/cicd-stacks/EDC-deployment-ci-cf.yml
+++ b/cicd-stacks/EDC-deployment-ci-cf.yml
@@ -15,8 +15,6 @@ Resources:
     Properties:
       ClientIdList:
         - sts.amazonaws.com
-      ThumbprintList:
-        - 6938fd4d98bab03faadb97b34396831e3780aea1
       Url: https://token.actions.githubusercontent.com
 
   CloudformationDeploymentRole:

--- a/cicd-stacks/EDC-deployment-ci-cf.yml
+++ b/cicd-stacks/EDC-deployment-ci-cf.yml
@@ -28,10 +28,10 @@ Resources:
               Federated: !Sub arn:aws:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com
             Action: sts:AssumeRoleWithWebIdentity
             Condition:
+              StringEquals:
+                token.actions.githubusercontent.com:aud: sts.amazonaws.com
               StringLike:
-                'token.actions.githubusercontent.com:sub': !Ref SourceRepositories
-              StringEqualsIgnoreCase:
-                'token.actions.githubusercontent.com:aud': sts.amazonaws.com
+                token.actions.githubusercontent.com:sub: !Ref SourceRepositories
       Policies:
         - PolicyName: cloud-formation-deployment-policy
           PolicyDocument:

--- a/cicd-stacks/EDC-deployment-ci-cf.yml
+++ b/cicd-stacks/EDC-deployment-ci-cf.yml
@@ -1,0 +1,103 @@
+AWSTemplateFormatVersion: 2010-09-09
+
+Parameters:
+  TemplateBucketName:
+    Description: AWS S3 bucket name for uploading CloudFormation templates
+    Type: String
+
+  SourceRepositories:
+    Type: CommaDelimitedList
+    Default: repo:ASFHyP3/*
+
+Resources:
+  GitHubActionsOidcProvider:
+    Type: AWS::IAM::OIDCProvider
+    Properties:
+      ClientIdList:
+        - sts.amazonaws.com
+      ThumbprintList:
+        - 6938fd4d98bab03faadb97b34396831e3780aea1
+      Url: https://token.actions.githubusercontent.com
+
+  CloudformationDeploymentRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !Sub arn:aws:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringLike:
+                'token.actions.githubusercontent.com:sub': !Ref SourceRepositories
+              StringEqualsIgnoreCase:
+                'token.actions.githubusercontent.com:aud': sts.amazonaws.com
+      Policies:
+        - PolicyName: cloud-formation-deployment-policy
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ec2:*
+                  - s3:*
+                  - ecs:*
+                  - batch:*
+                  - events:*
+                  - logs:*
+                  - iam:*
+                  - lambda:*
+                  - ssm:GetParameters
+                  - apigateway:*
+                  - states:*
+                  - dynamodb:*
+                  - rds:*
+                  - cloudwatch:*
+                  - sns:*
+                  - secretsmanager:*
+                  - kms:*
+                Resource: "*"
+
+              - Effect: Allow
+                Action: s3:PutObject
+                Resource: !Sub "arn:aws:s3:::${TemplateBucketName}/*"
+
+              - Effect: Allow
+                Action:
+                  - cloudformation:ValidateTemplate
+                  - cloudformation:DescribeStacks
+                  - ssm:GetParameters
+                Resource: "*"
+
+              - Effect: Allow
+                Action:
+                  - cloudformation:SetStackPolicy
+                  - cloudformation:CreateStack
+                  - cloudformation:UpdateStack
+                  - cloudformation:DeleteStack
+                  - cloudformation:CreateChangeSet
+                  - cloudformation:DescribeChangeSet
+                  - cloudformation:ExecuteChangeSet
+                  - cloudformation:DeleteChangeSet
+                  - cloudformation:GetTemplateSummary
+                Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*"
+
+  ApiGatewayLoggingRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          Action: sts:AssumeRole
+          Principal:
+            Service: apigateway.amazonaws.com
+          Effect: Allow
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs
+
+  ApiGatewayLoggingPermission:
+    Type: AWS::ApiGateway::Account
+    Properties:
+      CloudWatchRoleArn: !GetAtt ApiGatewayLoggingRole.Arn


### PR DESCRIPTION
TODO before merging:
- [x] delete the manually-created GitHub identity provider in the edc-prod account
- [x] deploy the CI stack to the edc-prod account
- [x] delete the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY secrets from the edc-prod github environment
- [x] add the AWS_ROLE_ARN secret to the edc-prod github environment

UAT deployment via OIDC succeeded: https://github.com/ASFHyP3/hyp3/actions/runs/27990921071
UAT verification job succeeded: https://hyp3-test-api.asf.alaska.edu/jobs/779b9649-8a95-473c-ac31-4dbe4015d373
UAT API access logging continues to work as expected.