### PR TITLE
Fix  /user endpoint lambda timeout from job name search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [10.17.8]
+
+### Fixed
+
+- `/user` endpoint no longer times out for users with large amounts of jobs.
+
 ## [10.17.7]
 
 ### Added

--- a/apps/api/src/hyp3_api/handlers.py
+++ b/apps/api/src/hyp3_api/handlers.py
@@ -14,6 +14,7 @@ from dynamo.exceptions import (
 from hyp3_api import util
 from hyp3_api.multi_burst_validation import MultiBurstValidationError
 from hyp3_api.validation import CmrError, ValidationError, validate_jobs
+import time
 
 
 def problem_format(status: int, message: str) -> Response:
@@ -128,9 +129,13 @@ def _user_response(user_record: dict) -> dict:
 
 def _get_names_for_user(user: str) -> list[str]:
     jobs, next_key = dynamo.jobs.query_jobs(user)
-    while next_key is not None:
-        new_jobs, next_key = dynamo.jobs.query_jobs(user, start_key=next_key)
-        jobs.extend(new_jobs)
+    start = time.time()
+    current_time = time.time()
+    if next_key:
+        while next_key is not None and current_time - start < 10:
+            new_jobs, next_key = dynamo.jobs.query_jobs(user, start_key=next_key)
+            jobs.extend(new_jobs)
+            current_time = time.time()
     names = {job['name'] for job in jobs if 'name' in job}
     return sorted(list(names))
 

--- a/apps/api/src/hyp3_api/handlers.py
+++ b/apps/api/src/hyp3_api/handlers.py
@@ -1,3 +1,4 @@
+import time
 from http.client import responses
 
 from flask import Response, abort, jsonify, request
@@ -14,7 +15,6 @@ from dynamo.exceptions import (
 from hyp3_api import util
 from hyp3_api.multi_burst_validation import MultiBurstValidationError
 from hyp3_api.validation import CmrError, ValidationError, validate_jobs
-import time
 
 
 def problem_format(status: int, message: str) -> Response:

--- a/apps/api/src/hyp3_api/handlers.py
+++ b/apps/api/src/hyp3_api/handlers.py
@@ -129,13 +129,12 @@ def _user_response(user_record: dict) -> dict:
 
 def _get_names_for_user(user: str) -> list[str]:
     jobs, next_key = dynamo.jobs.query_jobs(user)
-    start = time.time()
-    current_time = time.time()
-    if next_key:
-        while next_key is not None and current_time - start < 10:
-            new_jobs, next_key = dynamo.jobs.query_jobs(user, start_key=next_key)
-            jobs.extend(new_jobs)
-            current_time = time.time()
+    start = time.monotonic()
+    while next_key is not None:
+        new_jobs, next_key = dynamo.jobs.query_jobs(user, start_key=next_key)
+        jobs.extend(new_jobs)
+        if time.monotonic() - start > 10:
+            break
     names = {job['name'] for job in jobs if 'name' in job}
     return sorted(list(names))
 


### PR DESCRIPTION
The /user endpoint iterates through every job a user has. For users with _a lot_ of jobs this causes the request to hit a lambda timeout and error. This stops workflows in both the sdk and vertex interface.

This adds a time check to the function that gets jobs names that cuts off retrieval after 10 seconds pass and gives whatever job names it found during that time back to the user. The job names part of the user endpoint as far as I know is only used in vertex to fill in the project name selector option with some autofill options.

Fixes #1312