### PR TITLE
Drop hyp3-carter deployment

### DIFF
--- a/.github/workflows/deploy-custom-prod.yml
+++ b/.github/workflows/deploy-custom-prod.yml
@@ -287,28 +287,6 @@ jobs:
             same_account_publishing: false
             ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
 
-          - environment: hyp3-carter
-            domain: hyp3-carter.asf.alaska.edu
-            template_bucket: cf-templates-1qx2mwia5g4kh-us-west-2
-            image_tag: latest
-            product_lifetime_in_days: 30
-            default_credits_per_user: 0
-            default_application_status: APPROVED
-            cost_profile: DEFAULT
-            job_files: >-
-              job_spec/AUTORIFT.yml
-              job_spec/INSAR_GAMMA.yml
-              job_spec/RTC_GAMMA.yml
-              job_spec/INSAR_ISCE_BURST.yml
-              job_spec/INSAR_ISCE_MULTI_BURST.yml
-            instance_types: r8id.xlarge,r8id.2xlarge,r8id.4xlarge,r8id.8xlarge,r8id.12xlarge,r8id.16xlarge
-            default_max_vcpus: 640
-            expanded_max_vcpus: 640
-            required_surplus: 0
-            security_environment: ASF
-            same_account_publishing: false
-            ami_id: /aws/service/ecs/optimized-ami/amazon-linux-2023/recommended/image_id
-
           - environment: hyp3-lavas
             domain: hyp3-lavas.asf.alaska.edu
             template_bucket: cf-templates-10a5pjrsv3cgo-us-west-2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The SrgGslc and SlimSAR compute environments have been upgraded to AL2023-based AMIs from AL2 AMIs due to the pending end-of-life of AL2.
 - The `check_same_relative_orbits` validator has been updated to account for the repositioning of Sentinel-1C in June, 2026.
 
+### Removed
+- The `hyp3-carter` deployment has been retired.
+
+
 ## [10.17.5]
 
 ### Added


### PR DESCRIPTION
HyP3 Carter hasn't been used in any meaningful sense since 2023, and the parent AWS account has now been closed. 