### PR TITLE
OIDC for custom deployments

### DIFF
--- a/.github/workflows/deploy-custom-prod.yml
+++ b/.github/workflows/deploy-custom-prod.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+  id-token: write
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
@@ -340,9 +344,7 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.V2_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.V2_AWS_SECRET_ACCESS_KEY }}
-          aws-session-token: ${{ secrets.V2_AWS_SESSION_TOKEN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - uses: actions/setup-python@v6

--- a/.github/workflows/deploy-custom-test.yml
+++ b/.github/workflows/deploy-custom-test.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: read
+  id-token: write
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
@@ -190,9 +194,7 @@ jobs:
 
       - uses: aws-actions/configure-aws-credentials@v6
         with:
-          aws-access-key-id: ${{ secrets.V2_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.V2_AWS_SECRET_ACCESS_KEY }}
-          aws-session-token: ${{ secrets.V2_AWS_SESSION_TOKEN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ secrets.AWS_REGION }}
 
       - uses: actions/setup-python@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added `FIRE_TRACK` job spec to `hyp3-ak-fire-safe`.
 - Added parameter `upload_to_db` to `AK_FIRE_SAFE` job spec.
 - Added environment variable `DB_HOST` to `AK_FIRE_SAFE` job spec.
+- Added SQS and ECR permissions to `ASF-deployment-ci-cf.yml` for deploying HyP3-based monitoring stacks.
 
 ### Changed
 - Parquet file products are now visible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Parquet file products are now visible.
+- `JPL-deployment-ci-cf.yml` now deploys a role to be assumed via OIDC by GitHub Actions, rather than a service user
+- HyP3 deployments in the `delpoy-custom-test.yml` and `deploy-custom-prod.yml` workflows are now deployed via OIDC
 
 ### Fixed
 - The SrgGslc and SlimSAR compute environments have been upgraded to AL2023-based AMIs from AL2 AMIs due to the pending end-of-life of AL2.
@@ -24,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added an option to force static file regeneration for the `ITS_LIVE_AUTORIFT` job type.
 
 ### Changed
-- ASF-deployment-ci-cf.yml now deploys a role to be assumed via OIDC by Github Actions, rather than a service user
+- `ASF-deployment-ci-cf.yml` now deploys a role to be assumed via OIDC by GitHub Actions, rather than a service user
 - `plus-test` and `plus-prod` environments are now deployed via OIDC
 
 ## [10.17.4]

--- a/cicd-stacks/ASF-deployment-ci-cf.yml
+++ b/cicd-stacks/ASF-deployment-ci-cf.yml
@@ -40,6 +40,7 @@ Resources:
                   - dynamodb:*
                   - ec2:*
                   - ecs:*
+                  - ecr:GetAuthorizationToken
                   - events:*
                   - iam:*
                   - kms:*
@@ -49,8 +50,9 @@ Resources:
                   - s3:*
                   - secretsmanager:*
                   - sns:*
-                  - ssm:GetParameters
+                  - sqs:*
                   - states:*
+                  - sts:AssumeRole
                 Resource: "*"
 
               - Effect: Allow
@@ -65,6 +67,20 @@ Resources:
                   - cloudformation:DeleteChangeSet
                   - cloudformation:GetTemplateSummary
                 Resource: !Sub "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*"
+
+              - Effect: Allow
+                Action:
+                  - ecr:BatchCheckLayerAvailability
+                  - ecr:GetDownloadUrlForLayer
+                  - ecr:DescribeRepositories
+                  - ecr:ListImages
+                  - ecr:DescribeImages
+                  - ecr:BatchGetImage
+                  - ecr:InitiateLayerUpload
+                  - ecr:UploadLayerPart
+                  - ecr:CompleteLayerUpload
+                  - ecr:PutImage
+                Resource: !Sub "arn:aws:ecr:*:${AWS::AccountId}:repository/*"
 
   OIDCRole:
     Type: AWS::IAM::Role

--- a/cicd-stacks/ASF-deployment-ci-cf.yml
+++ b/cicd-stacks/ASF-deployment-ci-cf.yml
@@ -34,23 +34,23 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - ec2:*
-                  - s3:*
-                  - ecs:*
-                  - batch:*
-                  - events:*
-                  - logs:*
-                  - iam:*
-                  - lambda:*
-                  - ssm:GetParameters
                   - apigateway:*
-                  - states:*
-                  - dynamodb:*
-                  - rds:*
+                  - batch:*
                   - cloudwatch:*
-                  - sns:*
-                  - secretsmanager:*
+                  - dynamodb:*
+                  - ec2:*
+                  - ecs:*
+                  - events:*
+                  - iam:*
                   - kms:*
+                  - lambda:*
+                  - logs:*
+                  - rds:*
+                  - s3:*
+                  - secretsmanager:*
+                  - sns:*
+                  - ssm:GetParameters
+                  - states:*
                 Resource: "*"
 
               - Effect: Allow

--- a/cicd-stacks/EDC-deployment-ci-cf.yml
+++ b/cicd-stacks/EDC-deployment-ci-cf.yml
@@ -39,24 +39,24 @@ Resources:
             Statement:
               - Effect: Allow
                 Action:
-                  - ec2:*
-                  - s3:*
-                  - ecs:*
-                  - batch:*
-                  - events:*
-                  - logs:*
-                  - iam:*
-                  - lambda:*
-                  - ssm:GetParameters
                   - apigateway:*
-                  - states:*
-                  - dynamodb:*
-                  - rds:*
+                  - batch:*
                   - cloudwatch:*
-                  - sns:*
-                  - secretsmanager:*
+                  - dynamodb:*
+                  - ec2:*
+                  - ecs:*
+                  - events:*
+                  - iam:*
                   - kms:*
+                  - lambda:*
+                  - logs:*
+                  - rds:*
+                  - s3:*
+                  - secretsmanager:*
+                  - sns:*
                   - sqs:*
+                  - ssm:GetParameters
+                  - states:*
                 Resource: "*"
 
               - Effect: Allow

--- a/cicd-stacks/JPL-deployment-policy-cf.yml
+++ b/cicd-stacks/JPL-deployment-policy-cf.yml
@@ -1,10 +1,6 @@
 AWSTemplateFormatVersion: 2010-09-09
 
 Parameters:
-  TemplateBucketName:
-    Description: AWS S3 bucket name for uploading CloudFormation templates
-    Type: String
-
   SourceRepositories:
     Type: CommaDelimitedList
     Default: repo:ASFHyP3/*
@@ -65,6 +61,7 @@ Resources:
               - kms:*
               - lambda:*
               - logs:*
+              - rds:*
               - s3:*
               - secretsmanager:*
               - sns:*
@@ -83,11 +80,6 @@ Resources:
               - iam:TagInstanceProfile
               - iam:UntagInstanceProfile
             Resource: !Sub "arn:aws:iam::${AWS::AccountId}:instance-profile/account-managed/*"
-
-
-          - Effect: Allow
-            Action: s3:PutObject
-            Resource: !Sub "arn:aws:s3:::${TemplateBucketName}/*"
 
           - Effect: Allow
             Action:

--- a/cicd-stacks/JPL-deployment-policy-cf.yml
+++ b/cicd-stacks/JPL-deployment-policy-cf.yml
@@ -1,10 +1,47 @@
 AWSTemplateFormatVersion: 2010-09-09
+
+Parameters:
+  TemplateBucketName:
+    Description: AWS S3 bucket name for uploading CloudFormation templates
+    Type: String
+
+  SourceRepositories:
+    Type: CommaDelimitedList
+    Default: repo:ASFHyP3/*
+
 Resources:
+  GitHubActionsOidcProvider:
+    Type: AWS::IAM::OIDCProvider
+    Properties:
+      ClientIdList:
+        - sts.amazonaws.com
+      Url: https://token.actions.githubusercontent.com
+
+  CloudformationDeploymentRole:
+    Type: Custom::JplRole
+    Properties:
+      ServiceToken: !ImportValue Custom::JplRole::ServiceToken
+      Path: /account-managed/hyp3/
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Federated: !Sub arn:aws:iam::${AWS::AccountId}:oidc-provider/token.actions.githubusercontent.com
+            Action: sts:AssumeRoleWithWebIdentity
+            Condition:
+              StringEquals:
+                token.actions.githubusercontent.com:aud: sts.amazonaws.com
+              StringLike:
+                token.actions.githubusercontent.com:sub: !Ref SourceRepositories
+
   DeployPolicy:
     Type: Custom::JplPolicy
     Properties:
       ServiceToken: !ImportValue Custom::JplPolicy::ServiceToken
       Path: /account-managed/hyp3/
+      Roles:
+        - !Ref CloudformationDeploymentRole
       PolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -46,6 +83,11 @@ Resources:
               - iam:TagInstanceProfile
               - iam:UntagInstanceProfile
             Resource: !Sub "arn:aws:iam::${AWS::AccountId}:instance-profile/account-managed/*"
+
+
+          - Effect: Allow
+            Action: s3:PutObject
+            Resource: !Sub "arn:aws:s3:::${TemplateBucketName}/*"
 
           - Effect: Allow
             Action:


### PR DESCRIPTION
This should complete the switch to OIDC for all HyP3 deployments. 

TODO:
- [ ] (1) Deploy hyp3-ci and (2) replace `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` secrets with `AWS_ROLE_ARN` secret to deploy environment for these deployments:
  -  [ ] HyP3 Watermap
  -  [ ] ACCESS19 Stream Flow
  -  [ ] SciDev Sandbox
  -  [ ] AK FIRE SAFE
  -  [ ] VolcSARvatory
  -  [ ] HyP3 Alaska Volcano Observatory (AVO)
  -  [ ] HyP3 AZ DWR
  -  [ ] HyP3 Cargill
  -  [ ] HyP3 BGC Engineering
  -  [ ] LAVAS
  -  [ ] asf-stac
  -  [ ] CMR-notifier
  -  [ ] Frostbyte InSAR
  -  [ ] PISM-Cloud
  -  [ ] JPL its-live
  -  [ ] JPL access-cloud-based-insar-aws
  -  [ ] JPL aria-hyp3-tibet-account-aws
  -  [ ] JPL nisar-hyp3-gunw-generation-aws
