### PR TITLE
Change AMI IDs to Amazon Linux 2023

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Parquet file products are now visible.
 
+### Fixed
+- The SrgGslc and SlimSAR compute environments have been upgraded to AL2023-based AMIs from AL2 AMIs due to the pending end-of-life of AL2.
+
 ## [10.17.5]
 
 ### Added

--- a/job_spec/config/compute_environments.yml
+++ b/job_spec/config/compute_environments.yml
@@ -7,7 +7,7 @@ compute_environments:
   #   max_vcpus
   SrgGslc:
     instance_types: g6.2xlarge
-    ami_id: "'{{resolve:ssm:/aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended/image_id}}'"
+    ami_id: "'{{resolve:ssm:/aws/service/ecs/optimized-ami/amazon-linux-2023/gpu/recommended/image_id}}'"
   SrgTimeSeries:
     instance_types: c6id.16xlarge
   ItsLiveSpotIntel:
@@ -21,7 +21,7 @@ compute_environments:
     ami_id: "'{{resolve:ssm:/aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id}}'"
   SlimSAR:
     instance_types: g4dn.2xlarge,g4dn.4xlarge,g4dn.8xlarge,g4dn.16xlarge
-    ami_id: "'{{resolve:ssm:/aws/service/ecs/optimized-ami/amazon-linux-2/gpu/recommended/image_id}}'"
+    ami_id: "'{{resolve:ssm:/aws/service/ecs/optimized-ami/amazon-linux-2023/gpu/recommended/image_id}}'"
   DefaultSpot:
     allocation_type: SPOT
     allocation_strategy: SPOT_PRICE_CAPACITY_OPTIMIZED


### PR DESCRIPTION
Updated AMI IDs to use Amazon Linux 2023 for GPU optimized environments.

Fixes #3039 