### PR TITLE
Add SRG_TS for LAVAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [10.17.6]
 
 ### Added
+- Added a new job spec (`SRG_TS`) to separate the time series workflow from the back projection.
+
+## [10.17.6]
+
+### Added
 - Added RDS Connection Permission to the TaskRole.
 - Added `FIRE_TRACK` job spec to `hyp3-ak-fire-safe`.
 - Added parameter `upload_to_db` to `AK_FIRE_SAFE` job spec.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [10.17.6]
+## [10.17.7]
 
 ### Added
 - Added a new job spec (`SRG_TS`) to separate the time series workflow from the back projection.

--- a/job_spec/SRG_TS.yml
+++ b/job_spec/SRG_TS.yml
@@ -1,0 +1,63 @@
+SRG_TIME_SERIES:
+  required_parameters:
+    - bounds
+  parameters:
+    bounds:
+      api_schema:
+        type: array
+        description: Bounds for extent of processing, formatted like [min lon, min lat, max lon, max lat] in EPSG:4326.
+        minItems: 4
+        maxItems: 4
+        example:
+          - -122.53
+          - 37.78
+          - -122.44
+          - 37.85
+        items:
+          type: number
+          example: -122.53
+    process:
+      api_schema:
+        description: SBAS or PS processing.
+        type: string
+        default: 'sbas'
+    tbaseline:
+      api_schema:
+        description: Temporal baseline.
+        type: integer
+        default: 60
+    pbaseline:
+      api_schema:
+        description: Perpendicular baseline.
+        type: integer
+        default: 1000
+  validators: [
+    check_bounds_formatting,
+    check_bounding_box_size
+  ]
+  cost_profiles:
+    DEFAULT:
+      cost: 1.0
+  steps:
+    - name: ''
+      image: ghcr.io/asfhyp3/hyp3-srg
+      command:
+        - ++process
+        - time_series
+        - --bounds
+        - Ref::bounds
+        - --process
+        - Ref::process
+        - --tbaseline
+        - Ref::tbaseline
+        - --pbaseline
+        - Ref::pbaseline
+        - --bucket
+        - Ref::bucket
+        - --bucket-prefix
+        - Ref::bucket_prefix
+        - --use-gslc-prefix
+      timeout: 86400 # 24 hr
+      compute_environment: SrgTimeSeries
+      vcpu: 1
+      memory: 125000


### PR DESCRIPTION
This PR adds a new job spec for LAVAS to separate the time series workflow from the back projection.