### PR TITLE
update ASF CI for OIDC, including plus-test and plus-prod deployments

### DIFF
--- a/.github/workflows/deploy-plus-prod.yml
+++ b/.github/workflows/deploy-plus-prod.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+  id-token: write
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
@@ -47,9 +51,7 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.V2_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.V2_AWS_SECRET_ACCESS_KEY }}
-          aws-session-token: ${{ secrets.V2_AWS_SESSION_TOKEN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - uses: actions/setup-python@v6

--- a/.github/workflows/deploy-plus-test.yml
+++ b/.github/workflows/deploy-plus-test.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: read
+  id-token: write
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
@@ -48,9 +52,7 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.V2_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.V2_AWS_SECRET_ACCESS_KEY }}
-          aws-session-token: ${{ secrets.V2_AWS_SESSION_TOKEN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - uses: actions/setup-python@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added an option to force static file regeneration for the `ITS_LIVE_AUTORIFT` job type.
 
+### Changed
+- ASF-deployment-ci-cf.yml now deploys a role to be assumed via OIDC by Github Actions, rather than a service user
+- `plus-test` and `plus-prod` environments are now deployed via OIDC
+
 ## [10.17.4]
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -129,15 +129,14 @@ The primary and recommended way to deploy HyP3 is though our GitHub Actions CI/C
 For ASF and JPL, this requires some setup:
 
 <details>
-<summary>ASF: Create a service user and deployment role</summary>
+<summary>ASF: Create an OIDC role and deployment role</summary>
 <br />
 
 In order to integrate an ASF deployment we'll need:
 
 1. Account-wide API Gateway logging permissions
 2. A deployment role with the necessary permissions to deploy HyP3
-3. A "service user" so that we can generate long-term AWS access keys and
-   integrate the deployment into our CI/CD pipelines
+3. An OIDC role that GitHub actions can assume to execute deployments in our CI/CD pipelines
 
 These can be done by deploying the [ASF CI stack](cicd-stacks/ASF-deployment-ci-cf.yml).
 
@@ -156,15 +155,6 @@ aws --profile <profile> cloudformation deploy \
     --capabilities CAPABILITY_NAMED_IAM \
     --parameter-overrides TemplateBucketName=<template-bucket>
 ```
-
-Once the `github-actions` IAM user has been created, you can create an AWS access key for that user,
-which we will use to deploy HyP3 via CI/CD tooling:
-
-1. Go to AWS console -> IAM -> Users -> github-actions -> security credentials tab -> "create access key".
-2. Select "Other" for key usage
-3. (Optional) Add tag value to describe the key, such as "For GitHub Actions CI/CD pipelines"
-4. Store the access key ID and secret access key using your team's password manager. You will use them below in "Create the GitHub environment"
-   as `V2_AWS_ACCESS_KEY_ID` and `V2_AWS_SECRET_ACCESS_KEY`.
 </details>
 
 <details>
@@ -284,11 +274,9 @@ of the form `<CNAME_name> IN CNAME <CNAME_value>`, stripping `.asf.alaska.edu` f
     - `CERTIFICATE_ARN` (ASF and JPL only) - ARN of the AWS Certificate Manager certificate that you created manually, e.g. `arn:aws:acm:us-west-2:XXXXXXXXXXXX:certificate/XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX`
     - `CLOUDFORMATION_ROLE_ARN` (ASF only) - part of the `hyp3-ci` stack that you deployed, e.g. `arn:aws:iam::xxxxxxxxxxxx:role/hyp3-ci-CloudformationDeploymentRole-XXXXXXXXXXXXX`
     - `SECRET_ARN` - ARN for the AWS Secrets Manager Secret that you created manually, e.g. `arn:aws:secretsmanager:us-west-X:XXXXXXXXXXXX:secret:hyp3-foobar-XXXXXX`
-    - `V2_AWS_ACCESS_KEY_ID` - AWS access key ID:
-      - ASF: for the `github-actions` user (created in step "Enable CI/CD above")
-      - JPL: for the service user
-      - EDC: created by an ASF developer via Kion
-    - `V2_AWS_SECRET_ACCESS_KEY` - The corresponding secret access key
+    - `AWS_ROLE_ARN`  (ASF and EDC only) - part of the `hyp3-ci` stack that you deployed, e.g.  `arn:aws:iam::xxxxxxxxxxxx:role/hyp3-ci-OIDCRole-XXXXXXXXXXXXX`
+    - `V2_AWS_ACCESS_KEY_ID` (JPL only) - AWS access key ID for the service user
+    - `V2_AWS_SECRET_ACCESS_KEY` (JPL only) - The corresponding secret access key
     - `VPC_ID` - ID of the default VPC for this AWS account and region (aws console -> VPC -> Your VPCs, e.g. `vpc-xxxxxxxxxxxxxxxxx`)
     - `SUBNET_IDS` - Comma delimited list (no spaces) of the default subnets for the VPC specified in `VPC_ID` (aws console -> VPC -> Subnets, e.g. `subnet-xxxxxxxxxxxxxxxxx,subnet-xxxxxxxxxxxxxxxxx,subnet-xxxxxxxxxxxxxxxxx,subnet-xxxxxxxxxxxxxxxxx`)
 

--- a/README.md
+++ b/README.md
@@ -153,9 +153,12 @@ aws --profile <profile> cloudformation deploy \
     --stack-name hyp3-ci \
     --template-file cicd-stacks/ASF-deployment-ci-cf.yml \
     --capabilities CAPABILITY_NAMED_IAM \
-    --parameter-overrides TemplateBucketName=<template-bucket>
+    --parameter-overrides TemplateBucketName=<template-bucket> SourceRepositories=<source-repositores>
 ```
 </details>
+
+where `SourceRepositories` is a comma-delimited list of repository name patterns from which you will be deploying, e.g. `repo:ASFHyP3/*`.
+See https://github.com/aws-actions/configure-aws-credentials#quick-start-oidc-recommended for more details.
 
 <details>
 <summary>JPL: Set up roles-as-code and request a service user</summary>

--- a/cicd-stacks/ASF-deployment-ci-cf.yml
+++ b/cicd-stacks/ASF-deployment-ci-cf.yml
@@ -5,7 +5,18 @@ Parameters:
     Description: AWS S3 bucket name for uploading CloudFormation templates
     Type: String
 
+  SourceRepositories:
+    Type: CommaDelimitedList
+    Default: repo:ASFHyP3/*
+
 Resources:
+  GitHubActionsOidcProvider:
+    Type: AWS::IAM::OIDCProvider
+    Properties:
+      ClientIdList:
+        - sts.amazonaws.com
+      Url: https://token.actions.githubusercontent.com
+
   CloudformationDeploymentRole:
     Type: AWS::IAM::Role
     Properties:
@@ -55,12 +66,23 @@ Resources:
                   - cloudformation:GetTemplateSummary
                 Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*"
 
-  GithubActionsUser:
-    Type: AWS::IAM::User
+  OIDCRole:
+    Type: AWS::IAM::Role
     Properties:
-      UserName: github-actions
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !Sub arn:aws:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                token.actions.githubusercontent.com:aud: sts.amazonaws.com
+              StringLike:
+                token.actions.githubusercontent.com:sub: !Ref SourceRepositories
       Policies:
-        - PolicyName: github-actions-user-policy
+        - PolicyName: github-actions-oidc-policy
           PolicyDocument:
             Version: 2012-10-17
             Statement:


### PR DESCRIPTION
TODO before merging:
- [x] deploy new ASF CI stack to hyp3-enterprise account
- [x] remove `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secrets from plus-test environment
- [x] add `AWS_ROLE_ARN` secret to plus-prod environment